### PR TITLE
fix: add reduction to u512 montgomerry mul

### DIFF
--- a/crypto/src/bigint_delegation/mod.rs
+++ b/crypto/src/bigint_delegation/mod.rs
@@ -5,22 +5,18 @@ pub mod u256;
 pub mod u512;
 
 pub trait DelegatedModParams<const N: usize>: Default {
+    const MODULUS_BITSIZE: usize;
+
     /// Provides a reference to the modululs for delegation purposes
-    /// # Safety
-    /// The reference has to be to a value outside the ROM, i.e. a mutable static
-    unsafe fn modulus() -> &'static BigInt<N>;
+    fn modulus() -> &'static BigInt<N>;
 }
 
 pub trait DelegatedMontParams<const N: usize>: DelegatedModParams<N> {
     /// Provides a reference to the reduction const (`-1/Self::modulus mod 2^256`) for Montgomerry reduction
-    /// # Safety
-    /// The reference has to be to a value outside the ROM, i.e. a mutable static
-    unsafe fn reduction_const() -> &'static BigInt<4>;
+    fn reduction_const() -> &'static BigInt<4>;
 }
 
 pub trait DelegatedBarretParams<const N: usize>: DelegatedModParams<N> {
     /// Provides a reference to `-Self::modulus mod 2^256` for Barret reduction
-    /// # Safety
-    /// The reference has to be to a value outside the ROM, i.e. a mutable static
-    unsafe fn neg_modulus() -> &'static BigInt<4>;
+    fn neg_modulus() -> &'static BigInt<4>;
 }

--- a/crypto/src/bigint_delegation/u256.rs
+++ b/crypto/src/bigint_delegation/u256.rs
@@ -29,20 +29,20 @@ use std::cell::UnsafeCell;
 
 #[cfg(test)]
 thread_local! {
-    static SCRATCH_SPACE: UnsafeCell<ScratchSpace> = UnsafeCell::new(ScratchSpace {
+    static SCRATCH_SPACE: UnsafeCell<Box<ScratchSpace>> = UnsafeCell::new(Box::new(ScratchSpace {
         copy_place_0: U256::zero(),
         copy_place_1: U256::zero(),
         copy_place_2: U256::zero(),
         copy_place_3: U256::zero(),
         scratch: U256::zero(),
-    })
+    }))
 }
 
 #[cfg(test)]
 macro_rules! with_scratch {
     ($scratch:ident => $($body:tt)*) => {
         SCRATCH_SPACE.with(|cell| unsafe {
-            let $scratch = &mut *cell.get();
+            let $scratch = &mut **cell.get();
             $($body)*
         })
     };

--- a/crypto/src/bigint_delegation/u256.rs
+++ b/crypto/src/bigint_delegation/u256.rs
@@ -375,7 +375,9 @@ mod tests {
     struct ZeroMod;
 
     impl DelegatedModParams<4> for ZeroMod {
-        unsafe fn modulus() -> &'static BigInt<4> {
+        const MODULUS_BITSIZE: usize = 0;
+
+        fn modulus() -> &'static BigInt<4> {
             &ZERO
         }
     }

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -3,10 +3,7 @@ use super::{
     u256::{self, U256},
     DelegatedModParams, DelegatedMontParams,
 };
-use crate::{
-    ark_ff_delegation::{BigInt, BigInteger},
-    bigint_delegation::u256::sub_assign,
-};
+use crate::ark_ff_delegation::{BigInt, BigInteger};
 
 pub(super) type U512 = BigInt<8>;
 

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -356,11 +356,10 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
         // // Final reduction: result is in [0, 2*modulus). Subtract modulus if >= modulus.
         // // For BLS12-381, p ≈ 2^381 and R = 2^512, so the probability of a
         // // non-canonical result is p²/R / p ≈ 2^{-131}
-        // // so we check to avoid unnecessary delegation calls
-        // if carry || !u256::lt(a1, as_high(T::modulus())) {
-        //     sub_mod_with_carry::<T>(a, carry);
-        // }
-        sub_mod_with_carry::<T>(a, carry);
+        // so we check to avoid unnecessary delegation calls
+        if carry || !u256::lt(a1, as_high(T::modulus())) {
+            sub_mod_with_carry::<T>(a, carry);
+        }
 
         debug_assert!(a.0[6..8].iter().all(|&x| x == 0));
     })

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -353,13 +353,14 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
 
         let carry = u256::add_assign(a1, carry2);
 
-        // Final reduction: result is in [0, 2*modulus). Subtract modulus if >= modulus.
-        // For BLS12-381, p ≈ 2^381 and R = 2^512, so the probability of a
-        // non-canonical result is p²/R / p ≈ 2^{-131}
-        // so we check to avoid unnecessary delegation calls
-        if carry || !u256::lt(a1, as_high(T::modulus())) {
-            sub_mod_with_carry::<T>(a, carry);
-        }
+        // // Final reduction: result is in [0, 2*modulus). Subtract modulus if >= modulus.
+        // // For BLS12-381, p ≈ 2^381 and R = 2^512, so the probability of a
+        // // non-canonical result is p²/R / p ≈ 2^{-131}
+        // // so we check to avoid unnecessary delegation calls
+        // if carry || !u256::lt(a1, as_high(T::modulus())) {
+        //     sub_mod_with_carry::<T>(a, carry);
+        // }
+        sub_mod_with_carry::<T>(a, carry);
 
         debug_assert!(a.0[6..8].iter().all(|&x| x == 0));
     })

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -187,12 +187,14 @@ pub unsafe fn neg_mod_assign<T: DelegatedModParams<8>>(a: &mut U512) {
 /// Both `self` and `rhs` are assumed to be in montgomery form.
 /// The reduction constant is expected to be `-1/modulus mod 2^256`
 ///
-/// Note: as this is only used for bls12-381, we assume that modulus is
-/// strictly less than 512 bits
+/// Note: we assume that modulus is strictly less than 512 bits
 /// # Safety
 /// `DelegationMontParams` should only provide references to mutable statics.
 /// It is the responsibility of the caller to make sure that is the case
 pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: &U512) {
+    // otherwise we may get a carry in the final addition
+    assert!(T::MODULUS_BITSIZE < 512);
+
     with_scratch!(s => {
         let (r0, r1) = {
             let b0 = as_low(b);
@@ -354,8 +356,8 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
 
         let carry2 = new_carry_2;
 
-        // for bls12-381 we can't have a carry here
         let carry = u256::add_assign(a1, carry2);
+        // we can't have a carry since MODULUS_BITSIZE < 512
         debug_assert!(!carry);
 
         let borrow = u256::sub_assign(a0, as_low(T::modulus()));
@@ -404,7 +406,9 @@ mod tests {
     ]);
 
     impl DelegatedModParams<8> for TestMod {
-        unsafe fn modulus() -> &'static BigInt<8> {
+        const MODULUS_BITSIZE: usize = 381;
+
+        fn modulus() -> &'static BigInt<8> {
             &TEST_MODULUS
         }
     }

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -110,20 +110,6 @@ fn copy(dst: &mut U512, src: &U512) {
     delegation::memcpy(high_dst, as_high(src));
 }
 
-#[inline(always)]
-fn is_ge_modulus<T: DelegatedModParams<8>>(a: &U512) -> bool {
-    let m = unsafe { T::modulus() };
-    for i in (0..8).rev() {
-        if a.0[i] > m.0[i] {
-            return true;
-        }
-        if a.0[i] < m.0[i] {
-            return false;
-        }
-    }
-    true // equal
-}
-
 /// Tries to get `self` in the range `[0..modulus)`.
 /// Note: we assume `self < 2*modulus`, otherwise the result might not be in the range
 /// # Safety

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -110,6 +110,20 @@ fn copy(dst: &mut U512, src: &U512) {
     delegation::memcpy(high_dst, as_high(src));
 }
 
+#[inline(always)]
+fn is_ge_modulus<T: DelegatedModParams<8>>(a: &U512) -> bool {
+    let m = unsafe { T::modulus() };
+    for i in (0..8).rev() {
+        if a.0[i] > m.0[i] {
+            return true;
+        }
+        if a.0[i] < m.0[i] {
+            return false;
+        }
+    }
+    true // equal
+}
+
 /// Tries to get `self` in the range `[0..modulus)`.
 /// Note: we assume `self < 2*modulus`, otherwise the result might not be in the range
 /// # Safety
@@ -352,7 +366,14 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
         let carry2 = new_carry_2;
 
         let carry = u256::add_assign(a1, carry2);
-        sub_mod_with_carry::<T>(a, carry);
+
+        // Final reduction: result is in [0, 2*modulus). Subtract modulus if >= modulus.
+        // For BLS12-381, p ≈ 2^381 and R = 2^512, so the probability of a
+        // non-canonical result is p²/R / p ≈ 2^{-131}
+        // so we check to avoid unnecessary delegation calls
+        if carry || !u256::lt(a1, as_high(T::modulus())) {
+            sub_mod_with_carry::<T>(a, carry);
+        }
 
         debug_assert!(a.0[6..8].iter().all(|&x| x == 0));
     })

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -38,7 +38,7 @@ use std::cell::UnsafeCell;
 
 #[cfg(test)]
 thread_local! {
-    static SCRATCH_SPACE: UnsafeCell<ScratchSpace> = UnsafeCell::new(ScratchSpace {
+    static SCRATCH_SPACE: UnsafeCell<Box<ScratchSpace>> = UnsafeCell::new(Box::new(ScratchSpace {
         copy_place_0: U512::zero(),
         low_word_scratch: U256::zero(),
         mul_copy_place_0: U256::zero(),
@@ -47,14 +47,14 @@ thread_local! {
         mul_copy_place_3: U256::zero(),
         mul_copy_place_4: U256::zero(),
         mul_copy_place_5: U256::zero(),
-    })
+    }))
 }
 
 #[cfg(test)]
 macro_rules! with_scratch {
     ($scratch:ident => $($body:tt)*) => {
         SCRATCH_SPACE.with(|cell| unsafe {
-            let $scratch = &mut *cell.get();
+            let $scratch = &mut **cell.get();
             $($body)*
         })
     };
@@ -351,7 +351,8 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
 
         let carry2 = new_carry_2;
 
-        u256::add_assign(a1, carry2);
+        let carry = u256::add_assign(a1, carry2);
+        sub_mod_with_carry::<T>(a, carry);
 
         debug_assert!(a.0[6..8].iter().all(|&x| x == 0));
     })

--- a/crypto/src/bigint_delegation/u512.rs
+++ b/crypto/src/bigint_delegation/u512.rs
@@ -3,7 +3,10 @@ use super::{
     u256::{self, U256},
     DelegatedModParams, DelegatedMontParams,
 };
-use crate::ark_ff_delegation::{BigInt, BigInteger};
+use crate::{
+    ark_ff_delegation::{BigInt, BigInteger},
+    bigint_delegation::u256::sub_assign,
+};
 
 pub(super) type U512 = BigInt<8>;
 
@@ -186,6 +189,9 @@ pub unsafe fn neg_mod_assign<T: DelegatedModParams<8>>(a: &mut U512) {
 /// Compute `self = self * rhs mod modulus` using montgomery reduction.
 /// Both `self` and `rhs` are assumed to be in montgomery form.
 /// The reduction constant is expected to be `-1/modulus mod 2^256`
+///
+/// Note: as this is only used for bls12-381, we assume that modulus is
+/// strictly less than 512 bits
 /// # Safety
 /// `DelegationMontParams` should only provide references to mutable statics.
 /// It is the responsibility of the caller to make sure that is the case
@@ -351,14 +357,15 @@ pub unsafe fn mul_assign_montgomery<T: DelegatedMontParams<8>>(a: &mut U512, b: 
 
         let carry2 = new_carry_2;
 
+        // for bls12-381 we can't have a carry here
         let carry = u256::add_assign(a1, carry2);
+        debug_assert!(!carry);
 
-        // // Final reduction: result is in [0, 2*modulus). Subtract modulus if >= modulus.
-        // // For BLS12-381, p ≈ 2^381 and R = 2^512, so the probability of a
-        // // non-canonical result is p²/R / p ≈ 2^{-131}
-        // so we check to avoid unnecessary delegation calls
-        if carry || !u256::lt(a1, as_high(T::modulus())) {
-            sub_mod_with_carry::<T>(a, carry);
+        let borrow = u256::sub_assign(a0, as_low(T::modulus()));
+        let borrow = u256::sub_with_carry_bit(a1, as_high(T::modulus()), borrow);
+        if borrow {
+            let carry = u256::add_assign(a0, as_low(T::modulus()));
+            let _ = u256::add_with_carry_bit(a1, as_high(T::modulus()), carry);
         }
 
         debug_assert!(a.0[6..8].iter().all(|&x| x == 0));

--- a/crypto/src/bls12_381/fields/fq.rs
+++ b/crypto/src/bls12_381/fields/fq.rs
@@ -11,13 +11,15 @@ compile_error!("feature `bigint_ops` must be activated for RISC-V target");
 struct FqParams;
 
 impl DelegatedModParams<8> for FqParams {
-    unsafe fn modulus() -> &'static BigInt<8> {
+    const MODULUS_BITSIZE: usize = 381;
+
+    fn modulus() -> &'static BigInt<8> {
         &MODULUS_CONSTANT
     }
 }
 
 impl DelegatedMontParams<8> for FqParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &MONT_REDUCTION_CONSTANT
     }
 }

