### PR TITLE
chore(docs): update CUDA_LAUNCH_BLOCKING guidance

### DIFF
--- a/docs/proving_ethereum.md
+++ b/docs/proving_ethereum.md
@@ -22,13 +22,20 @@ cargo run -p eth_runner --release --features rig/no_print,rig/unlimited_native -
 
 Now, from zksync-airbender's directory (suggested version v0.3.0) run the prover with GPU or with CPU using the following:
 
-With GPU (GPU requires at least 22GB of VRAM):
+### With GPU (GPU requires at least 22GB of VRAM):
+```shell
+mkdir /tmp/output
+CUDA_VISIBLE_DEVICES=0 cargo run -p cli --release --features gpu prove --bin ../zksync-os/zksync_os/evm_replay.bin --input-file /tmp/witness/22244135_witness --until final-recursion --output-dir /tmp/output --gpu --cycles 400000000
+```
+
+To hide latency, Airbender uses an asynchronous allocator and internal pipelining (e.g. overlapping cpu<->gpu transfers with computations). The pipelining requires dedicated allocations.
+If you encounter an error, it may be because you ran out of memory. You can reduce the necessary high-water mark by running the GPU in synchronous mode with CUDA_LAUNCH_BLOCKING=1:
 ```shell
 mkdir /tmp/output
 CUDA_LAUNCH_BLOCKING=1 CUDA_VISIBLE_DEVICES=0 cargo run -p cli --release --features gpu prove --bin ../zksync-os/zksync_os/evm_replay.bin --input-file /tmp/witness/22244135_witness --until final-recursion --output-dir /tmp/output --gpu --cycles 400000000
 ```
 
-With CPU:
+### With CPU:
 ```shell
 mkdir /tmp/output
 cargo run -p cli --release prove --bin ../zksync-os/zksync_os/evm_replay.bin --input-file /tmp/witness/22244135_witness --until final-recursion --output-dir /tmp/output --cycles 400000000


### PR DESCRIPTION
## What ❔

Updates guidance to list CUDA_LAUNCH_BLOCKING as optional.

## Why ❔

To reproduce our numbers, people should run _without_ CUDA_LAUNCH_BLOCKING=1.
However, we should still let them know it can help reduce the memory footprint in a pinch.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.