### PR TITLE
fix!: handle validation errors for l1 transactions

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/ethereum/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/ethereum/mod.rs
@@ -223,7 +223,7 @@ where
         _is_priority_op: bool,
         _tracer: &mut impl Tracer<S>,
         _validator: &mut impl TxValidator<S>,
-    ) -> Result<Self::ExecutionResult<'a>, TxError>
+    ) -> Result<Self::ExecutionResult<'a>, BootloaderSubsystemError>
     where
         S: 'a,
     {

--- a/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
@@ -40,7 +40,11 @@ impl<S: EthereumLikeTypes> core::fmt::Debug for ResourcesForTx<S> {
 ///
 /// Create initial resources for a transaction.
 ///
+/// IMPORTANT: if [is_l1_tx], then this function cannot fail
+/// with a validation error. Instead, saturating arithmetic
+/// should be applied.
 pub fn create_resources_for_tx<S: EthereumLikeTypes>(
+    system: &mut System<S>,
     gas_limit: u64,
     free_native: bool,
     native_prepaid_from_gas: u64,
@@ -139,7 +143,20 @@ where
             InvalidTransaction::OutOfGasDuringValidation,
         ))
     } else {
-        let gas_limit_for_tx = gas_limit - intrinsic_overhead;
+        // If an L1 transaction's gas limit doesn't cover the intrinsic gas,
+        // we just apply saturated arithmetic.
+        // L1 contracts enforce the gas limit to be >= the intrinsic cost, but
+        // if the L1 contracts are outdated and use a wrong constant for intrinsic
+        // gas, it's better to allow L1 transaction to go through rather than fail.
+        let gas_limit_for_tx = gas_limit
+            .checked_sub(intrinsic_overhead)
+            .unwrap_or_else(|| {
+                system_log!(
+                    system,
+                    "Gas limit < intrinsic gas for L1 tx, proceeding anyways"
+                );
+                0
+            });
         let ergs = gas_limit_for_tx.saturating_mul(ERGS_PER_GAS); // we checked at the very start that gas_limit * ERGS_PER_GAS doesn't overflow
         let main_resources = S::Resources::from_ergs_and_native(Ergs(ergs), native_limit);
 

--- a/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
@@ -11,6 +11,157 @@ use zk_ee::system_log;
 
 use super::super::*;
 
+/// Policy trait for handling arithmetic validation errors during resource creation.
+///
+/// This trait allows L1 and L2 transactions to handle errors differently:
+/// - L1: Only returns internal errors (validation errors are logged and saturated)
+/// - L2: Returns both validation and internal errors
+pub trait ResourcesCreationErrorPolicy<S: EthereumLikeTypes> {
+    /// The return error type for create_resources_for_tx.
+    /// For L1: BootloaderSubsystemError (no validation errors possible)
+    /// For L2: TxError (both validation and internal errors)
+    type Error;
+
+    /// The error type that describes arithmetic validation failures.
+    /// For L1: a descriptive enum for logging
+    /// For L2: InvalidTransaction
+    type ArithmeticError;
+
+    /// Create an error for native limit underflow
+    fn native_underflow_error(operation: &'static str) -> Self::ArithmeticError;
+
+    /// Create an error for intrinsic gas exceeding gas limit
+    fn intrinsic_gas_overflow_error(
+        intrinsic_overhead: u64,
+        gas_limit: u64,
+    ) -> Self::ArithmeticError;
+
+    /// Handle an arithmetic validation error.
+    /// For L1: logs the error and returns Ok(saturated_value)
+    /// For L2: returns Err(Self::Error)
+    fn handle_arithmetic_error(
+        system: &mut System<S>,
+        error: Self::ArithmeticError,
+    ) -> Result<u64, Self::Error>;
+
+    /// Convert an internal error to the policy's error type
+    #[allow(dead_code)] // Reserved for future use if internal errors are added
+    fn from_internal_error(error: BootloaderSubsystemError) -> Self::Error;
+
+    /// Convert a validation error to the policy's error type.
+    /// For L1: should never be called (deployment checks don't apply)
+    /// For L2: wraps in TxError::Validation
+    fn from_validation_error(error: InvalidTransaction) -> Self::Error;
+}
+
+/// Arithmetic error descriptor for L1 transactions
+#[derive(Debug)]
+pub enum L1ArithmeticError {
+    /// Native limit underflow during an operation
+    NativeUnderflow { operation: &'static str },
+    /// Gas limit is less than intrinsic gas overhead
+    IntrinsicGasOverflow {
+        intrinsic_overhead: u64,
+        gas_limit: u64,
+    },
+}
+
+/// Resource creation policy for L1 transactions: log and saturate on errors
+pub struct L1ResourcesPolicy;
+
+impl<S: EthereumLikeTypes> ResourcesCreationErrorPolicy<S> for L1ResourcesPolicy {
+    type Error = BootloaderSubsystemError;
+    type ArithmeticError = L1ArithmeticError;
+
+    fn native_underflow_error(operation: &'static str) -> Self::ArithmeticError {
+        L1ArithmeticError::NativeUnderflow { operation }
+    }
+
+    fn intrinsic_gas_overflow_error(
+        intrinsic_overhead: u64,
+        gas_limit: u64,
+    ) -> Self::ArithmeticError {
+        L1ArithmeticError::IntrinsicGasOverflow {
+            intrinsic_overhead,
+            gas_limit,
+        }
+    }
+
+    fn handle_arithmetic_error(
+        system: &mut System<S>,
+        error: Self::ArithmeticError,
+    ) -> Result<u64, Self::Error> {
+        match error {
+            L1ArithmeticError::NativeUnderflow { operation } => {
+                system_log!(
+                    system,
+                    "Native underflow during {}, saturating to 0 for L1 tx",
+                    operation
+                );
+                Ok(0)
+            }
+            L1ArithmeticError::IntrinsicGasOverflow {
+                intrinsic_overhead,
+                gas_limit,
+            } => {
+                system_log!(
+                    system,
+                    "Gas limit {} < intrinsic gas {} for L1 tx, saturating to 0",
+                    gas_limit,
+                    intrinsic_overhead
+                );
+                Ok(0)
+            }
+        }
+    }
+
+    fn from_internal_error(error: BootloaderSubsystemError) -> Self::Error {
+        error
+    }
+
+    fn from_validation_error(error: InvalidTransaction) -> Self::Error {
+        // L1 transactions never have deployment validation, so this should never be called
+        unreachable!(
+            "L1ResourcesPolicy should never encounter validation error: {:?}",
+            error
+        )
+    }
+}
+
+/// Resource creation policy for L2 transactions: fail on arithmetic errors
+pub struct L2ResourcesPolicy;
+
+impl<S: EthereumLikeTypes> ResourcesCreationErrorPolicy<S> for L2ResourcesPolicy {
+    type Error = TxError;
+    type ArithmeticError = InvalidTransaction;
+
+    fn native_underflow_error(_operation: &'static str) -> Self::ArithmeticError {
+        InvalidTransaction::OutOfNativeResourcesDuringValidation
+    }
+
+    fn intrinsic_gas_overflow_error(
+        _intrinsic_overhead: u64,
+        _gas_limit: u64,
+    ) -> Self::ArithmeticError {
+        InvalidTransaction::OutOfGasDuringValidation
+    }
+
+    fn handle_arithmetic_error(
+        _system: &mut System<S>,
+        error: Self::ArithmeticError,
+    ) -> Result<u64, Self::Error> {
+        Err(TxError::Validation(error))
+    }
+
+    fn from_internal_error(error: BootloaderSubsystemError) -> Self::Error {
+        TxError::Internal(error)
+    }
+
+    fn from_validation_error(error: InvalidTransaction) -> Self::Error {
+        TxError::Validation(error)
+    }
+}
+
 pub struct ResourcesForTx<S: EthereumLikeTypes> {
     // Resources to run the transaction.
     // These will be capped to MAX_NATIVE_COMPUTATIONAL, to prevent
@@ -40,10 +191,12 @@ impl<S: EthereumLikeTypes> core::fmt::Debug for ResourcesForTx<S> {
 ///
 /// Create initial resources for a transaction.
 ///
-/// IMPORTANT: if [is_l1_tx], then this function cannot fail
-/// with a validation error. Instead, saturating arithmetic
-/// should be applied.
-pub fn create_resources_for_tx<S: EthereumLikeTypes>(
+/// The `P` parameter controls how arithmetic validation errors are handled:
+/// - Use `L1ResourcesPolicy` for L1 transactions: logs and saturates (never fails validation)
+///   Returns `Result<..., BootloaderSubsystemError>` - validation errors are impossible
+/// - Use `L2ResourcesPolicy` for L2 transactions: returns validation errors
+///   Returns `Result<..., TxError>` - can fail with validation or internal errors
+pub fn create_resources_for_tx<S: EthereumLikeTypes, P: ResourcesCreationErrorPolicy<S>>(
     system: &mut System<S>,
     gas_limit: u64,
     free_native: bool,
@@ -55,8 +208,7 @@ pub fn create_resources_for_tx<S: EthereumLikeTypes>(
     intrinsic_gas: u64,
     intrinsic_pubdata: u64,
     intrinsic_native: u64,
-    is_l1_tx: bool,
-) -> Result<ResourcesForTx<S>, TxError>
+) -> Result<ResourcesForTx<S>, P::Error>
 where
     S::Metadata: ZkSpecificPricingMetadata,
 {
@@ -76,12 +228,13 @@ where
 
     // Charge pubdata overhead
     let intrinsic_pubdata_overhead = native_per_pubdata_byte.saturating_mul(intrinsic_pubdata);
-    let native_limit = native_limit
-        .checked_sub(intrinsic_pubdata_overhead)
-        .or(if is_l1_tx { Some(0) } else { None })
-        .ok_or(TxError::Validation(
-            InvalidTransaction::OutOfNativeResourcesDuringValidation,
-        ))?;
+    let native_limit = match native_limit.checked_sub(intrinsic_pubdata_overhead) {
+        Some(val) => val,
+        None => P::handle_arithmetic_error(
+            system,
+            P::native_underflow_error("subtracting pubdata overhead"),
+        )?,
+    };
 
     // EVM tester requires high native limits, so for it we never hold off resources.
     // But for the real world, we bound the available resources.
@@ -109,12 +262,13 @@ where
         .saturating_mul(evm_interpreter::native_resource_constants::COPY_BYTE_NATIVE_COST);
     let intrinsic_computational_native_charged = calldata_native.saturating_add(intrinsic_native);
 
-    let native_limit = native_limit
-        .checked_sub(intrinsic_computational_native_charged)
-        .or(if is_l1_tx { Some(0) } else { None })
-        .ok_or(TxError::Validation(
-            InvalidTransaction::OutOfNativeResourcesDuringValidation,
-        ))?;
+    let native_limit = match native_limit.checked_sub(intrinsic_computational_native_charged) {
+        Some(val) => val,
+        None => P::handle_arithmetic_error(
+            system,
+            P::native_underflow_error("subtracting intrinsic computational native"),
+        )?,
+    };
 
     let native_limit =
         <<S as zk_ee::system::SystemTypes>::Resources as Resources>::Native::from_computational(
@@ -126,7 +280,7 @@ where
 
     if is_deployment {
         if calldata_len > MAX_INITCODE_SIZE as u64 {
-            return Err(TxError::Validation(
+            return Err(P::from_validation_error(
                 InvalidTransaction::CreateInitCodeSizeLimit,
             ));
         }
@@ -138,34 +292,23 @@ where
     intrinsic_overhead =
         intrinsic_overhead.saturating_add(calldata_tokens.saturating_mul(CALLDATA_TOKEN_GAS_COST));
 
-    if intrinsic_overhead > gas_limit && !is_l1_tx {
-        Err(TxError::Validation(
-            InvalidTransaction::OutOfGasDuringValidation,
-        ))
-    } else {
-        // If an L1 transaction's gas limit doesn't cover the intrinsic gas,
-        // we just apply saturated arithmetic.
-        // L1 contracts enforce the gas limit to be >= the intrinsic cost, but
-        // if the L1 contracts are outdated and use a wrong constant for intrinsic
-        // gas, it's better to allow L1 transaction to go through rather than fail.
-        let gas_limit_for_tx = gas_limit
-            .checked_sub(intrinsic_overhead)
-            .unwrap_or_else(|| {
-                system_log!(
-                    system,
-                    "Gas limit < intrinsic gas for L1 tx, proceeding anyways"
-                );
-                0
-            });
-        let ergs = gas_limit_for_tx.saturating_mul(ERGS_PER_GAS); // we checked at the very start that gas_limit * ERGS_PER_GAS doesn't overflow
-        let main_resources = S::Resources::from_ergs_and_native(Ergs(ergs), native_limit);
+    // Check if intrinsic gas exceeds gas limit
+    let gas_limit_for_tx = match gas_limit.checked_sub(intrinsic_overhead) {
+        Some(val) => val,
+        None => P::handle_arithmetic_error(
+            system,
+            P::intrinsic_gas_overflow_error(intrinsic_overhead, gas_limit),
+        )?,
+    };
 
-        Ok(ResourcesForTx {
-            main_resources,
-            withheld,
-            intrinsic_computational_native_charged,
-        })
-    }
+    let ergs = gas_limit_for_tx.saturating_mul(ERGS_PER_GAS); // we checked at the very start that gas_limit * ERGS_PER_GAS doesn't overflow
+    let main_resources = S::Resources::from_ergs_and_native(Ergs(ergs), native_limit);
+
+    Ok(ResourcesForTx {
+        main_resources,
+        withheld,
+        intrinsic_computational_native_charged,
+    })
 }
 
 ///

--- a/basic_bootloader/src/bootloader/transaction_flow/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/mod.rs
@@ -198,7 +198,7 @@ where
         is_priority_op: bool,
         tracer: &mut impl Tracer<S>,
         validator: &mut impl TxValidator<S>,
-    ) -> Result<Self::ExecutionResult<'a>, TxError>
+    ) -> Result<Self::ExecutionResult<'a>, BootloaderSubsystemError>
     where
         S: 'a;
 }

--- a/basic_bootloader/src/bootloader/transaction_flow/process_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/process_transaction.rs
@@ -29,7 +29,7 @@ where
                     if !is_first_tx {
                         Err(TxError::Validation(InvalidTransaction::UpgradeTxNotFirst))
                     } else {
-                        F::process_l1_transaction::<Config>(
+                        let r = F::process_l1_transaction::<Config>(
                             system,
                             system_functions,
                             memories,
@@ -37,10 +37,11 @@ where
                             false,
                             tracer,
                             validator,
-                        )
+                        )?;
+                        Ok(r)
                     }
                 } else if transaction.is_l1_l2() {
-                    F::process_l1_transaction::<Config>(
+                    let r = F::process_l1_transaction::<Config>(
                         system,
                         system_functions,
                         memories,
@@ -48,7 +49,8 @@ where
                         true,
                         tracer,
                         validator,
-                    )
+                    )?;
+                    Ok(r)
                 } else {
                     Self::process_l2_transaction::<Config>(
                         system,

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
@@ -586,7 +586,7 @@ where
         is_priority_op: bool,
         tracer: &mut impl Tracer<S>,
         validator: &mut impl TxValidator<S>,
-    ) -> Result<Self::ExecutionResult<'a>, TxError>
+    ) -> Result<Self::ExecutionResult<'a>, BootloaderSubsystemError>
     where
         S: 'a,
     {

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -100,7 +100,7 @@ where
 
     let native_prepaid_from_gas = native_per_gas.saturating_mul(gas_limit);
 
-    let (calldata_tokens, _minimal_gas_used) =
+    let (calldata_tokens, minimal_gas_used) =
         compute_calldata_tokens(system, gas_limit, transaction.calldata())?;
 
     let ResourcesForTx {
@@ -254,7 +254,7 @@ where
         system,
         to_charge_for_pubdata,
         gas_limit,
-        0, //minimal_gas_used
+        minimal_gas_used,
         native_per_gas,
         &mut resources,
     )?;

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -1,7 +1,7 @@
 use crate::bootloader::config::BasicBootloaderExecutionConfig;
 use crate::bootloader::constants::{
-    L1_TX_INTRINSIC_L2_GAS, L1_TX_INTRINSIC_NATIVE_COST, L1_TX_INTRINSIC_PUBDATA,
-    L1_TX_NATIVE_PRICE, UPGRADE_TX_NATIVE_PER_GAS,
+    L1_TX_INTRINSIC_NATIVE_COST, L1_TX_INTRINSIC_PUBDATA, L1_TX_NATIVE_PRICE,
+    UPGRADE_TX_NATIVE_PER_GAS,
 };
 use crate::bootloader::errors::BootloaderInterfaceError;
 use crate::bootloader::errors::TxError;
@@ -13,7 +13,6 @@ use crate::bootloader::transaction_flow::gas_helpers::{
 };
 use crate::bootloader::transaction_flow::refund_calculation::{compute_gas_refund, RefundInfo};
 use crate::bootloader::transaction_flow::{ExecutionOutput, ExecutionResult};
-use crate::bootloader::InvalidTransaction;
 use crate::bootloader::{BasicBootloader, BootloaderSubsystemError};
 use crate::require_internal;
 use arrayvec::ArrayVec;
@@ -54,7 +53,7 @@ pub(crate) fn process_l1_transaction<
     is_priority_op: bool,
     tracer: &mut impl Tracer<S>,
     validator: &mut impl TxValidator<S>,
-) -> Result<ZkTxResult<'a>, TxError>
+) -> Result<ZkTxResult<'a>, BootloaderSubsystemError>
 where
     S::IO: IOSubsystemExt,
     S::Metadata: ZkSpecificPricingMetadata
@@ -76,50 +75,30 @@ where
     // will be refunded to the user.
     let gas_per_pubdata = transaction.gas_per_pubdata_limit.read();
 
-    // For L1->L2 txs, we use a constant native price to avoid censorship.
-    let native_price = L1_TX_NATIVE_PRICE;
-    let native_per_gas = if is_priority_op {
-        if Config::SIMULATION && gas_price.is_zero() {
-            // For simulation, if gas price isn't set, we use base fee
-            // for native calculation
-            u256_try_to_u64(&system.get_eip1559_basefee().div_ceil(native_price)).ok_or(
-                TxError::Validation(InvalidTransaction::NativeResourcesAreTooExpensive),
-            )?
-        } else {
-            u256_try_to_u64(&gas_price.div_ceil(native_price)).ok_or(TxError::Validation(
-                InvalidTransaction::NativeResourcesAreTooExpensive,
-            ))?
-        }
-    } else {
-        UPGRADE_TX_NATIVE_PER_GAS
-    };
-
-    let native_per_pubdata = (gas_per_pubdata as u64)
-        .checked_mul(native_per_gas)
-        .ok_or(TxError::Validation(InvalidTransaction::PubdataPriceTooHigh))?;
-
-    let native_prepaid_from_gas = native_per_gas.saturating_mul(gas_limit);
-
-    let (calldata_tokens, minimal_gas_used) =
-        compute_calldata_tokens(system, gas_limit, transaction.calldata())?;
-
-    let ResourcesForTx {
-        main_resources: mut resources,
-        withheld: withheld_resources,
-        intrinsic_computational_native_charged,
-    } = create_resources_for_tx::<S>(
-        gas_limit,
-        native_per_gas == 0,
-        native_prepaid_from_gas,
+    // Compute resource and fee information, making sure we handle
+    // all possible validation errors carefully.
+    // L1 transactions cannot be invalidated. Therefore, the following
+    // function makes sure L1 transactions are processable even when
+    // some checks that should be performed by the L1 don't hold.
+    let ResourceAndFeeInfo {
+        resources:
+            ResourcesForTx {
+                main_resources: mut resources,
+                withheld: withheld_resources,
+                intrinsic_computational_native_charged,
+            },
+        native_per_gas,
         native_per_pubdata,
-        false, // is_deployment
-        transaction.calldata().len() as u64,
-        calldata_tokens,
-        L1_TX_INTRINSIC_L2_GAS,
-        L1_TX_INTRINSIC_PUBDATA,
-        L1_TX_INTRINSIC_NATIVE_COST,
-        true,
+        minimal_gas_used,
+    } = prepare_and_check_resources::<S, Config>(
+        system,
+        transaction,
+        is_priority_op,
+        gas_limit,
+        gas_price,
+        gas_per_pubdata,
     )?;
+
     // Just used for computing native used
     let initial_resources = resources.clone();
 
@@ -364,6 +343,115 @@ where
         native_used,
         pubdata_used: pubdata_used + L1_TX_INTRINSIC_PUBDATA,
         blob_gas_used: 0,
+    })
+}
+
+struct ResourceAndFeeInfo<S: EthereumLikeTypes> {
+    resources: ResourcesForTx<S>,
+    native_per_pubdata: u64,
+    native_per_gas: u64,
+    minimal_gas_used: u64,
+}
+
+///
+/// Compute and perform some checks on fee/resource parameters.
+/// This function handles cases that for L2 transactions would be
+/// validation errors, as "invalidating" an L1 transaction can halt
+/// the chain (due to the priority queue).
+/// Note that the "validation errors" are practically unreachable, as
+/// gas_limit, gas_price and gas_per_pubdata are either checked or set
+/// by the L1 contracts. We decide to handle these cases as a fallback in
+/// case the L1 contracts aren't properly updated to reflect a change in
+/// ZKsync OS.
+/// The approach is to use saturating arithmetic and emit a system
+/// log if this situation ever happens.
+///
+fn prepare_and_check_resources<
+    'a,
+    S: EthereumLikeTypes + 'a,
+    Config: BasicBootloaderExecutionConfig,
+>(
+    system: &mut System<S>,
+    transaction: &AbiEncodedTransaction<S::Allocator>,
+    is_priority_op: bool,
+    gas_limit: u64,
+    gas_price: U256,
+    gas_per_pubdata: u32,
+) -> Result<ResourceAndFeeInfo<S>, BootloaderSubsystemError>
+where
+    S::IO: IOSubsystemExt,
+    S::Metadata: ZkSpecificPricingMetadata
+        + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
+{
+    // For L1->L2 txs, we use a constant native price to avoid censorship.
+    let native_price = L1_TX_NATIVE_PRICE;
+    let native_per_gas = if is_priority_op {
+        if Config::SIMULATION && gas_price.is_zero() {
+            // For simulation, if gas price isn't set, we use base fee
+            // for native calculation
+            u256_try_to_u64(&system.get_eip1559_basefee().div_ceil(native_price))
+                .unwrap_or_else(|| {
+                    system_log!(
+                        system,
+                        "Native per gas calculation for L1 tx simulation overflows, using saturated arithmetic instead"
+                    );
+                    u64::MAX
+                })
+        } else {
+            u256_try_to_u64(&gas_price.div_ceil(native_price))
+                .unwrap_or_else(|| {
+                    system_log!(
+                        system,
+                        "Native per gas calculation for L1 tx overflows, using saturated arithmetic instead");
+                        u64::MAX
+                })
+        }
+    } else {
+        UPGRADE_TX_NATIVE_PER_GAS
+    };
+
+    let native_per_pubdata = (gas_per_pubdata as u64)
+        .checked_mul(native_per_gas)
+        .unwrap_or_else(|| {
+            system_log!(
+                system,
+                "Native per pubdata calculation for L1 tx overflows, using saturated arithmetic instead");
+                u64::MAX
+        });
+
+    let native_prepaid_from_gas = native_per_gas.saturating_mul(gas_limit);
+
+    let (calldata_tokens, minimal_gas_used) =
+        compute_calldata_tokens(system, transaction.calldata(), true);
+
+    let resources = match create_resources_for_tx::<S>(
+        system,
+        gas_limit,
+        native_per_gas == 0,
+        native_prepaid_from_gas,
+        native_per_pubdata,
+        false, // is_deployment
+        transaction.calldata().len() as u64,
+        calldata_tokens,
+        minimal_gas_used,
+        L1_TX_INTRINSIC_PUBDATA,
+        L1_TX_INTRINSIC_NATIVE_COST,
+        true,
+    ) {
+        Ok(r) => Ok(r),
+        Err(TxError::Internal(e)) => Err(e),
+        Err(TxError::Validation(e)) => {
+            // As documented in [create_resources_for_tx], this function cannot return
+            // a validation error for L1 transactions.
+            unreachable!("Resource creation cannot fail with a validation error for L1 transactions, but got {e:?}")
+        }
+    }?;
+
+    Ok(ResourceAndFeeInfo {
+        resources,
+        native_per_pubdata,
+        native_per_gas,
+        minimal_gas_used,
     })
 }
 

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -7,9 +7,9 @@ use crate::bootloader::errors::BootloaderInterfaceError;
 use crate::bootloader::errors::TxError;
 use crate::bootloader::runner::RunnerMemoryBuffers;
 use crate::bootloader::transaction::abi_encoded::AbiEncodedTransaction;
-use crate::bootloader::transaction_flow::gas_helpers::create_resources_for_tx;
 use crate::bootloader::transaction_flow::gas_helpers::{
-    check_enough_resources_for_pubdata, get_resources_to_charge_for_pubdata, ResourcesForTx,
+    check_enough_resources_for_pubdata, create_resources_for_tx,
+    get_resources_to_charge_for_pubdata, L1ResourcesPolicy, ResourcesForTx,
 };
 use crate::bootloader::transaction_flow::refund_calculation::{compute_gas_refund, RefundInfo};
 use crate::bootloader::transaction_flow::{ExecutionOutput, ExecutionResult};
@@ -124,7 +124,7 @@ where
             Err(e) => {
                 match e {
                     TxError::Internal(e) if !matches!(e.root_cause(), RootCause::Runtime(_)) => {
-                        return Err(e.into());
+                        return Err(e);
                     }
                     // Only way hashing of L1 tx can fail due to Validation or Runtime is
                     // due to running out of native.
@@ -204,7 +204,7 @@ where
                             S::Resources::empty(),
                         )
                     }
-                    _ => return Err(e.into()),
+                    _ => return Err(e),
                 }
             }
         }
@@ -421,10 +421,12 @@ where
 
     let native_prepaid_from_gas = native_per_gas.saturating_mul(gas_limit);
 
-    let (calldata_tokens, minimal_gas_used) =
+    let (calldata_tokens, intrinsic_cost) =
         compute_calldata_tokens(system, transaction.calldata(), true);
 
-    let resources = match create_resources_for_tx::<S>(
+    // With L1ResourcesPolicy, this returns Result<ResourcesForTx<S>, BootloaderSubsystemError>
+    // Validation errors are type-safe impossible - they're logged and saturated instead
+    let resources = create_resources_for_tx::<S, L1ResourcesPolicy>(
         system,
         gas_limit,
         native_per_gas == 0,
@@ -433,19 +435,14 @@ where
         false, // is_deployment
         transaction.calldata().len() as u64,
         calldata_tokens,
-        minimal_gas_used,
+        intrinsic_cost,
         L1_TX_INTRINSIC_PUBDATA,
         L1_TX_INTRINSIC_NATIVE_COST,
-        true,
-    ) {
-        Ok(r) => Ok(r),
-        Err(TxError::Internal(e)) => Err(e),
-        Err(TxError::Validation(e)) => {
-            // As documented in [create_resources_for_tx], this function cannot return
-            // a validation error for L1 transactions.
-            unreachable!("Resource creation cannot fail with a validation error for L1 transactions, but got {e:?}")
-        }
-    }?;
+    )?;
+
+    // L1 transactions might have a gas limit < intrinsic cost,
+    // so we pick the min as minimal_gas_used.
+    let minimal_gas_used = intrinsic_cost.min(gas_limit);
 
     Ok(ResourceAndFeeInfo {
         resources,

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
@@ -88,8 +88,13 @@ where
     }
 
     // EIP-7623
-    let (calldata_tokens, minimal_gas_used) =
-        compute_calldata_tokens(system, tx_gas_limit, calldata)?;
+    let (calldata_tokens, minimal_gas_used) = compute_calldata_tokens(system, calldata, false);
+    #[cfg(feature = "eip_7623")]
+    require!(
+        minimal_gas_used <= tx_gas_limit,
+        InvalidTransaction::EIP7623IntrinsicGasIsTooLow,
+        system
+    )?;
 
     let pubdata_price = system.get_pubdata_price();
     let native_price = system.get_native_price();
@@ -133,6 +138,7 @@ where
 
     // Now we will materialize resources, from which we will try to charge intrinsic cost on top
     let mut tx_resources = create_resources_for_tx::<S>(
+        system,
         tx_gas_limit,
         native_per_gas == 0,
         native_prepaid_from_gas,
@@ -437,31 +443,30 @@ where
 #[allow(unused_variables)]
 pub(crate) fn compute_calldata_tokens<S: SystemTypes>(
     system: &mut System<S>,
-    tx_gas_limit: u64,
     calldata: &[u8],
-) -> Result<(u64, u64), TxError> {
+    is_l1_tx: bool,
+) -> (u64, u64) {
     let zero_bytes = calldata.iter().filter(|byte| **byte == 0).count() as u64;
     let non_zero_bytes = (calldata.len() as u64) - zero_bytes;
     let zero_bytes_factor = zero_bytes.saturating_mul(CALLDATA_ZERO_BYTE_TOKEN_FACTOR);
     let non_zero_bytes_factor = non_zero_bytes.saturating_mul(CALLDATA_NON_ZERO_BYTE_TOKEN_FACTOR);
     let num_tokens = zero_bytes_factor.saturating_add(non_zero_bytes_factor);
+    let intrinsic_gas = if is_l1_tx {
+        L1_TX_INTRINSIC_L2_GAS
+    } else {
+        L2_TX_INTRINSIC_GAS
+    };
 
     #[cfg(feature = "eip_7623")]
     {
         let floor_tokens_gas_cost = num_tokens.saturating_mul(TOTAL_COST_FLOOR_PER_TOKEN);
-        let intrinsic_gas = (L2_TX_INTRINSIC_GAS).saturating_add(floor_tokens_gas_cost);
+        let intrinsic_gas = intrinsic_gas.saturating_add(floor_tokens_gas_cost);
 
-        require!(
-            intrinsic_gas <= tx_gas_limit,
-            InvalidTransaction::EIP7623IntrinsicGasIsTooLow,
-            system
-        )?;
-
-        Ok((num_tokens, intrinsic_gas))
+        (num_tokens, intrinsic_gas)
     }
 
     #[cfg(not(feature = "eip_7623"))]
     {
-        Ok((num_tokens, L2_TX_INTRINSIC_GAS))
+        (num_tokens, intrinsic_gas)
     }
 }

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
@@ -4,7 +4,9 @@ use crate::bootloader::errors::{InvalidTransaction, TxError};
 use crate::bootloader::transaction::access_list::parse_and_warm_up_access_list;
 use crate::bootloader::transaction::blobs::parse_blobs_list;
 use crate::bootloader::transaction::{charge_keccak, Transaction};
-use crate::bootloader::transaction_flow::gas_helpers::{create_resources_for_tx, get_gas_price};
+use crate::bootloader::transaction_flow::gas_helpers::{
+    create_resources_for_tx, get_gas_price, L2ResourcesPolicy,
+};
 use crate::bootloader::BasicBootloaderExecutionConfig;
 use crate::require;
 use basic_system::cost_constants::ECRECOVER_NATIVE_COST;
@@ -137,7 +139,7 @@ where
     let native_prepaid_from_gas = native_per_gas.saturating_mul(tx_gas_limit);
 
     // Now we will materialize resources, from which we will try to charge intrinsic cost on top
-    let mut tx_resources = create_resources_for_tx::<S>(
+    let mut tx_resources = create_resources_for_tx::<S, L2ResourcesPolicy>(
         system,
         tx_gas_limit,
         native_per_gas == 0,
@@ -149,7 +151,6 @@ where
         L2_TX_INTRINSIC_GAS,
         L2_TX_INTRINSIC_PUBDATA,
         L2_TX_INTRINSIC_NATIVE_COST,
-        false,
     )?;
 
     system_log!(

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -1,0 +1,143 @@
+//!
+//! Regression tests for L1 transaction processing resilience.
+//!
+//! These tests verify that L1 transactions are processed gracefully even when
+//! certain validation constraints are violated. This is important because
+//! L1 transactions cannot be invalidated (doing so would halt the chain due
+//! to the priority queue).
+//!
+//! The scenarios tested here would have caused validation errors prior to the
+//! resilience changes, but now use saturating arithmetic to allow processing
+//! to continue.
+//!
+
+use alloy::primitives::TxKind;
+use rig::alloy::primitives::address;
+use rig::alloy::rpc::types::TransactionRequest;
+use rig::ruint::aliases::{B160, U256};
+use rig::{alloy, Chain};
+
+fn run_config() -> Option<rig::chain::RunConfig> {
+    Some(rig::chain::RunConfig {
+        app: Some("for_tests".to_string()),
+        only_forward: false,
+        check_storage_diff_hashes: true,
+        ..Default::default()
+    })
+}
+
+/// Test that an L1 transaction with gas limit below intrinsic gas (21k) is
+/// processed gracefully instead of causing a validation error.
+///
+/// Prior to the resilience changes, this would fail with a validation error
+/// because gas_limit < intrinsic_gas. Now, saturating arithmetic is used
+/// and the transaction proceeds.
+#[test]
+fn test_l1_tx_gas_limit_below_intrinsic() {
+    let mut chain = Chain::empty(None);
+
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = address!("4242000000000000000000000000000000000000");
+
+    // Give the sender some balance
+    chain.set_balance(B160::from_be_bytes(from.into_array()), U256::from(u64::MAX));
+
+    // Create an L1 transaction with gas limit below intrinsic gas (21000)
+    // The intrinsic gas for L1 txs is L1_TX_INTRINSIC_L2_GAS = 21_000
+    let tx = {
+        let tx = TransactionRequest {
+            chain_id: Some(37),
+            from: Some(from),
+            to: Some(TxKind::Call(to)),
+            gas: Some(20_000), // Below 21k intrinsic gas
+            max_fee_per_gas: Some(1500),
+            max_priority_fee_per_gas: Some(1500),
+            value: Some(alloy::primitives::U256::from(100)),
+            nonce: Some(0),
+            ..TransactionRequest::default()
+        };
+        rig::utils::encode_l1_tx(tx)
+    };
+
+    // The block should complete without panicking (no internal error)
+    let result = chain.run_block_no_panic(vec![tx], None, None, run_config());
+    assert!(
+        result.is_ok(),
+        "Block should complete without internal error, got: {:?}",
+        result.err()
+    );
+
+    // The transaction should be processed (L1 txs cannot be invalidated)
+    let output = result.unwrap();
+    let tx_result = output.tx_results.first().expect("Should have tx result");
+    assert!(
+        tx_result.is_ok(),
+        "L1 tx should be processed (not rejected with validation error), got: {:?}",
+        tx_result
+    );
+
+    // The execution doesn't fail, as it doesn't consume non-intrinsic gas
+    let tx_output = tx_result.as_ref().unwrap();
+    assert!(tx_output.is_success(), "Transaction should succeed");
+}
+
+/// Test that an L1 transaction with a gas price that would overflow the
+/// native_per_gas calculation is processed gracefully.
+///
+/// The calculation is: native_per_gas = gas_price.div_ceil(L1_TX_NATIVE_PRICE)
+/// where L1_TX_NATIVE_PRICE = 10. To overflow u64, gas_price needs to be
+/// > u64::MAX * 10.
+///
+/// Prior to the resilience changes, this would fail with
+/// InvalidTransaction::NativeResourcesAreTooExpensive. Now, u64::MAX is used
+/// via saturating arithmetic.
+#[test]
+fn test_l1_tx_gas_price_overflow_native_per_gas() {
+    let mut chain = Chain::empty(None);
+
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = address!("4242000000000000000000000000000000000000");
+
+    // Give the sender a reasonable balance (not MAX to avoid overflow issues elsewhere)
+    chain.set_balance(
+        B160::from_be_bytes(from.into_array()),
+        U256::from(1_000_000_000_000_000_u64),
+    );
+
+    // L1_TX_NATIVE_PRICE = 10
+    // To overflow u64 in native_per_gas calculation: gas_price / 10 > u64::MAX
+    // So gas_price > u64::MAX * 10
+    let overflow_gas_price = u128::from(u64::MAX) * 11;
+
+    let tx = {
+        let tx = TransactionRequest {
+            chain_id: Some(37),
+            from: Some(from),
+            to: Some(TxKind::Call(to)),
+            gas: Some(100_000),
+            max_fee_per_gas: Some(overflow_gas_price),
+            max_priority_fee_per_gas: Some(overflow_gas_price),
+            value: Some(alloy::primitives::U256::from(100)),
+            nonce: Some(0),
+            ..TransactionRequest::default()
+        };
+        rig::utils::encode_l1_tx(tx)
+    };
+
+    // The block should complete without panicking (no internal error)
+    let result = chain.run_block_no_panic(vec![tx], None, None, run_config());
+    assert!(
+        result.is_ok(),
+        "Block should complete without internal error, got: {:?}",
+        result.err()
+    );
+
+    // The transaction should be processed (L1 txs cannot be invalidated)
+    let output = result.unwrap();
+    let tx_result = output.tx_results.first().expect("Should have tx result");
+    assert!(
+        tx_result.is_ok(),
+        "L1 tx should be processed (not rejected with validation error), got: {:?}",
+        tx_result
+    );
+}

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -15,6 +15,7 @@ use alloy::primitives::TxKind;
 use rig::alloy::primitives::address;
 use rig::alloy::rpc::types::TransactionRequest;
 use rig::ruint::aliases::{B160, U256};
+use rig::utils::encode_l1_tx;
 use rig::{alloy, Chain};
 
 fn run_config() -> Option<rig::chain::RunConfig> {
@@ -139,5 +140,46 @@ fn test_l1_tx_gas_price_overflow_native_per_gas() {
         tx_result.is_ok(),
         "L1 tx should be processed (not rejected with validation error), got: {:?}",
         tx_result
+    );
+}
+
+#[test]
+fn test_l1_tx_intrinsic_gas_overflow() {
+    let mut chain = Chain::empty(None);
+    let from_address = address!("1234000000000000000000000000000000000000");
+    let to_address = address!("4242000000000000000000000000000000000000");
+
+    // Create an L1 transaction that will cause gas overflow
+    // L1 transactions bypass the intrinsic gas check that would normally prevent this
+    let overflow_l1_tx = {
+        let tx = TransactionRequest {
+            chain_id: Some(37),
+            from: Some(from_address),
+            to: Some(TxKind::Call(to_address)),
+            gas: Some(200000), // Gas limit that should not be sufficient for the input data
+            max_fee_per_gas: Some(1000),
+            max_priority_fee_per_gas: Some(1000),
+            value: Some(alloy::primitives::U256::from(100)),
+            nonce: Some(0),
+            input: vec![0u8; 50_000].into(), // Very large input data to increase intrinsic cost
+            ..TransactionRequest::default()
+        };
+        encode_l1_tx(tx)
+    };
+
+    // Set up balances
+    chain.set_balance(
+        rig::ruint::aliases::B160::from_be_bytes(from_address.into_array()),
+        rig::ruint::aliases::U256::from(1_000_000_000_000_000_u64),
+    );
+    // Test L1 transaction - this triggers the overflow scenario
+    let result_l1 = chain.run_block(vec![overflow_l1_tx], None, None, None);
+
+    assert!(result_l1.tx_results[0].is_ok());
+
+    let res = result_l1.tx_results[0].as_ref().unwrap();
+    assert!(
+        res.is_success(),
+        "This L1 transaction with gas overflow should not be reverted"
     );
 }

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -19,6 +19,7 @@ use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_web3_rs::signers::{LocalWallet, Signer};
 
+mod l1_tx_resilience;
 mod native_charging;
 
 fn run_config() -> Option<rig::chain::RunConfig> {


### PR DESCRIPTION
## What ❔
Handle "validation errors" that should be already enforced by L1 contracts, as a fallback
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.