### PR TITLE
fix: remove unused generic in generate_proof_input

### DIFF
--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -73,11 +73,7 @@ pub fn run_batch<T: ReadStorageTree, PS: PreimageSource, TS: TxSource, TR: TxRes
 }
 
 // TODO: we should run it on native arch and it should return pubdata and other outputs via result keeper
-pub fn generate_proof_input<
-    T: ReadStorageTree,
-    PS: PreimageSource,
-    TS: TxSource,
->(
+pub fn generate_proof_input<T: ReadStorageTree, PS: PreimageSource, TS: TxSource>(
     zk_os_program_path: PathBuf,
     batch_context: BatchContext,
     storage_commitment: StorageCommitment,


### PR DESCRIPTION
## What ❔

remove unused generic in generate_proof_input

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.