### PR TITLE
Add scripts for easy local rebuilds

### DIFF
--- a/zksync_os/.gitignore
+++ b/zksync_os/.gitignore
@@ -1,4 +1,5 @@
-os.elf
-app.elf
-app.text
+*.elf
+*.text
+server_app.bin
+server_app_logging_enabled.bin
 /target

--- a/zksync_os/dump_bin.sh
+++ b/zksync_os/dump_bin.sh
@@ -1,11 +1,67 @@
 #!/bin/sh
-rm app.bin
-rm app.elf
-rm app.text
+set -e
 
-cargo build --features proving --release # easier errors
-# cargo build -Z build-std=core,panic_abort,alloc -Z build-std-features=panic_immediate_abort --release
-cargo objcopy --features proving --release -- -O binary app.bin
-cargo objcopy --features proving --release -- -R .text app.elf
-cargo objcopy --features proving --release -- -O binary --only-section=.text app.text
-# cargo objcopy -- -O binary app.bin
+# Default mode
+TYPE="default"
+
+# Parse --type argument
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: $0 [--type default|server|server-logging-enabled]"
+      exit 1
+      ;;
+  esac
+done
+
+# Base features and output names
+FEATURES="proving"
+BIN_NAME="app.bin"
+ELF_NAME="app.elf"
+TEXT_NAME="app.text"
+
+# Adjust for server modes
+case "$TYPE" in
+  server)
+    FEATURES="$FEATURES,proof_running_system/unlimited_native,proof_running_system/wrap-in-batch"
+    BIN_NAME="server_app.bin"
+    ELF_NAME="server_app.elf"
+    TEXT_NAME="server_app.text"
+    ;;
+  server-logging-enabled)
+    FEATURES="$FEATURES,proof_running_system/unlimited_native,proof_running_system/wrap-in-batch,print_debug_info"
+    BIN_NAME="server_app_logging_enabled.bin"
+    ELF_NAME="server_app_logging_enabled.elf"
+    TEXT_NAME="server_app_logging_enabled.text"
+    ;;
+  default)
+    # leave defaults
+    ;;
+  *)
+    echo "Invalid --type: $TYPE"
+    echo "Valid types are: default, server, server-logging-enabled"
+    exit 1
+    ;;
+esac
+
+# Clean up only the artifacts for this mode
+rm -f "$BIN_NAME" "$ELF_NAME" "$TEXT_NAME"
+
+# Build
+cargo build --features "$FEATURES" --release
+
+# Produce and rename outputs
+cargo objcopy --features "$FEATURES" --release -- -O binary "$BIN_NAME"
+cargo objcopy --features "$FEATURES" --release -- -R .text "$ELF_NAME"
+cargo objcopy --features "$FEATURES" --release -- -O binary --only-section=.text "$TEXT_NAME"
+
+# Summary
+echo "Built [$TYPE] with features: $FEATURES"
+echo "→ $BIN_NAME"
+echo "→ $ELF_NAME"
+echo "→ $TEXT_NAME"

--- a/zksync_os/upd_local_era.sh
+++ b/zksync_os/upd_local_era.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+
+# Default: do recompile/dump
+RECOMPILE=true
+
+# Parse flags
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-recompile)
+      RECOMPILE=false
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      echo "Usage: $0 [--no-recompile]"
+      exit 1
+      ;;
+  esac
+done
+
+TARGET_DIR="../../zksync-era"
+
+# 1. Optionally regenerate the server binaries
+if [ "$RECOMPILE" = "true" ]; then
+  echo "Regenerating server binaries…"
+  
+  echo " → ./dump_bin.sh --type server"
+  ./dump_bin.sh --type server
+
+  echo " → ./dump_bin.sh --type server-logging-enabled"
+  ./dump_bin.sh --type server-logging-enabled
+fi
+
+# 2. Verify target directory exists
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Error: target directory '$TARGET_DIR' does not exist."
+  exit 1
+fi
+
+# 3. Copy server_app.bin → app.bin
+if [ ! -f server_app.bin ]; then
+  echo "Error: source file 'server_app.bin' not found."
+  exit 1
+fi
+cp -f server_app.bin "$TARGET_DIR/app.bin"
+echo "Copied server_app.bin → $TARGET_DIR/app.bin"
+
+# 4. Copy server_app_logging_enabled.bin → app_logging_enabled.bin
+if [ ! -f server_app_logging_enabled.bin ]; then
+  echo "Error: source file 'server_app_logging_enabled.bin' not found."
+  exit 1
+fi
+cp -f server_app_logging_enabled.bin "$TARGET_DIR/app_logging_enabled.bin"
+echo "Copied server_app_logging_enabled.bin → $TARGET_DIR/app_logging_enabled.bin"
+
+# 5. Done
+echo "All specified binaries have been replaced in '$TARGET_DIR'."


### PR DESCRIPTION
## What ❔

When working on Era locally, there is often a need to build `app.bin` and `app_logging_enabled.bin` to be copied to the server

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.