### PR TITLE
fix: Fix allocated capacity in from_big_endian_with_double_capacity_or_min_capacity

### DIFF
--- a/basic_system/src/system_functions/modexp/delegation/bigint.rs
+++ b/basic_system/src/system_functions/modexp/delegation/bigint.rs
@@ -151,7 +151,7 @@ impl<A: Allocator + Clone> BigintRepr<A> {
         allocator: A,
     ) -> Self {
         if bytes.is_empty() {
-            let backing = Vec::new_in(allocator);
+            let backing = Vec::with_capacity_in(min_capacity, allocator);
             return Self { backing, digits: 0 };
         }
         let (remainder, digits_bytes) = bytes.as_rchunks::<32>();


### PR DESCRIPTION
## What ❔

Fixes small issue

## Why ❔

The min_capacity should be used

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted.