### PR TITLE
fix: use constant for native_per_gas in simulation mode

### DIFF
--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -92,3 +92,8 @@ pub const DEFAULT_GAS_PER_PUBDATA: U256 = U256::from_limbs([1, 0, 0, 0]);
 /// low gas prices. We need to bypass the usual way to compute this
 /// value. The value is so high because of modexp tests.
 pub const TESTER_NATIVE_PER_GAS: usize = 25_000;
+
+/// native_per_gas value to use for simulation. Should be in line with
+/// the value of basefee / native_price provided by operator.
+/// Needed because simulation is done with basefee = 0.
+pub const SIMULATION_NATIVE_PER_GAS: U256 = U256::from_limbs([100, 0, 0, 0]);

--- a/basic_bootloader/src/bootloader/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/process_transaction.rs
@@ -7,6 +7,7 @@ use crate::bootloader::config::BasicBootloaderExecutionConfig;
 use crate::bootloader::errors::TxError::Validation;
 use crate::bootloader::errors::{InvalidAA, InvalidTransaction, TxError};
 use crate::{require, require_internal};
+use constants::SIMULATION_NATIVE_PER_GAS;
 use constants::{
     L1_TX_INTRINSIC_L2_GAS, L1_TX_INTRINSIC_PUBDATA, L2_TX_INTRINSIC_GAS, L2_TX_INTRINSIC_PUBDATA,
     MAX_BLOCK_GAS_LIMIT,
@@ -435,6 +436,8 @@ where
         };
         let native_per_gas = if cfg!(feature = "resources_for_tester") {
             U256::from(crate::bootloader::constants::TESTER_NATIVE_PER_GAS)
+        } else if Config::ONLY_SIMULATE {
+            SIMULATION_NATIVE_PER_GAS
         } else {
             U256::from(gas_price).div_ceil(native_price)
         };


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.