### PR TITLE
feat: add public `LeafProof` constructor

### DIFF
--- a/basic_system/src/system_implementation/flat_storage_model/simple_growable_storage.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/simple_growable_storage.rs
@@ -917,6 +917,17 @@ pub struct LeafProof<const N: usize, H: FlatStorageHasher, A: Allocator = Global
     _marker: core::marker::PhantomData<H>,
 }
 
+impl<const N: usize, H: FlatStorageHasher, A: Allocator> LeafProof<N, H, A> {
+    pub fn new(index: u64, leaf: FlatStorageLeaf<N>, path: Box<[Bytes32; N], A>) -> Self {
+        Self {
+            index,
+            leaf,
+            path,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
 impl<const N: usize, H: FlatStorageHasher, A: Allocator> core::fmt::Debug for LeafProof<N, H, A> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct(core::any::type_name::<Self>())


### PR DESCRIPTION
## What ❔

Ditto, adds a public constructor for `LeafProof`

## Why ❔

Needed in server so that `ReadStorageTree` is implementable (it requires you to construct `LeafProof` which is impossible right now)

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.