### PR TITLE
fix: modexp mod 1 case

### DIFF
--- a/basic_system/src/system_functions/modexp/delegation/mod.rs
+++ b/basic_system/src/system_functions/modexp/delegation/mod.rs
@@ -24,6 +24,11 @@ pub(super) fn modexp<O: IOOracle, L: Logger, A: Allocator + Clone>(
     let output = if m.digits == 0 {
         Vec::new_in(allocator)
     } else {
+        // another short circuit (as parsing below is infailable - we can even skip parsing the base and exponent)
+        if m.digits == 1 && m.backing[0].is_one() {
+            // it is base ^ exponend mod 1 == 0 in all the cases
+            return Vec::new_in(allocator);
+        }
         let min_capacity = m.capacity();
         let x = BigintRepr::from_big_endian_with_double_capacity_or_min_capacity(
             &base,

--- a/basic_system/src/system_functions/modexp/delegation/mod.rs
+++ b/basic_system/src/system_functions/modexp/delegation/mod.rs
@@ -60,6 +60,11 @@ mod test {
         let output = if m.digits == 0 {
             Vec::new_in(allocator)
         } else {
+            // another short circuit (as parsing below is infailable - we can even skip parsing the base and exponent)
+            if m.digits == 1 && m.backing[0].is_one() {
+                // it is base ^ exponend mod 1 == 0 in all the cases
+                return Vec::new_in(allocator);
+            }
             let min_capacity = m.capacity();
             let x = BigintRepr::from_big_endian_with_double_capacity_or_min_capacity(
                 &base,
@@ -197,7 +202,7 @@ mod test {
 
     #[test]
     fn test_5() {
-        // 0^1 mod 2 - somewhat degenerate
+        // 0^1 mod 2
 
         let base = hex::decode("00").unwrap();
 
@@ -214,7 +219,7 @@ mod test {
 
     #[test]
     fn test_6() {
-        // 0^0 mod 2 - somewhat degenerate
+        // 0^0 mod 2
 
         let base = hex::decode("00").unwrap();
 
@@ -227,6 +232,40 @@ mod test {
         let expected =
             hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_7() {
+        // 3^2 mod 1
+
+        let base = hex::decode("03").unwrap();
+
+        let exp = hex::decode("02").unwrap();
+
+        let modulus = hex::decode("01").unwrap();
+
+        let output = invoke_precompile_no_prepadding(&modulus, &base, &exp);
+
+        let expected = hex::decode("").unwrap();
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_8() {
+        // 0^0 mod 1
+
+        let base = hex::decode("00").unwrap();
+
+        let exp = hex::decode("00").unwrap();
+
+        let modulus = hex::decode("01").unwrap();
+
+        let output = invoke_precompile_no_prepadding(&modulus, &base, &exp);
+
+        let expected = hex::decode("").unwrap();
 
         assert_eq!(output, expected);
     }

--- a/basic_system/src/system_functions/modexp/delegation/u256.rs
+++ b/basic_system/src/system_functions/modexp/delegation/u256.rs
@@ -101,6 +101,20 @@ impl DelegatedU256 {
             eq != 0
         }
     }
+
+    pub(crate) fn is_one(&self) -> bool {
+        #[allow(static_mut_refs)]
+        unsafe {
+            // equality is non-destructive, so we can cast
+            let eq = bigint_op_delegation_raw(
+                (self as *const Self).cast_mut().cast(),
+                ONE.as_ptr().cast(),
+                BigIntOps::Eq,
+            );
+
+            eq != 0
+        }
+    }
 }
 
 impl Clone for DelegatedU256 {


### PR DESCRIPTION
## What ❔

Degenerate case now bails immediately if modulus us 1

## Why ❔

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.