--- a/crypto/src/bls12_381/fields/fq.rs
+++ b/crypto/src/bls12_381/fields/fq.rs
@@ -441,8 +441,8 @@ mod test {
 
     #[test]
     fn test_montgomery_mul_requires_final_reduction_fq() {
-        use crate::bigint_delegation::u512;
         use super::FqParams;
+        use crate::bigint_delegation::u512;
         // Montgomery-form inputs chosen to force the raw Montgomery product
         // above the modulus if final reduction is omitted.
         let mut a = BigInt([

--- a/crypto/src/bls12_381/fields/fq.rs
+++ b/crypto/src/bls12_381/fields/fq.rs
@@ -438,6 +438,48 @@ mod test {
             assert!(gt.cyclotomic_exp(r).is_one());
         }
     }
+
+    #[test]
+    fn test_montgomery_mul_requires_final_reduction_fq() {
+        use crate::bigint_delegation::u512;
+        use super::FqParams;
+        // Montgomery-form inputs chosen to force the raw Montgomery product
+        // above the modulus if final reduction is omitted.
+        let mut a = BigInt([
+            13402431016077863594,
+            2210141511517208575,
+            7435674573564081700,
+            7239337960414712511,
+            5412103778470702295,
+            1873798617647539866,
+            0,
+            0,
+        ]); // p - 1 (valid Montgomery residue)
+
+        let b = BigInt([
+            2558544279233641998,
+            15670776001706131633,
+            16499115467214941661,
+            5658596800012892911,
+            5792713988013659675,
+            1672441503323099093,
+            0,
+            0,
+        ]);
+
+        assert!(a < super::MODULUS_CONSTANT);
+        assert!(b < super::MODULUS_CONSTANT);
+
+        unsafe {
+            u512::mul_assign_montgomery::<FqParams>(&mut a, &b);
+        }
+
+        assert!(
+            a < super::MODULUS_CONSTANT,
+            "non-reduced montgomery mul result: {:?}",
+            a
+        );
+    }
 }
 
 // Helper functions for EIP-2537 precompile serialization

--- a/crypto/src/bls12_381/fields/fr.rs
+++ b/crypto/src/bls12_381/fields/fr.rs
@@ -13,13 +13,15 @@ static MODULUS: BigInt<4> = FrConfig::MODULUS;
 pub struct FrParams;
 
 impl DelegatedModParams<4> for FrParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 255;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS
     }
 }
 
 impl DelegatedMontParams<4> for FrParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &MONT_REDUCTION_CONSTANT
     }
 }

--- a/crypto/src/bn254/fields/fq.rs
+++ b/crypto/src/bn254/fields/fq.rs
@@ -28,13 +28,15 @@ static MONT_REDUCTION_CONSTANT: B =
 struct FqParams;
 
 impl DelegatedModParams<4> for FqParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 254;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS_CONSTANT
     }
 }
 
 impl DelegatedMontParams<4> for FqParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &MONT_REDUCTION_CONSTANT
     }
 }

--- a/crypto/src/secp256k1/field/field_8x32.rs
+++ b/crypto/src/secp256k1/field/field_8x32.rs
@@ -14,13 +14,15 @@ static NEG_MODULUS: BigInt<4> = FieldElement8x32::NEG_MODULUS;
 pub(super) struct FieldParams;
 
 impl DelegatedModParams<4> for FieldParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 256;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS
     }
 }
 
 impl DelegatedBarretParams<4> for FieldParams {
-    unsafe fn neg_modulus() -> &'static BigInt<4> {
+    fn neg_modulus() -> &'static BigInt<4> {
         &NEG_MODULUS
     }
 }

--- a/crypto/src/secp256k1/scalars/scalar32_delegation.rs
+++ b/crypto/src/secp256k1/scalars/scalar32_delegation.rs
@@ -12,13 +12,15 @@ static REDUCTION_CONST: BigInt<4> = ScalarInner::REDUCTION_CONST.0;
 pub(super) struct ScalarParams;
 
 impl DelegatedModParams<4> for ScalarParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 256;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS
     }
 }
 
 impl DelegatedMontParams<4> for ScalarParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &REDUCTION_CONST
     }
 }

--- a/crypto/src/secp256r1/field/fe32_delegation.rs
+++ b/crypto/src/secp256r1/field/fe32_delegation.rs
@@ -26,13 +26,15 @@ static R2: BigInt<4> = BigInt::<4>(super::R2);
 pub struct FieldParams;
 
 impl DelegatedModParams<4> for FieldParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 256;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS
     }
 }
 
 impl DelegatedMontParams<4> for FieldParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &REDUCTION_CONST
     }
 }

--- a/crypto/src/secp256r1/scalar/scalar_delegation.rs
+++ b/crypto/src/secp256r1/scalar/scalar_delegation.rs
@@ -10,13 +10,15 @@ static R2: BigInt<4> = BigInt::<4>(super::R2);
 pub struct ScalarParams;
 
 impl DelegatedModParams<4> for ScalarParams {
-    unsafe fn modulus() -> &'static BigInt<4> {
+    const MODULUS_BITSIZE: usize = 256;
+
+    fn modulus() -> &'static BigInt<4> {
         &MODULUS
     }
 }
 
 impl DelegatedMontParams<4> for ScalarParams {
-    unsafe fn reduction_const() -> &'static BigInt<4> {
+    fn reduction_const() -> &'static BigInt<4> {
         &REDUCTION_CONST
     }
 }


### PR DESCRIPTION
## What ❔
add a final reduction step to montgomerry multiplication to make sure we don't get non-canonical representation.
(the scratch space test infrastructure would sometimes be unaligned, so this PR fixes that as well)

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted.