### PR TITLE
fix: exclude timeout and slow-unit artifacts from the fuzzer's output

### DIFF
--- a/tests/fuzzer/fuzz_deep.sh
+++ b/tests/fuzzer/fuzz_deep.sh
@@ -16,7 +16,6 @@ FUZZ_FLAGS=(
   -timeout=5
   -ignore_timeouts=1
   -fork="$FORK"
-  -report_slow_units=0
   -verbosity=0
 )
 
@@ -161,7 +160,7 @@ run_target() {
 
   mapfile -t flags < <(printf "%s\n" "${FUZZ_FLAGS[@]}")
 
-  ( setsid stdbuf -oL -eL cargo fuzz run "$target" -- "${flags[@]}" 2>&1 | tee -a "$log_file" ) &
+  ( setsid stdbuf -oL -eL cargo fuzz run "$target" -- "${flags[@]}" ) >> "$log_file" 2>&1 &
   run_pid=$!
 
   wait "$run_pid" 2>/dev/null


### PR DESCRIPTION
## What ❔

This PR fixes the `fuzz_deep.sh` script so it ignores `timeout` and `slow-unit` artifacts generated by libFuzzer.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted.