### PR TITLE
fix: avoid panic on internal error

### DIFF
--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -102,3 +102,7 @@ pub const TESTER_NATIVE_PER_GAS: usize = 25_000;
 /// the value of basefee / native_price provided by operator.
 /// Needed because simulation is done with basefee = 0.
 pub const SIMULATION_NATIVE_PER_GAS: U256 = U256::from_limbs([100, 0, 0, 0]);
+
+// Default native price for L1->L2 transactions.
+// TODO: find a reasonable value for it.
+pub const L1_TX_NATIVE_PRICE: U256 = U256::from_limbs([10, 0, 0, 0]);

--- a/basic_bootloader/src/bootloader/mod.rs
+++ b/basic_bootloader/src/bootloader/mod.rs
@@ -289,6 +289,11 @@ impl<S: EthereumLikeTypes> BasicBootloader<S> {
                 }
             }
 
+            let tx_stats = system.flush_tx();
+            let _ = system
+                .get_logger()
+                .write_fmt(format_args!("Tx stats = {:?}\n", tx_stats));
+
             first_tx = false;
 
             let mut logger = system.get_logger();

--- a/basic_bootloader/src/bootloader/mod.rs
+++ b/basic_bootloader/src/bootloader/mod.rs
@@ -6,6 +6,7 @@ use ruint::aliases::*;
 use system_hooks::addresses_constants::BOOTLOADER_FORMAL_ADDRESS;
 use zk_ee::execution_environment_type::ExecutionEnvironmentType;
 use zk_ee::memory::slice_vec::SliceVec;
+use zk_ee::system::errors::InternalError;
 use zk_ee::system::{EthereumLikeTypes, System, SystemTypes};
 
 pub mod run_single_interaction;
@@ -169,7 +170,7 @@ impl<S: EthereumLikeTypes> BasicBootloader<S> {
     pub fn run_prepared<Config: BasicBootloaderExecutionConfig>(
         oracle: <S::IO as IOSubsystemExt>::IOOracle,
         result_keeper: &mut impl ResultKeeperExt,
-    ) -> <S::IO as IOSubsystemExt>::FinalData
+    ) -> Result<<S::IO as IOSubsystemExt>::FinalData, InternalError>
     where
         S::IO: IOSubsystemExt,
         S::Memory: MemorySubsystemExt,
@@ -241,7 +242,7 @@ impl<S: EthereumLikeTypes> BasicBootloader<S> {
                         "Tx execution result: Internal error = {:?}\n",
                         err,
                     ));
