### PR TITLE
feat!: ignore priority fee when base fee is 0

### DIFF
--- a/basic_bootloader/src/bootloader/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/process_transaction.rs
@@ -981,19 +981,24 @@ where
         max_priority_fee_per_gas: Option<&U256>,
     ) -> Result<U256, TxError> {
         let base_fee = system.get_eip1559_basefee();
-        let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or(max_fee_per_gas);
-        require!(
-            max_priority_fee_per_gas <= max_fee_per_gas,
-            TxError::Validation(InvalidTransaction::PriorityFeeGreaterThanMaxFee,),
-            system
-        )?;
-        require!(
-            &base_fee <= max_fee_per_gas,
-            TxError::Validation(InvalidTransaction::BaseFeeGreaterThanMaxFee,),
-            system
-        )?;
-        let priority_fee_per_gas = (*max_priority_fee_per_gas).min(max_fee_per_gas - base_fee);
-        Ok(base_fee + priority_fee_per_gas)
+        if base_fee.is_zero() {
+            // If base fee is zero, then we ignore priority fee
+            Ok(U256::ZERO)
+        } else {
+            let max_priority_fee_per_gas = max_priority_fee_per_gas.unwrap_or(max_fee_per_gas);
+            require!(
+                max_priority_fee_per_gas <= max_fee_per_gas,
+                TxError::Validation(InvalidTransaction::PriorityFeeGreaterThanMaxFee,),
+                system
+            )?;
+            require!(
+                &base_fee <= max_fee_per_gas,
+                TxError::Validation(InvalidTransaction::BaseFeeGreaterThanMaxFee,),
+                system
+            )?;
+            let priority_fee_per_gas = (*max_priority_fee_per_gas).min(max_fee_per_gas - base_fee);
+            Ok(base_fee + priority_fee_per_gas)
+        }
     }
 
     // Returns (refund_info, total_pubdata_used)

--- a/docs/execution_environments/evm.md
+++ b/docs/execution_environments/evm.md
@@ -11,3 +11,4 @@ The EVM version we support currently is Cancun.
 - Deployment doesn’t fail if the storage for the deployed address is already used (when nonce is 0 and code is empty).
 - We use the L2Tx type to encode transactions, which encodes nonces as u32. This means that, in practice, violate EIP 2681, even if ZKsync OS internally doesn’t.
 - DIFFICULTY is mocked (returns 0), we don’t plan to support it
+- When the block base fee is 0, then priority fee from transactions is ignored. That is, the gas price will also be 0 for every transaction.

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -196,13 +196,23 @@ fn test_block_of_erc20() {
 }
 
 #[test]
-fn test_gas_price_zero() {
+fn test_gas_price_zero_fee_zero() {
     let mut chain = Chain::empty_randomized(None);
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
     };
-    run_block_of_erc20(&mut chain, 10, Some(block_context));
+    run_block_of_erc20_with_fee(&mut chain, 10, Some(block_context), 0);
+}
+
+#[test]
+fn test_gas_price_zero_fee_one() {
+    let mut chain = Chain::empty_randomized(None);
+    let block_context = BlockContext {
+        eip1559_basefee: U256::ZERO,
+        ..BlockContext::default()
+    };
+    run_block_of_erc20_with_fee(&mut chain, 10, Some(block_context), 1);
 }
 
 #[test]

--- a/tests/rig/src/utils.rs
+++ b/tests/rig/src/utils.rs
@@ -189,6 +189,15 @@ pub fn run_block_of_erc20<const RANDOMIZED: bool>(
     n: usize,
     block_context: Option<BlockContext>,
 ) -> BlockOutput {
+    run_block_of_erc20_with_fee(chain, n, block_context, 1000)
+}
+
+pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
+    chain: &mut Chain<RANDOMIZED>,
+    n: usize,
+    block_context: Option<BlockContext>,
+    fee: u128,
+) -> BlockOutput {
     let wallets: Vec<_> = (1..=n).map(|_| PrivateKeySigner::random()).collect();
     let dsts: Vec<_> = (1..=n)
         .map(|i| {
@@ -199,15 +208,8 @@ pub fn run_block_of_erc20<const RANDOMIZED: bool>(
         })
         .collect();
 
-    // If base fee is zero, we can avoid paying priority fee.
-    let max_priority_fee_per_gas = if block_context
-        .as_ref()
-        .is_some_and(|bc| bc.eip1559_basefee.is_zero())
-    {
-        0
-    } else {
-        1000
-    };
+    let max_fee_per_gas = fee;
+    let max_priority_fee_per_gas = fee;
 
     let transactions: Vec<_> = wallets
         .iter()
@@ -216,7 +218,7 @@ pub fn run_block_of_erc20<const RANDOMIZED: bool>(
             let transfer_tx = TxEip1559 {
                 chain_id: 37u64,
                 nonce: 0,
-                max_fee_per_gas: 1000,
+                max_fee_per_gas,
                 max_priority_fee_per_gas,
                 gas_limit: 60_000,
                 to: TxKind::Call(to),

--- a/tests/rig/src/utils.rs
+++ b/tests/rig/src/utils.rs
@@ -322,9 +322,10 @@ pub fn calldata_for_forwarder(target: alloy::primitives::Address, input: &[u8]) 
 /// * `[u8; 32]` - The versioned hash of the blob
 pub fn get_alloy_4844_blob_versioned_hash(data: &[u8]) -> [u8; 32] {
     // Create a blob sidecar using Alloy's SimpleCoder (handles encoding internally)
-    let blob_sidecar = SidecarBuilder::<SimpleCoder>::from_slice(data)
-        .build()
-        .unwrap();
+    let blob_sidecar: alloy::consensus::BlobTransactionSidecar =
+        SidecarBuilder::<SimpleCoder>::from_slice(data)
+            .build()
+            .unwrap();
 
     // Extract the versioned hash - there should be exactly one for single blob
     let mut alloy_hashes_iter = blob_sidecar.versioned_hashes();


### PR DESCRIPTION
## What ❔

When base fee for a block is set to 0, ignore the priority fee. That means that the gas price for every transaction will be 0 if the base fee is 0.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Otherwise, the native per gas computation can be thrown off by very small priority fees, making the native and gas consumption huge.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.