### PR TITLE
fix: do not send l1 log for upgrade tx result

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -310,15 +310,17 @@ where
     }
 
     // Emit log
-    let success = matches!(result, ExecutionResult::Success { .. });
-    let mut inf_resources = S::Resources::FORMAL_INFINITE;
-    system.io.emit_l1_l2_tx_log(
-        ExecutionEnvironmentType::NoEE,
-        &mut inf_resources,
-        tx_hash,
-        success,
-        is_priority_op,
-    )?;
+    // We don't send logs for upgrade txs by protocol convention
+    if is_priority_op {
+        let success = matches!(result, ExecutionResult::Success { .. });
+        let mut inf_resources = S::Resources::FORMAL_INFINITE;
+        system.io.emit_l1_l2_tx_log(
+            ExecutionEnvironmentType::NoEE,
+            &mut inf_resources,
+            tx_hash,
+            success,
+        )?;
+    }
 
     // Add back the intrinsic native charged in get_resources_for_tx,
     // as initial_resources doesn't include them.

--- a/basic_system/src/system_implementation/system/io_subsystem.rs
+++ b/basic_system/src/system_implementation/system/io_subsystem.rs
@@ -684,14 +684,13 @@ impl<
         _resources: &mut Self::Resources,
         tx_hash: Bytes32,
         success: bool,
-        is_priority: bool,
     ) -> Result<(), SystemError> {
         // Resources for it charged as part of intrinsic:
         // Storage: EVENT_STORAGE_BASE_NATIVE_COST
         // Hashing: keccak256_native_cost(L1_L2_TX_LOG_SERIALIZE_SIZE) + 2 * keccak256_native_cost(64).
         // See emit_l1_message for more details.
         self.logs_storage
-            .push_l1_l2_tx_log(self.tx_number, tx_hash, success, is_priority)
+            .push_l1_l2_tx_log(self.tx_number, tx_hash, success)
     }
 
     fn update_account_nominal_token_balance(

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -963,7 +963,7 @@ fn test_upgrade_tx_succeeds() {
     // Use run_block_no_panic to catch the error instead of panicking
     let result = chain.run_block_no_panic(transactions, None, None, None);
     assert!(result.is_ok());
-    let tx_output = result.unwrap().tx_results[0].as_ref().unwrap();
+    let tx_output = result.as_ref().unwrap().tx_results[0].as_ref().unwrap();
     assert!(tx_output.is_success());
     // make sure that it didn't produce l1 log with upgrade tx result
     // (such logs were present in the past, but we removed them)

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -945,15 +945,15 @@ fn test_upgrade_tx_succeeds() {
     let mut chain = Chain::empty(None);
 
     // Create a contract that always succeeds
-    let revert_contract_address = address!("0000000000000000000000000000000000010003");
+    let contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does RETURN(0, 0)
-    let revert_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    chain.set_evm_bytecode(B160::from_alloy(revert_contract_address), &revert_bytecode);
+    let bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
+    chain.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
 
     // Create a proper upgrade transaction that calls the contract
     let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
         from: address!("1234000000000000000000000000000000000000"),
-        to: revert_contract_address,
+        to: contract_address,
         gas_limit: 100_000u128,
         ..Default::default()
     });
@@ -963,8 +963,11 @@ fn test_upgrade_tx_succeeds() {
     // Use run_block_no_panic to catch the error instead of panicking
     let result = chain.run_block_no_panic(transactions, None, None, None);
     assert!(result.is_ok());
-
-    assert!(result.unwrap().tx_results[0].as_ref().unwrap().is_success());
+    let tx_output = result.unwrap().tx_results[0].as_ref().unwrap();
+    assert!(tx_output.is_success());
+    // make sure that it didn't produce l1 log with upgrade tx result
+    // (such logs were present in the past, but we removed them)
+    assert!(tx_output.l2_to_l1_logs.is_empty());
 }
 
 #[test]

--- a/zk_ee/src/common_structs/logs_storage.rs
+++ b/zk_ee/src/common_structs/logs_storage.rs
@@ -103,7 +103,6 @@ pub struct UserMsgData<DATA, HASH, ADDRESS> {
 pub struct L1TxLog<HASH> {
     pub tx_hash: HASH,
     pub success: bool,
-    pub is_priority: bool,
 }
 
 /// Log content reference to be returned from the storage
@@ -120,7 +119,6 @@ impl<IOTypes: SystemIOTypesConfig, A: Allocator> GenericLogContent<IOTypes, A> {
             GenericLogContentData::L1TxLog(l) => GenericLogContentData::L1TxLog(L1TxLog {
                 tx_hash: &l.tx_hash,
                 success: l.success,
-                is_priority: l.is_priority,
             }),
             GenericLogContentData::UserMsg(m) => GenericLogContentData::UserMsg(UserMsgData {
                 address: &m.address,
@@ -139,7 +137,6 @@ impl<IOTypes: SystemIOTypesConfig, A: Allocator> GenericLogContent<IOTypes, A> {
             GenericLogContentData::L1TxLog(l) => GenericLogContentData::L1TxLog(L1TxLog {
                 tx_hash: *l.tx_hash,
                 success: l.success,
-                is_priority: l.is_priority,
             }),
             GenericLogContentData::UserMsg(m) => GenericLogContentData::UserMsg(UserMsgData {
                 address: *m.address,
@@ -218,7 +215,6 @@ impl<SF: StackFactory<M>, const M: usize, A: Allocator + Clone + Default> LogsSt
         tx_number: u32,
         tx_hash: Bytes32,
         success: bool,
-        is_priority: bool,
     ) -> Result<(), SystemError> {
         let total_pubdata = L2_TO_L1_LOG_SERIALIZE_SIZE;
         let total_pubdata = total_pubdata as u32;
@@ -231,11 +227,7 @@ impl<SF: StackFactory<M>, const M: usize, A: Allocator + Clone + Default> LogsSt
         self.list.push(
             LogContent {
                 tx_number,
-                data: GenericLogContentData::L1TxLog(L1TxLog {
-                    tx_hash,
-                    success,
-                    is_priority,
-                }),
+                data: GenericLogContentData::L1TxLog(L1TxLog { tx_hash, success }),
             },
             total_pubdata,
         );
@@ -511,9 +503,7 @@ impl<A: Allocator> From<&LogContent<A>> for L2ToL1Log {
                 address.into(),
                 data_hash,
             ),
-            GenericLogContentData::L1TxLog(L1TxLog {
-                tx_hash, success, ..
-            }) => {
+            GenericLogContentData::L1TxLog(L1TxLog { tx_hash, success }) => {
                 let data = if success { U256::from(1) } else { U256::ZERO };
                 (
                     // TODO: move into const

--- a/zk_ee/src/system/io.rs
+++ b/zk_ee/src/system/io.rs
@@ -510,7 +510,6 @@ pub trait IOSubsystemExt: IOSubsystem {
         resources: &mut Self::Resources,
         tx_hash: Bytes32,
         success: bool,
-        is_priority: bool,
     ) -> Result<(), SystemError>;
 
     /// Returns old balance


### PR DESCRIPTION
## What ❔

Remove l1 -> l2 log for upgrade tx results.

## Why ❔

By protocol from v31 we shouldn't send them, GW asset tracker relies on it.

## Is this a breaking change?
- [x] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.