### PR TITLE
fix: add UARTPrintResponder processor in generate_proof_input

### DIFF
--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -127,6 +127,7 @@ pub fn generate_proof_input<T: ReadStorageTree, PS: PreimageSource, TS: TxSource
     oracle.add_external_processor(preimage_responder);
     oracle.add_external_processor(tree_responder);
     oracle.add_external_processor(callable_oracles::arithmetic::ArithmeticQuery::default());
+    oracle.add_external_processor(UARTPrintResponder);
 
     // We'll wrap the source, to collect all the reads.
     let copy_source = ReadWitnessSource::new(oracle);


### PR DESCRIPTION
## What ❔

add UARTPrintResponder processor in generate_proof_input

## Why ❔

generate_proof_input should work with logging_enabled bins

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted.