### PR TITLE
feat: Add Stage 1 support

### DIFF
--- a/api/src/helpers.rs
+++ b/api/src/helpers.rs
@@ -166,7 +166,7 @@ pub fn encode_tx(
                     U256::ZERO
                 }
             } else if tx_type == 0x7f {
-                U256::from_be_bytes(value).add(U256::from(gas_limit * max_fee_per_gas))
+                U256::from(gas_limit * max_fee_per_gas)
             } else {
                 U256::ZERO
             })

--- a/api/src/helpers.rs
+++ b/api/src/helpers.rs
@@ -16,7 +16,6 @@ use basic_system::system_implementation::flat_storage_model::AccountProperties;
 use forward_system::run::PreimageSource;
 use ruint::aliases::U256;
 use std::alloc::Global;
-use std::ops::Add;
 use zk_ee::common_structs::interop_root_storage::InteropRoot as StoredInteropRoot;
 use zk_ee::execution_environment_type::ExecutionEnvironmentType;
 use zk_ee::system::EIP7702_DELEGATION_MARKER;

--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -103,7 +103,7 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
     }
 
     ///
-    /// Returns if the batch has had an upgrade tx in the first block
+    /// Returns if the batch has had an upgrade tx
     ///
     pub fn has_upgrade_tx(&self) -> bool {
         self.upgrade_tx_hash

--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -106,7 +106,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
     /// Returns if the batch has had an upgrade tx
     ///
     pub fn has_upgrade_tx(&self) -> bool {
-        self.upgrade_tx_hash
+        !self
+            .upgrade_tx_hash
             .is_none_or(|hash| hash == Bytes32::ZERO)
     }
 
@@ -297,5 +298,45 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> TxHashesAccumulator for ZKBatchDat
     // used to write l1 txs in tx loop
     fn add_tx_hash(&mut self, tx_hash: &Bytes32) {
         self.enforced_txs_accumulator.add_tx_hash(tx_hash);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::alloc::Global;
+    use zk_ee::oracle::usize_serialization::{UsizeDeserializable, UsizeSerializable};
+    use zk_ee::system::errors::internal::InternalError;
+
+    struct DummyOracle;
+
+    impl IOOracle for DummyOracle {
+        type RawIterator<'a> = core::iter::Empty<usize>;
+
+        fn raw_query<'a, I: UsizeSerializable + UsizeDeserializable>(
+            &'a mut self,
+            _query_type: u32,
+            _input: &I,
+        ) -> Result<Self::RawIterator<'a>, InternalError> {
+            Ok(core::iter::empty())
+        }
+    }
+
+    #[test]
+    fn has_upgrade_tx_is_false_for_none_and_zero_hash() {
+        let mut keeper = ZKBatchDataKeeper::<Global, DummyOracle>::new();
+
+        assert!(!keeper.has_upgrade_tx());
+
+        keeper.upgrade_tx_hash = Some(Bytes32::ZERO);
+        assert!(!keeper.has_upgrade_tx());
+    }
+
+    #[test]
+    fn has_upgrade_tx_is_true_for_non_zero_hash() {
+        let mut keeper = ZKBatchDataKeeper::<Global, DummyOracle>::new();
+        keeper.upgrade_tx_hash = Some(Bytes32::from_byte_fill(1));
+
+        assert!(keeper.has_upgrade_tx());
     }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -26,6 +26,8 @@ pub struct ZKBatchDataKeeper<A: alloc::alloc::Allocator, O: IOOracle> {
     pub da_commitment_generator: Option<alloc::boxed::Box<dyn DACommitmentGenerator<O>, A>>,
     pub logs_storage: ArrayVec<Bytes32, 16384>,
     enforced_txs_accumulator: TransactionsRollingKeccakHasher,
+    // Includes all transactions
+    pub tx_count: U256,
     upgrade_tx_hash: Option<Bytes32>,
     interop_roots_rolling_hash: Bytes32,
     settlement_layer_chain_id: Option<U256>,
@@ -45,6 +47,7 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
             logs_storage: ArrayVec::new(),
             // keccak256([])
             enforced_txs_accumulator: TransactionsRollingKeccakHasher::empty(),
+            tx_count: U256::ZERO,
             upgrade_tx_hash: None,
             interop_roots_rolling_hash: Bytes32::ZERO,
             settlement_layer_chain_id: None,
@@ -64,6 +67,7 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
         upgrade_tx_hash: Bytes32,
         interop_roots: impl Iterator<Item = &'a InteropRoot>,
         settlement_layer_chain_id: U256,
+        number_of_txs_in_block: u32,
     ) {
         if self.is_first_block {
             self.initial_state_commitment = Some(state_commitment_before);
@@ -89,6 +93,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
             );
         }
 