-                    panic!("Internal error during tx execution {:?}", err)
+                    return Err(err);
                 }
                 Err(TxError::Validation(err)) => {
                     let _ = system.get_logger().write_fmt(format_args!(
@@ -374,6 +375,6 @@ impl<S: EthereumLikeTypes> BasicBootloader<S> {
         let r = system.finish(block_hash, l1_to_l2_tx_hash, upgrade_tx_hash, result_keeper);
         cycle_marker::end!("run_prepared");
         #[allow(clippy::let_and_return)]
-        r
+        Ok(r)
     }
 }

--- a/basic_bootloader/src/bootloader/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/process_transaction.rs
@@ -9,6 +9,7 @@ use crate::bootloader::errors::{InvalidAA, InvalidTransaction, TxError};
 use crate::bootloader::supported_ees::SupportedEEVMState;
 use crate::{require, require_internal};
 use constants::L1_TX_INTRINSIC_NATIVE_COST;
+use constants::L1_TX_NATIVE_PRICE;
 use constants::L2_TX_INTRINSIC_NATIVE_COST;
 use constants::SIMULATION_NATIVE_PER_GAS;
 use constants::{
@@ -105,10 +106,8 @@ where
         // will be refunded to the user.
         let gas_per_pubdata = transaction.gas_per_pubdata_limit.read();
 
-        let native_price = system.get_native_price();
-        if native_price.is_zero() {
-            return Err(InternalError("Native price cannot be 0").into());
-        };
+        // For L1->L2 txs, we use a constant native price to avoid censorship.
+        let native_price = L1_TX_NATIVE_PRICE;
         let native_per_gas = U256::from(gas_price).div_ceil(native_price);
         let native_per_pubdata = U256::from(gas_per_pubdata)
             .checked_mul(native_per_gas)

--- a/basic_bootloader/src/bootloader/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/process_transaction.rs
@@ -287,11 +287,6 @@ where
             success,
         )?;
 
-        let tx_stats = system.flush_tx();
-        let _ = system
-            .get_logger()
-            .write_fmt(format_args!("Tx stats = {:?}\n", tx_stats));
-
         Ok(TxProcessingResult {
             result,
             tx_hash,
@@ -584,12 +579,6 @@ where
         } else {
             0
         };
-
-        let tx_stats = system.flush_tx();
-
-        let _ = system
-            .get_logger()
-            .write_fmt(format_args!("Tx stats = {:?}\n", tx_stats));
 
         #[cfg(not(target_arch = "riscv32"))]
         cycle_marker::log_marker(

--- a/docs/double_resource_accounting.md
+++ b/docs/double_resource_accounting.md
@@ -1,0 +1,52 @@
+# Double resource accounting
+
+As introduced in the [Overview](./overview.md), ZKsyncOS implements a double resource accounting model, where both a Execution Environment resource (EVM gas, for instance) and native resource are tracked.
+
+The interface to interact with resources can be found in [resources.rs](../zk_ee/src/system/resources.rs).
+
+## Execution Environment resource: Ergs
+
+The EE resource is called Ergs, and corresponds to a model for computation performed by Execution Environments. The current ZKsyncOS design assumes every EE will use essentially the same resource for this, but potentially with a different conversion rate. For example, a unit of EVM gas is currently equivalent to 256 ergs, while a unit of EraVM gas might use a smaller constant for this conversion.
+
+The gas-related related fields of ZKsyncOS transactions are interpreted as referring to EVM gas. In general, any reference to the word "gas" in the codebase or docs refer to EVM gas.
+
+Ergs passed to a new EE frame during a call/deployment can be limited as in EVM, in which case the caller will keep the rest of the ergs available.
+
+## Native resource
+
+The native resource models the offchain cost of processing a transaction. Currently, this is dominated by proving and publishing data. A good intuition for it is "how many risc-v cycles it takes to prove a given computation".
+
+If a transaction execution runs out of native resources, the entire transaction is reverted. If the same happens during transaction validation, the transaction is considered invalid.
+
+The native resources are passed fully from frame to frame, a call cannot set a limit on how much of it the callee can spend.
+
+### Native resource limit
+
+In order to avoid having to use a new custom transaction format, the native resource limit (or native limit) is derived from the transaction's gas limit and fee. That is, the native limit can be incremented by either increasing the gas limit or the gas price of the transaction (using priority fee). The idea of using both these fields is to allow users re-use presigned transactions with a fixed EVM-computed gas limit.
+
+However, if a wallet uses the standard `eth_estimateGas` RPC, the gas estimation will assume no priority fee is added, and will add enough gas to make sure the transaction has enough native resource to go through.
+
+More precisely, the logic for native resource limit derivation and charging is:
+
+Let:
+
+- `gasPrice` be the transaction's gas price (base fee + priority fee).
+- `nativePrice` be a constant set by the operator, reflecting the "cost of processing a single cycle". Note: for L1->L2 transactions we use a code constant instead of one provided by operator.
+- `gasLimit` be the transaction's (EVM) gas limit.
+
+First we define the ratio between EVM gas and native resource as:
+  `nativePerGas := gasPrice/nativePrice`
+Note: for call simulation we use a constant for it, as gasPrice might be set to 0.
+
+Next we define the limit for the native resource as:
+  `nativeLimit := gasLimit * nativePerGas`
+
+Then we process the transaction, charging both Ergs for EE execution and native resource for any kind of computation (EE, bootloader or system work).
+
+If execution doesn't run out of native resources, we first charge for pubdata from native resource.
+Then we compute the difference between the implicit gas used derived from native resource consumption and the gas used by EEs from the ergs used. We call this value `deltaGas`.
+  `deltaGas := (nativeUsed / nativePerGas) - gasUsed`
+
+If `deltaGas > 0`, we add it to `gasUsed` and charge it from ergs. This ensures that gas estimation will include additional gas to cover for native resources using just base fee. We expect the base fee to be enough to cover most transactions without the need of additional gas.
+
+Finally, refund any remaining gas left is refunded as usual.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,3 +42,8 @@ The two running environments are:
 2. **Proving running mode** - to be used during proofs generation. The code is running on the pure RISC-V platform without OS, so we should manage memory, also different non-determinism source needed to pass the data inside the RISC-V machine. And we should prove everything.
 
 In order to achieve that we want to have some way to configure the system, as mentioned above - oracle, allocator, disabling/enabling code that is needed only during proving.
+
+## System Resources
+
+In ZKsyncOS we need a concept of "resources" to limit and charge for computation (mainly proving) and data.
+This is trickier that it may seem: ZKsyncOS is built to be EVM gas-equivalent, meaning that EVM code execution should follow the same gas schedule as Ethereum. The main issue with this is that for several reasons the EVM gas schedule doesn't correspond to the costs of proving it. The solution to this problem is to perform double accounting of both Execution Environment gas (think of EVM gas) and a "native" computational resource, the latter modeling the cost of proving. More details about this solution can be found in [Double resource accounting](./double_resource_accounting.md)

--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -161,6 +161,8 @@ pub fn run_batch_from_oracle_dump<
 ///
 /// Simulate single transaction on top of given state.
 /// The validation step is skipped, fields that needed for validation can be empty(any).
+/// Note that, as the validation step is skipped, an internal error is returned
+/// if the sender does not have enough balance for the top-level call value transfer.
 ///
 /// Needed for `eth_call` and `eth_estimateGas`.
 ///
@@ -189,7 +191,7 @@ pub fn simulate_tx<S: ReadStorage, PS: PreimageSource>(
     CallSimulationBootloader::run_prepared::<BasicBootloaderCallSimulationConfig>(
         oracle,
         &mut result_keeper,
-    );
+    )?;
     let mut batch_output: BatchOutput = result_keeper.into();
     Ok(batch_output.tx_results.remove(0))
 }

--- a/forward_system/src/system/bootloader.rs
+++ b/forward_system/src/system/bootloader.rs
@@ -17,5 +17,7 @@ pub fn run_forward<
     oracle: ForwardRunningOracle<T, PS, TS>,
     result_keeper: &mut impl ResultKeeperExt,
 ) {
-    let _oracle = ForwardBootloader::run_prepared::<Config>(oracle, result_keeper);
+    if let Err(err) = ForwardBootloader::run_prepared::<Config>(oracle, result_keeper) {
+        panic!("Forward run failed with: {:?}", err)
+    };
 }

--- a/proof_running_system/src/system/bootloader.rs
+++ b/proof_running_system/src/system/bootloader.rs
@@ -178,7 +178,8 @@ pub fn run_proving_inner<
     // Load all transactions from oracle and apply them.
     let (mut oracle, public_input) = ProvingBootloader::<O, L>::run_prepared::<
         BasicBootloaderProvingExecutionConfig,
-    >(oracle, &mut NopResultKeeper);
+    >(oracle, &mut NopResultKeeper)
+    .expect("Tried to prove a failing batch");
 
     // disconnect oracle before returning
     // TODO: check this is the intended behaviour (ignoring the result)


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR handles internal errors in the main loop of ZKsyncOS. These are handled by invalidating the entire transaction.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.