### PR TITLE
fix: Actually clean storage cache on selfdestruct

### DIFF
--- a/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
@@ -311,6 +311,7 @@ where {
         Ok(old_value)
     }
 
+    /// Cleae state at specified address
     pub fn clear_state_impl(&mut self, address: impl AsRef<B160>) -> Result<(), SystemError>
     where
         K::Subspace: TyEq<B160>,
@@ -321,6 +322,10 @@ where {
         self.cache
             .for_each_range((Included(&lower_bound), Included(&upper_bound)), |mut x| {
                 x.update(|cache_record| {
+                    cache_record.update(|v, _| {
+                        *v = V::default();
+                        Ok(())
+                    })?;
                     cache_record.unset();
                     Ok(())
                 })


### PR DESCRIPTION
## What ❔

Reset storage values to 0.

## Why ❔

At least affects pubdata calculation for user's tx.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted.