### PR TITLE
fix: use validation gas as minimal gas used for l1 tx processing

### DIFF
--- a/basic_bootloader/src/bootloader/transaction/access_list.rs
+++ b/basic_bootloader/src/bootloader/transaction/access_list.rs
@@ -35,9 +35,11 @@ where
                     <<S::Resources as Resources>::Native as zk_ee::system::Computational>::from_computational(crate::bootloader::constants::PER_ADDRESS_ACCESS_LIST_NATIVE_COST)
                 )
             )?;
-            system
-                .io
-                .touch_account(ExecutionEnvironmentType::NoEE, resources, &address)?;
+            resources.with_infinite_ergs(|resources| {
+                system
+                    .io
+                    .touch_account(ExecutionEnvironmentType::NoEE, resources, &address)
+            })?;
             for key in slots_list.iter() {
                 // per-slot charge
                 resources.charge(&S::Resources::from_ergs_and_native(
@@ -46,14 +48,14 @@ where
                     )
                 )?;
                 let key = key?;
-                // We charged already, so we use infinite resources
-                let mut inf_resources = S::Resources::FORMAL_INFINITE;
-                system.io.storage_touch(
-                    ExecutionEnvironmentType::NoEE,
-                    &mut inf_resources,
-                    &address,
-                    &Bytes32::from_array(*key),
-                )?;
+                resources.with_infinite_ergs(|resources| {
+                    system.io.storage_touch(
+                        ExecutionEnvironmentType::NoEE,
+                        resources,
+                        &address,
+                        &Bytes32::from_array(*key),
+                    )
+                })?;
             }
         }
     }

--- a/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
@@ -139,7 +139,11 @@ where
             InvalidTransaction::OutOfGasDuringValidation,
         ))
     } else {
-        let gas_limit_for_tx = gas_limit - intrinsic_overhead;
+        let gas_limit_for_tx = gas_limit
+            .checked_sub(intrinsic_overhead)
+            .ok_or(internal_error!(
+                "L1 should check that gas limit covers intrinsic cost"
+            ))?;
         let ergs = gas_limit_for_tx.saturating_mul(ERGS_PER_GAS); // we checked at the very start that gas_limit * ERGS_PER_GAS doesn't overflow
         let main_resources = S::Resources::from_ergs_and_native(Ergs(ergs), native_limit);
 

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -100,7 +100,7 @@ where
 
     let native_prepaid_from_gas = native_per_gas.saturating_mul(gas_limit);
 
-    let (calldata_tokens, _minimal_gas_used) =
+    let (calldata_tokens, minimal_gas_used) =
         compute_calldata_tokens(system, gas_limit, transaction.calldata())?;
 
     let ResourcesForTx {
@@ -254,7 +254,7 @@ where
         system,
         to_charge_for_pubdata,
         gas_limit,
-        0, //minimal_gas_used
+        minimal_gas_used,
         native_per_gas,
         &mut resources,
     )?;

--- a/tests/instances/transactions/src/native_charging.rs
+++ b/tests/instances/transactions/src/native_charging.rs
@@ -203,10 +203,10 @@ fn test_l2_tx_high_ratio() {
     run_tx(tx, gas_price, native_price, true, false)
 }
 
-// Test with 0 gas limit, both l1 and l2 txs.
+// Test with 0 gas limit on l2 txs.
 // Also call as simulation to skip validation step.
 #[test]
-fn test_0_gas_limit() {
+fn test_0_gas_limit_l2_tx() {
     let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
     let native_price = 10;
     let gas_price = native_price * AVG_RATIO;
@@ -226,7 +226,17 @@ fn test_0_gas_limit() {
     };
     run_tx(tx.clone(), gas_price, native_price, false, false);
     run_tx(tx, gas_price, native_price, false, true);
+}
 
+// Test with 0 gas limit on l1 txs, should fail,
+// as L1 must check that gas limit covers intrinsic costs.
+// Also call as simulation to skip validation step.
+#[test]
+#[should_panic]
+fn test_0_gas_limit_l1_tx() {
+    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let native_price = 10;
+    let gas_price = native_price * AVG_RATIO;
     let tx = {
         let tx = TransactionRequest {
             chain_id: Some(37),


### PR DESCRIPTION
## What ❔
We were using 0, but it's better to used minimal_gas_used for future EVM compatibility
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.