### PR TITLE
fix: Changes for fee model

### DIFF
--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -107,6 +107,6 @@ pub const SIMULATION_NATIVE_PER_GAS: U256 = U256::from_limbs([100, 0, 0, 0]);
 // TODO: find a reasonable value for it.
 pub const L1_TX_NATIVE_PRICE: U256 = U256::from_limbs([10, 0, 0, 0]);
 
-// Upgrade transactions are expected to have ~72 million gas. We will use enough 
+// Upgrade transactions are expected to have ~72 million gas. We will use enough
 // gas to ensure that multiplied by the 72 million they exceed the native computational limit.
 pub const UPGRADE_TX_NATIVE_PER_GAS: U256 = U256::from_limbs([10000, 0, 0, 0]);

--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -106,3 +106,7 @@ pub const SIMULATION_NATIVE_PER_GAS: U256 = U256::from_limbs([100, 0, 0, 0]);
 // Default native price for L1->L2 transactions.
 // TODO: find a reasonable value for it.
 pub const L1_TX_NATIVE_PRICE: U256 = U256::from_limbs([10, 0, 0, 0]);
+
+// Upgrade transactions are expected to have ~72 million gas. We will use enough 
+// gas to ensure that multiplied by the 72 million they exceed the native computational limit.
+pub const UPGRADE_TX_NATIVE_PER_GAS: U256 = U256::from_limbs([10000, 0, 0, 0]);

--- a/basic_bootloader/src/bootloader/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/gas_helpers.rs
@@ -6,6 +6,10 @@ use zk_ee::system::{Computational, Resources};
 
 use super::*;
 
+/// Returns the resources for the transaction and the withheld resources.
+/// The withheld resources are the resources that are withheld from the transaction's
+/// execution to ensure that it does not use too many native computational resources.
+/// They are reclaimed at the end of the transaction and used to charge the pubdata.
 pub fn get_resources_for_tx<S: EthereumLikeTypes>(
     gas_limit: u64,
     native_per_pubdata: U256,
@@ -42,10 +46,10 @@ pub fn get_resources_for_tx<S: EthereumLikeTypes>(
     // EVM tester requires high native limits, so for it we never hold off resources.
     // But for the real world, we bound the available resources.
 
-    let withheld_resources = S::Resources::from_ergs(Ergs(0));
+    let mut withheld_resources = S::Resources::from_ergs(Ergs(0));
 
     #[cfg(not(feature = "resources_for_tester"))]
-    let (native_limit, withheld_resources) = if native_limit <= MAX_NATIVE_COMPUTATIONAL {
+    let (native_limit, mut withheld_resources) = if native_limit <= MAX_NATIVE_COMPUTATIONAL {
         (native_limit, S::Resources::from_ergs(Ergs(0)))
     } else {
         let withheld =
@@ -96,6 +100,7 @@ pub fn get_resources_for_tx<S: EthereumLikeTypes>(
             .ok_or(InternalError("glft*EPF"))?;
         let mut resources = S::Resources::from_ergs_and_native(Ergs(ergs), native_limit);
         resources.set_as_limit();
+        withheld_resources.set_as_limit();
         Ok((resources, withheld_resources))
     }
 }

--- a/basic_bootloader/src/bootloader/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/gas_helpers.rs
@@ -53,7 +53,10 @@ pub fn get_resources_for_tx<S: EthereumLikeTypes>(
                 native_limit - MAX_NATIVE_COMPUTATIONAL,
             );
 
-        (MAX_NATIVE_COMPUTATIONAL, S::Resources::from_native(withheld))
+        (
+            MAX_NATIVE_COMPUTATIONAL,
+            S::Resources::from_native(withheld),
+        )
     };
 
     // Charge for calldata and intrinsic native

--- a/basic_bootloader/src/bootloader/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/process_transaction.rs
@@ -117,7 +117,7 @@ where
         let native_per_pubdata = U256::from(gas_per_pubdata)
             .checked_mul(native_per_gas)
             .ok_or(InternalError("gpp*npg"))?;
-        
+
         let (mut resources, withheld_resources) = get_resources_for_tx::<S>(
             gas_limit,
             native_per_pubdata,
@@ -180,7 +180,7 @@ where
                 value,
                 native_per_pubdata,
                 &mut resources,
-                withheld_resources
+                withheld_resources,
             ) {
                 Ok(r) => {
                     match r {

--- a/zk_ee/src/reference_implementations/mod.rs
+++ b/zk_ee/src/reference_implementations/mod.rs
@@ -111,7 +111,7 @@ impl Resource for IncreasingNative {
 
     fn reclaim_withheld(&mut self, to_reclaim: Self) {
         self.count += to_reclaim.count;
-        self.limit = to_reclaim.limit
+        self.limit += to_reclaim.limit
     }
 
     fn diff(&self, other: Self) -> Self {

--- a/zk_ee/src/reference_implementations/mod.rs
+++ b/zk_ee/src/reference_implementations/mod.rs
@@ -48,8 +48,11 @@ impl Resource for DecreasingNative {
 
     fn reclaim(&mut self, to_reclaim: Self) {
         // This is only used to "give back" the native resource.
-        // TODO: either rename the struct or make a new method for this.
-        // assert!(self.0 == 0 || to_reclaim.0 == 0);
+        assert!(self.0 == 0 || to_reclaim.0 == 0);
+        self.0 += to_reclaim.0
+    }
+
+    fn reclaim_withheld(&mut self, to_reclaim: Self) {
         self.0 += to_reclaim.0
     }
 
@@ -102,6 +105,11 @@ impl Resource for IncreasingNative {
     }
 
     fn reclaim(&mut self, to_reclaim: Self) {
+        self.count += to_reclaim.count;
+        self.limit = to_reclaim.limit
+    }
+
+    fn reclaim_withheld(&mut self, to_reclaim: Self) {
         self.count += to_reclaim.count;
         self.limit = to_reclaim.limit
     }
@@ -187,6 +195,11 @@ impl<Native: Resource> Resource for BaseResources<Native> {
     fn reclaim(&mut self, to_reclaim: Self) {
         self.ergs.reclaim(to_reclaim.ergs);
         self.native.reclaim(to_reclaim.native);
+    }
+
+    fn reclaim_withheld(&mut self, to_reclaim: Self) {
+        self.ergs.reclaim(to_reclaim.ergs);
+        self.native.reclaim_withheld(to_reclaim.native);
     }
 
     fn diff(&self, other: Self) -> Self {

--- a/zk_ee/src/reference_implementations/mod.rs
+++ b/zk_ee/src/reference_implementations/mod.rs
@@ -48,7 +48,8 @@ impl Resource for DecreasingNative {
 
     fn reclaim(&mut self, to_reclaim: Self) {
         // This is only used to "give back" the native resource.
-        assert!(self.0 == 0 || to_reclaim.0 == 0);
+        // TODO: either rename the struct or make a new method for this.
+        // assert!(self.0 == 0 || to_reclaim.0 == 0);
         self.0 += to_reclaim.0
     }
 

--- a/zk_ee/src/system/resources.rs
+++ b/zk_ee/src/system/resources.rs
@@ -33,6 +33,10 @@ pub trait Resource: 'static + Sized + Clone + core::fmt::Debug + PartialEq + Eq 
     /// Adds [to_reclaim] to a given resource.
     fn reclaim(&mut self, to_reclaim: Self);
 
+    /// Reclaims a withheld resource. Should be only used by the bootloader at the end
+    /// of a transaction.
+    fn reclaim_withheld(&mut self, to_reclaim: Self);
+
     /// Computes the absolute difference between [self] and [other].
     fn diff(&self, other: Self) -> Self;
 
@@ -101,6 +105,10 @@ impl Resource for Ergs {
     }
 
     fn reclaim(&mut self, to_reclaim: Self) {
+        self.0 += to_reclaim.0
+    }
+
+    fn reclaim_withheld(&mut self, to_reclaim: Self) {
         self.0 += to_reclaim.0
     }
 


### PR DESCRIPTION
## What ❔

Changes:

1. Introduced `UPGRADE_TX_NATIVE_PER_GAS`. Upgrade transactions have 0 fee per gas and so for them the native per gas would be 0. Setting a non-zero value there is IMO not desirable since to keep the invariant `amount_mint >= gas_limit * fee_per_gas`. At the same time the invariant the txs with smaller gas fee than base fee are not included is broken... In any case, I kept the same approach as the one used on Era.
2. Previously all the withheld resources would be burned (they would get into `native_used` [here](https://github.com/matter-labs/zksync-os/blob/53456cbe3f3d90315b506338510cefa019ff8999/basic_bootloader/src/bootloader/process_transaction.rs#L1002-L1006). But now I explicitly remember how much was withheld and return it. This feature is not mandatory (firstly it seemed like mandatory, but when I merged the `main` branch priority txs started working for me, but it is still really nice to not waste users' funds.
3. For L1 txs I always use `transaction.max_fee_per_gas`. Today they must be processed always, regardless of the base fee. Otherwise the priority queue would be stalled. 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.