### PR TITLE
fix: pin reth deps for fuzzer

### DIFF
--- a/basic_system/Cargo.toml
+++ b/basic_system/Cargo.toml
@@ -55,8 +55,8 @@ alloy = { version = "1", features = ["rlp", "full"] }
 alloy-rlp = { version = "*" }
 alloy-primitives = { version = "1", features = ["arbitrary"] }
 reqwest = { version = "*", features = ["blocking", "json"] }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }

--- a/tests/fuzzer/fuzz/wrappers/basic_system_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_system_forward/Cargo.toml
@@ -61,8 +61,8 @@ alloy = { version = "1", features = ["rlp", "full"] }
 alloy-rlp = { version = "*" }
 alloy-primitives = { version = "1", features = ["arbitrary"] }
 reqwest = { version = "*", features = ["blocking", "json"] }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }

--- a/tests/fuzzer/fuzz/wrappers/basic_system_proving/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_system_proving/Cargo.toml
@@ -61,8 +61,8 @@ alloy = { version = "1", features = ["rlp", "full"] }
 alloy-rlp = { version = "*" }
 alloy-primitives = { version = "1", features = ["arbitrary"] }
 reqwest = { version = "*", features = ["blocking", "json"] }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }


### PR DESCRIPTION
## What ❔
This PR just pins the reth crates used for the fuzzer, as latest git version doesn't build
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.