+        self.tx_count += U256::from(number_of_txs_in_block);
+
         self.interop_roots_rolling_hash = calculate_interop_roots_rolling_hash(
             self.interop_roots_rolling_hash,
             interop_roots,
@@ -97,10 +103,19 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
     }
 
     ///
+    /// Returns if the batch has had an upgrade tx in the first block
+    ///
+    pub fn has_upgrade_tx(&self) -> bool {
+        self.upgrade_tx_hash
+            .is_none_or(|hash| hash == Bytes32::ZERO)
+    }
+
+    ///
     /// Create public input for a batch that contains previously added blocks.
     ///
     pub fn into_public_input(self, mut logger: impl Logger, oracle: &mut O) -> BatchPublicInput {
         assert!(!self.is_first_block);
+        let has_upgrade_tx = self.has_upgrade_tx();
 
         let mut full_root_hasher = crypto::sha3::Keccak256::new();
         full_root_hasher.update(Self::l2_logs_root(self.logs_storage).as_u8_ref());
@@ -109,13 +124,21 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
 
         let (priority_operations_hash, number_of_layer_1_txs) =
             self.enforced_txs_accumulator.finish();
+        let number_of_layer_1_txs = U256::from(number_of_layer_1_txs);
+        // Number of L2 transactions can be calculated as:
+        // Total txs - l1 txs - upgrade txs
+        let mut number_of_layer_2_txs = self.tx_count - number_of_layer_1_txs;
+        if has_upgrade_tx {
+            number_of_layer_2_txs -= U256::ONE;
+        }
         let batch_output = BatchOutput {
             chain_id: self.chain_id.unwrap(),
             first_block_timestamp: self.first_block_timestamp.unwrap(),
             last_block_timestamp: self.current_block_timestamp.unwrap(),
             da_commitment_scheme: self.da_commitment_scheme.unwrap(),
             pubdata_commitment: self.da_commitment_generator.unwrap().finalize(oracle),
-            number_of_layer_1_txs: U256::from(number_of_layer_1_txs),
+            number_of_layer_1_txs,
+            number_of_layer_2_txs,
             priority_operations_hash,
             l2_logs_tree_root: full_l2_to_l1_logs_root.into(),
             upgrade_tx_hash: self.upgrade_tx_hash.unwrap(),

--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -106,9 +106,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
     /// Returns if the batch has had an upgrade tx
     ///
     pub fn has_upgrade_tx(&self) -> bool {
-        !self
-            .upgrade_tx_hash
-            .is_none_or(|hash| hash == Bytes32::ZERO)
+        self.upgrade_tx_hash
+            .is_some_and(|hash| hash != Bytes32::ZERO)
     }
 
     ///

--- a/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
@@ -157,4 +157,9 @@ impl UpgradeTx {
     pub fn finish(self) -> Bytes32 {
         self.inner
     }
+
+    /// Returns if an upgrade transaction has been recorded
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_zero()
+    }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -184,6 +184,7 @@ where
             upgrade_tx_hash,
             io.interop_root_storage.iter(),
             settlement_layer_chain_id,
+            block_data.current_transaction_number,
         );
 
         Ok(io.oracle)

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -101,12 +101,20 @@ where
 
         let (priority_operations_hash, number_of_layer_1_txs) =
             block_data.enforced_transaction_hashes_accumulator.finish();
+        // Number of L2 transactions can be calculated as:
+        // Total txs - l1 txs - upgrade txs
+        let mut number_of_layer_2_txs =
+            block_data.current_transaction_number - number_of_layer_1_txs;
+        if !block_data.upgrade_tx_recorder.is_empty() {
+            number_of_layer_2_txs -= 1;
+        }
         let upgrade_tx_hash = block_data.upgrade_tx_recorder.finish();
         let interop_roots_rolling_hash = calculate_interop_roots_rolling_hash(
             Bytes32::zero(),
             io.interop_root_storage.iter(),
             &mut crypto::sha3::Keccak256::new(),
         );
+
         let settlement_layer_chain_id = read_settlement_layer_chain_id(&mut io);
         if let Some(new_settlement_layer_chain_id) =
             io.new_settlement_layer_chain_id_storage.value()
@@ -188,6 +196,7 @@ where
             da_commitment_scheme: io.da_commitment_scheme.unwrap(),
             pubdata_commitment: da_commitment,
             number_of_layer_1_txs: U256::try_from(number_of_layer_1_txs).unwrap(),
+            number_of_layer_2_txs: U256::from(number_of_layer_2_txs),
             priority_operations_hash,
             l2_logs_tree_root: full_l2_to_l1_logs_root,
             upgrade_tx_hash,

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/public_input.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/public_input.rs
@@ -62,6 +62,8 @@ pub struct BatchOutput {
     pub pubdata_commitment: Bytes32,
     /// Number of l1 -> l2 processed txs in the batch.
     pub number_of_layer_1_txs: U256,
+    /// Number of processed L2 txs in the batch.
+    pub number_of_layer_2_txs: U256,
     /// Rolling keccak256 hash of l1 -> l2 txs processed in the batch.
     pub priority_operations_hash: Bytes32,
     /// L2 logs tree root.
@@ -91,6 +93,7 @@ impl BatchOutput {
         hasher.update([self.da_commitment_scheme as u8]);
         hasher.update(self.pubdata_commitment.as_u8_ref());
         hasher.update(self.number_of_layer_1_txs.to_be_bytes::<32>());
+        hasher.update(self.number_of_layer_2_txs.to_be_bytes::<32>());
         hasher.update(self.priority_operations_hash.as_u8_ref());
         hasher.update(self.l2_logs_tree_root.as_u8_ref());
         hasher.update(self.upgrade_tx_hash.as_u8_ref());

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -195,6 +195,7 @@ where
                                         .upgrade_tx_recorder
                                         .add_upgrade_tx_hash(&tx_processing_result.tx_hash);
                                 }
+                                block_data.current_transaction_number += 1;
 
                                 result_keeper.tx_processed(Ok(TxProcessingOutput {
                                     status,

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -128,11 +128,8 @@ where
         .ok_or(internal_error!("gp*gl"))?;
     let value = transaction.value.read();
     let total_deposited = transaction.reserved[0].read();
-    let needed_amount = value
-        .checked_add(U256::from(tx_internal_cost))
-        .ok_or(internal_error!("v+tic"))?;
     require_internal!(
-        total_deposited >= needed_amount,
+        total_deposited >= tx_internal_cost,
         "Deposited amount too low",
         system
     )?;
@@ -299,15 +296,15 @@ where
                 .ok_or(internal_error!("td-pto"))
         }
         ExecutionResult::Success { .. } => {
-            // If the transaction succeeds, then it is assumed that msg.value
-            // was transferred correctly.
+            // If the transaction succeeds, then it is assumed that the
+            // mint to `from` address was transferred correctly too.
             // However, the remaining value deposited will be given to
             // the refund recipient.
-            let value_plus_fee = value
-                .checked_add(pay_to_operator)
-                .ok_or(internal_error!("v+pto"))?;
-            total_deposited
-                .checked_sub(value_plus_fee)
+            let tx_internal_cost = gas_price
+                .checked_mul(U256::from(transaction.gas_limit.read()))
+                .ok_or(internal_error!("gp*gl"))?;
+            tx_internal_cost
+                .checked_sub(pay_to_operator)
                 .ok_or(internal_error!("td-vpf"))
         }
     }?;
@@ -407,13 +404,21 @@ where
     // Start a frame, to revert minting of value if execution fails
     let rollback_handle = system.start_global_frame()?;
 
-    // First we transfer value from treasury
-    if value > U256::ZERO {
+    let tx_internal_cost = gas_price
+        .checked_mul(U256::from(transaction.gas_limit.read()))
+        .ok_or(internal_error!("gp*gl"))?;
+    let total_deposited = transaction.reserved[0].read();
+    let to_transfer = total_deposited
+        .checked_sub(tx_internal_cost)
+        .ok_or(internal_error!("v+tic"))?;
+
+    // First we transfer from treasury
+    if to_transfer > U256::ZERO {
         resources
             .with_infinite_ergs(|inf_resources| {
                 transfer_from_treasury::<S>(
                     system,
-                    &value,
+                    &to_transfer,
                     &from,
                     inf_resources,
                     false, // Not a fee-related mint

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -288,9 +288,9 @@ where
             if !is_priority_op {
                 return Err(internal_error!("Upgrade transaction must succeed").into());
             }
-            // If the transaction reverts, then minting the msg.value to the
-            // user has been reverted as well, so we can simply mint everything
-            // that the user has deposited to the refund recipient
+            // If the transaction reverts, then the minting of the deposit
+            // reverted too. Thus, we need to refund the entire deposit minus
+            // the fee (`pay_to_operator`).
             total_deposited
                 .checked_sub(pay_to_operator)
                 .ok_or(internal_error!("td-pto"))
@@ -298,14 +298,14 @@ where
         ExecutionResult::Success { .. } => {
             // If the transaction succeeds, then it is assumed that the
             // mint to `from` address was transferred correctly too.
-            // However, the remaining value deposited will be given to
-            // the refund recipient.
-            let tx_internal_cost = gas_price
+            // In this case, we just refund the unused gas that the
+            // transaction paid for initially.
+            let prepaid_fee = gas_price
                 .checked_mul(U256::from(transaction.gas_limit.read()))
                 .ok_or(internal_error!("gp*gl"))?;
-            tx_internal_cost
+            prepaid_fee
                 .checked_sub(pay_to_operator)
-                .ok_or(internal_error!("td-vpf"))
+                .ok_or(internal_error!("pf-pto"))
         }
     }?;
     if to_refund_recipient > U256::ZERO {
@@ -404,13 +404,21 @@ where
     // Start a frame, to revert minting of value if execution fails
     let rollback_handle = system.start_global_frame()?;
 
-    let tx_internal_cost = gas_price
+    // Fee payment is done in two steps.
+    // The first step is here, where the max fee (gas limit * gas price)
+    // is committed to.
+    // This fee is deducted from the deposit to be minted (transferred from
+    // the treasury).
+    // After the execution of the transaction, the actual fee
+    // (gas used * gas price) is paid to the operator, while the
+    // rest of the max fee is refunded.
+    let max_fee_commitment = gas_price
         .checked_mul(U256::from(transaction.gas_limit.read()))
         .ok_or(internal_error!("gp*gl"))?;
     let total_deposited = transaction.reserved[0].read();
     let to_transfer = total_deposited
-        .checked_sub(tx_internal_cost)
-        .ok_or(internal_error!("v+tic"))?;
+        .checked_sub(max_fee_commitment)
+        .ok_or(internal_error!("mfc+tic"))?;
 
     // First we transfer from treasury
     if to_transfer > U256::ZERO {

--- a/tests/instances/system_hooks/src/lib.rs
+++ b/tests/instances/system_hooks/src/lib.rs
@@ -16,8 +16,268 @@ use rig::utils::{
     address_into_special_storage_key, AccountProperties, ACCOUNT_PROPERTIES_STORAGE_ADDRESS,
 };
 use rig::zk_ee::utils::Bytes32;
-use rig::zksync_os_interface::types::ExecutionResult;
+use rig::zksync_os_interface::types::{BlockOutput, ExecutionResult};
 use rig::{alloy, Chain};
+
+fn bal(chain: &mut Chain, addr: alloy::primitives::Address) -> alloy::primitives::U256 {
+    chain
+        .get_account_properties(&B160::from_be_bytes(addr.into_array()))
+        .balance
+}
+
+fn tx_succeeded(output: &BlockOutput, idx: usize) -> bool {
+    output.tx_results[idx]
+        .as_ref()
+        .ok()
+        .map(|o| o.is_success())
+        .unwrap_or(false)
+}
+
+fn tx_failed(output: &BlockOutput, idx: usize) -> bool {
+    !tx_succeeded(output, idx)
+}
+
+#[test]
+fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
+    let mut chain = Chain::empty(None);
+
+    let sender = address!("1234567890123456789012345678901234567890");
+    let recipient = address!("2222567890123456789012345678901234567890");
+
+    // Sender has 1 wei, tries to send 2^256 wei.
+    let initial_sender = alloy::primitives::U256::from(1u64);
+    let value = alloy::primitives::U256::MAX;
+
+    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+
+    let tx = TransactionRequest {
+        chain_id: Some(37),
+        from: Some(sender),
+        to: Some(TxKind::Call(recipient)),
+        input: hex::decode("").unwrap().into(),
+        value: Some(value),
+        gas: Some(200_000),
+        // keep fees at 0 so we can assert balances are unchanged on failure
+        max_fee_per_gas: Some(0),
+        max_priority_fee_per_gas: Some(0),
+        nonce: Some(0),
+        ..TransactionRequest::default()
+    };
+
+    let encoded = rig::utils::encode_l1_tx(tx);
+    let output = chain.run_block(vec![encoded], None, None, None);
+
+    assert!(
+        tx_failed(&output, 0),
+        "tx must fail when msg.value > sender balance"
+    );
+
+    // Balances must be unchanged (no fees).
+    assert_eq!(
+        bal(&mut chain, sender),
+        initial_sender,
+        "sender balance must not change"
+    );
+    assert_eq!(
+        bal(&mut chain, recipient),
+        alloy::primitives::U256::ZERO,
+        "recipient must not receive value"
+    );
+}
+
+#[test]
+fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
+    let mut chain = Chain::empty(None);
+
+    let l2_base_token_address = address!("000000000000000000000000000000000000800a");
+    let sender = address!("1234567890123456789012345678901234567890");
+    let l1_receiver = address!("0987654321098765432109876543210987654321");
+
+    // Sender has 1 wei, tries to withdraw 2 eth.
+    let initial_sender = alloy::primitives::U256::from(1u64);
+    let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
+
+    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+
+    // withdraw(address) selector 0x51cff8d9
+    let mut calldata = Vec::new();
+    calldata.extend_from_slice(&hex::decode("51cff8d9").unwrap());
+    calldata.extend_from_slice(&[0u8; 12]);
+    calldata.extend_from_slice(l1_receiver.as_slice());
+
+    let tx = TransactionRequest {
+        chain_id: Some(37),
+        from: Some(sender),
+        to: Some(TxKind::Call(l2_base_token_address)),
+        input: calldata.into(),
+        value: Some(value),
+        gas: Some(200_000),
+        max_fee_per_gas: Some(0),
+        max_priority_fee_per_gas: Some(0),
+        nonce: Some(0),
+        ..TransactionRequest::default()
+    };
+
+    let encoded = rig::utils::encode_l1_tx(tx);
+    let output = chain.run_block(vec![encoded], None, None, None);
+
+    assert!(
+        tx_failed(&output, 0),
+        "withdraw must fail when msg.value > sender balance"
+    );
+
+    // Balances unchanged
+    assert_eq!(
+        bal(&mut chain, sender),
+        initial_sender,
+        "sender balance must not change"
+    );
+
+    // No Withdrawal event must be emitted.
+    sol! {
+        event Withdrawal(address indexed _l2Sender, address indexed _l1Receiver, uint256 _amount);
+    }
+    let any_withdrawal = output.tx_results[0]
+        .as_ref()
+        .ok()
+        .map(|r| {
+            r.logs.iter().any(|ev| {
+                ev.address == l2_base_token_address && Withdrawal::decode_log_data(ev).is_ok()
+            })
+        })
+        .unwrap_or(false);
+
+    assert!(
+        !any_withdrawal,
+        "Withdrawal event must not be emitted on insufficient funds"
+    );
+}
+
+#[test]
+fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
+    let mut chain = Chain::empty(None);
+
+    let l2_base_token_address = address!("000000000000000000000000000000000000800a");
+    let sender = address!("1234567890123456789012345678901234567890");
+    let l1_receiver = address!("0987654321098765432109876543210987654321");
+    let additional_data = b"test message data";
+
+    // Sender has 1 wei, tries to withdrawWithMessage 2 eth.
+    let initial_sender = alloy::primitives::U256::from(1u64);
+    let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
+
+    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+
+    // withdrawWithMessage(address,bytes) selector 0x84bc3eb0
+    let mut calldata = Vec::new();
+    calldata.extend_from_slice(&hex::decode("84bc3eb0").unwrap());
+    calldata.extend_from_slice(&[0u8; 12]);
+    calldata.extend_from_slice(l1_receiver.as_slice());
+
+    // offset to bytes data (0x40)
+    calldata.extend_from_slice(&[0u8; 31]);
+    calldata.push(0x40);
+
+    // length
+    calldata.extend_from_slice(&[0u8; 31]);
+    calldata.push(additional_data.len() as u8);
+
+    // bytes data padded
+    calldata.extend_from_slice(additional_data);
+    let padding_needed = 32 - (additional_data.len() % 32);
+    if padding_needed != 32 {
+        calldata.extend_from_slice(&vec![0u8; padding_needed]);
+    }
+
+    let tx = TransactionRequest {
+        chain_id: Some(37),
+        from: Some(sender),
+        to: Some(TxKind::Call(l2_base_token_address)),
+        input: calldata.into(),
+        value: Some(value),
+        gas: Some(300_000),
+        max_fee_per_gas: Some(0),
+        max_priority_fee_per_gas: Some(0),
+        nonce: Some(0),
+        ..TransactionRequest::default()
+    };
+
+    let encoded = rig::utils::encode_l1_tx(tx);
+    let output = chain.run_block(vec![encoded], None, None, None);
+
+    assert!(
+        tx_failed(&output, 0),
+        "withdrawWithMessage must fail when msg.value > sender balance"
+    );
+
+    // Balances unchanged
+    assert_eq!(
+        bal(&mut chain, sender),
+        initial_sender,
+        "sender balance must not change"
+    );
+
+    // No WithdrawalWithMessage event must be emitted.
+    sol! {
+        event WithdrawalWithMessage(address indexed _l2Sender, address indexed _l1Receiver, uint256 _amount, bytes _additionalData);
+    }
+    let any_event = output.tx_results[0]
+        .as_ref()
+        .ok()
+        .map(|r| {
+            r.logs.iter().any(|ev| {
+                ev.address == l2_base_token_address
+                    && WithdrawalWithMessage::decode_log_data(ev).is_ok()
+            })
+        })
+        .unwrap_or(false);
+
+    assert!(
+        !any_event,
+        "WithdrawalWithMessage event must not be emitted on insufficient funds"
+    );
+}
+
+/// With sufficient existing L2 balance, an L1 tx with non-zero `value` should succeed and
+/// transfer funds to the recipient (spending from sender’s L2 balance).
+#[test]
+fn test_l1_value_transfer_spends_from_l2_balance() {
+    let mut chain = Chain::empty(None);
+
+    let sender = address!("1234567890123456789012345678901234567890");
+    let recipient = address!("2222567890123456789012345678901234567890");
+    let value = alloy::primitives::U256::from(1_000_000_000_000_000_000u64); // 1 ETH
+
+    // Fund sender so `msg.value` can be paid from L2 balance.
+    chain.set_balance(B160::from_be_bytes(sender.into_array()), value);
+
+    let tx = TransactionRequest {
+        chain_id: Some(37),
+        from: Some(sender),
+        to: Some(TxKind::Call(recipient)),
+        input: hex::decode("").unwrap().into(),
+        value: Some(value),
+        gas: Some(200_000),
+        // keep fees minimal to reduce side-effects
+        max_fee_per_gas: Some(0),
+        max_priority_fee_per_gas: Some(0),
+        nonce: Some(0),
+        ..TransactionRequest::default()
+    };
+
+    let encoded = rig::utils::encode_l1_tx(tx);
+    let output = chain.run_block(vec![encoded], None, None, None);
+
+    assert!(
+        tx_succeeded(&output, 0),
+        "tx must succeed with sufficient L2 balance"
+    );
+    assert_eq!(
+        bal(&mut chain, recipient),
+        value,
+        "recipient must receive msg.value"
+    );
+}
 
 #[test]
 fn test_set_bytecode_details_evm() {
@@ -577,6 +837,8 @@ fn test_l2_base_token_no_mint_event_regression() {
     let sender = address!("1234567890123456789012345678901234567890");
     let recipient = address!("2222567890123456789012345678901234567890");
     let mint_amount = alloy::primitives::U256::from(5000000000000000000u64); // 5 ETH
+
+    chain.set_balance(B160::from_be_bytes(sender.into_array()), mint_amount);
 
     // Prepare mint calldata - typically this would be called by the bootloader or bridge
     // For testing purposes, we'll simulate a mint by sending ETH value to the base token contract

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -179,6 +179,10 @@ fn run_base_system() {
         .set_balance(
             B160::from_be_bytes(eoa_wallet.address().0 .0),
             U256::from(1_000_000_000_000_000_u64),
+        ) // Set the balance for L1 -> L2 tx msg.value transfer
+        .set_balance(
+            B160::from_be_bytes(address!("1234000000000000000000000000000000000000").into()),
+            alloy::primitives::U256::from(100),
         );
 
     let output = chain.run_block(transactions, None, None, run_config());

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -1841,6 +1841,9 @@ fn test_treasury_based_token_distribution_regression() {
     let gas_limit = 100_000u64;
     let value_to_transfer = U256::from(1_000_000u64);
 
+    // Credit L1 sender with enough balance for the value transfer
+    chain.set_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
+
     let l1_tx = {
         let tx = TransactionRequest {
             chain_id: Some(37),
@@ -1904,10 +1907,9 @@ fn test_treasury_based_token_distribution_regression() {
     let total_to_operator = fee_paid_to_operator;
     let total_to_refund_recipient = refund_amount;
 
-    // Verify treasury balance decreased by total amount (fees + refund + value)
+    // Verify treasury balance decreased by max fee (fees + refund)
     let treasury_decrease = treasury_initial_balance - treasury_final_balance;
-    let expected_treasury_decrease =
-        total_to_operator + total_to_refund_recipient + value_to_transfer;
+    let expected_treasury_decrease = total_to_operator + total_to_refund_recipient;
     assert_eq!(
         treasury_decrease, expected_treasury_decrease,
         "Treasury should decrease by total operator payment plus refund and value transferred"

--- a/tests/instances/unit/src/validator/tx_validator_filtering.rs
+++ b/tests/instances/unit/src/validator/tx_validator_filtering.rs
@@ -234,6 +234,8 @@ fn test_l1_transactions_are_not_filtered_by_validator() {
         hex::decode("51cff8d9000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
             .unwrap();
 
+    chain.set_balance(B160::from_be_bytes(from.0 .0), U256::from(10_000_000));
+
     let mk_l1_tx = |nonce: u64, value: u64| {
         let tx = TransactionRequest {
             from: Some(from),


### PR DESCRIPTION
## What ❔

- Added `number_of_layer_2_txs` to the batch output/commitment 
    - It is needed for the Priority Mode, if it is activated smart contract will only accept batches with no L2 txs processed in the batch
- Changed the way L1 -> L2 transactions spends base tokens. Now they can spend base tokens from L2 balance, and not only the amount deposited from L1 in the same tx.
	- Previously, an L1 → L2 transaction minted `msg.value` before the call and minted the remaining deposited amount to the refund recipient after the call. The transaction then used that minted `msg.value` during execution.
	- Now, an L1 → L2 transaction mints the deposited amount minus the required fee. The `msg.value` can be set arbitrarily by the requester on L1. If it exceeds the account’s balance, the transaction fails and the deposited amount is credited to the refund recipient.

## Why ❔

- These are two features required for the Stage 1. 

## Is this a breaking change?
- [x] Yes
- [ ] No

## Other PRs

- https://github.com/matter-labs/era-contracts/pull/1943
- https://github.com/zksync-association/zk-governance/pull/32

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.