### PR TITLE
chore(docs): Add explicit evm_replay feature to proving_ethereum.md

### DIFF
--- a/docs/proving_ethereum.md
+++ b/docs/proving_ethereum.md
@@ -17,7 +17,7 @@ TL;DR:
 
 mkdir /tmp/witness
 
-cargo run -p eth_runner --release --features rig/no_print,rig/unlimited_native,evm_replay -- single-run --block-dir tests/instances/eth_runner/blocks/19299001 --randomized --witness-output-dir /tmp/witness
+cargo run -p eth_runner --release --features rig/no_print,evm_replay -- single-run --block-dir tests/instances/eth_runner/blocks/19299001 --randomized --witness-output-dir /tmp/witness
 ```
 
 Now, clone [zksync-airbender](https://github.com/matter-labs/zksync-airbender/tree/main) (suggested version v0.3.0).


### PR DESCRIPTION
## What ❔

^

## Why ❔

The evm_replay feature is now required to properly simulate EVM blocks.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.