### PR TITLE
fix: fix conversion of InvalidTx errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ codegen-units = 1
 debug = true
 
 [patch.crates-io]
+zksync_os_interface = { git = "https://github.com/matter-labs/zksync-os-interface", branch = "alocascio-update-errors" }
+zksync_os_evm_errors = { git = "https://github.com/matter-labs/zksync-os-interface", branch = "alocascio-update-errors" }
 #zksync_os_evm_errors = { path = "../zksync-os-interface/crates/evm-errors" }
 #zksync_os_interface = { path = "../zksync-os-interface/crates/interface" }
 


### PR DESCRIPTION
## What ❔
Fix conversion of InvalidTx errors for interface. 
Blocked by https://github.com/matter-labs/zksync-os-interface/pull/48, we're waiting to see if we need any further changes to interface.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.