### PR TITLE
perf: inline verify_kzg_proof to recover point eval performace

### DIFF
--- a/crypto/src/bls12_381/mod.rs
+++ b/crypto/src/bls12_381/mod.rs
@@ -12,6 +12,7 @@ use crate::ark_ec::AffineRepr;
 use crate::ark_ff::{Field, PrimeField};
 use consts::{G2_BY_TAU_POINT, PREPARED_G2_GENERATOR};
 
+#[inline(always)]
 pub fn verify_kzg_proof(
     commitment: G1Affine,
     proof: G1Affine,


### PR DESCRIPTION
## What ❔

#367 introduced a performance regression, this PR fixes that by inlining the call to `verify_kzg_proof`

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.