### PR TITLE
chore: remove trace_and_split dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ categories = ["cryptography"]
 risc_v_simulator = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.3.1"}
 blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.3.1"}
 prover_examples = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.3.1"}
-trace_and_split = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.3.1"}
 execution_utils = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.3.1"}
 
 # [profile.dev]
@@ -85,6 +84,5 @@ debug = true
 
 # blake2s_u32 = { path = "../zksync-airbender/blake2s_u32" }
 # prover_examples = { path = "../zksync-airbender/circuit_defs/prover_examples" }
-# trace_and_split = { path = "../zksync-airbender/circuit_defs/trace_and_split" }
 # risc_v_simulator = { path = "../zksync-airbender/risc_v_simulator" }
 # execution_utils = { path = "../zksync-airbender/execution_utils" }

--- a/zksync_os_runner/Cargo.toml
+++ b/zksync_os_runner/Cargo.toml
@@ -11,11 +11,9 @@ categories.workspace = true
 
 [dependencies]
 risc_v_simulator = { workspace = true, features = ["delegation"] }
-trace_and_split = { workspace = true }
 execution_utils = { workspace = true }
 prover_examples = { workspace = true }
 cycle_marker = { path = "../cycle_marker" }
-# risc_v_simulator = { path = "../../zksync-airbender/risc_v_simulator" }
 
 [features]
 opcode_stats = ["risc_v_simulator/opcode_stats"]

--- a/zksync_os_runner/src/lib.rs
+++ b/zksync_os_runner/src/lib.rs
@@ -139,7 +139,8 @@ pub fn simulate_witness_tracing(
 
     let num_instances_upper_bound = 1 << 14;
     let binary = execution_utils::get_padded_binary(&buffer);
-    let worker = trace_and_split::setups::prover::worker::Worker::new();
+
+    let worker = prover_examples::prover::worker::Worker::new();
 
     let now = std::time::Instant::now();
     let (all_witness_instances, _, _, _) =


### PR DESCRIPTION
## What ❔

* removing airbender trace_and_split dependency that was not really used.