### PR TITLE
fix: observe account read if previously touched

### DIFF
--- a/basic_system/src/system_implementation/caches/cache_element_properties.rs
+++ b/basic_system/src/system_implementation/caches/cache_element_properties.rs
@@ -25,14 +25,14 @@ pub struct CacheElementProperties {
 }
 
 impl CacheElementProperties {
-    pub fn new(is_new_element: bool, is_value_known: bool) -> Self {
+    pub fn new(is_new_element: bool, is_value_observed: bool) -> Self {
         let persistent_storage_status = if is_new_element {
             CacheElementPersistenceStatus::NonExisting
         } else {
             CacheElementPersistenceStatus::Existing
         };
 
-        let cache_value_status = if is_value_known {
+        let cache_value_status = if is_value_observed {
             CacheElementValueStatus::Materialized
         } else {
             CacheElementValueStatus::Undefined
@@ -51,7 +51,7 @@ impl CacheElementProperties {
 
     /// Returns true if the initial value from storage was accessed/used.
     /// This excludes records that were only touched but never observed, updated, or deleted.
-    pub fn is_value_known(&self) -> bool {
+    pub fn is_value_observed(&self) -> bool {
         matches!(
             self.cache_value_status,
             CacheElementValueStatus::Materialized
@@ -59,7 +59,7 @@ impl CacheElementProperties {
     }
 
     /// Marks the cache element's value as having been observed/accessed
-    pub fn mark_value_as_known(&mut self) {
+    pub fn mark_value_as_observed(&mut self) {
         if self.cache_value_status == CacheElementValueStatus::Undefined {
             self.cache_value_status = CacheElementValueStatus::Materialized;
         };

--- a/basic_system/src/system_implementation/ethereum_storage_model/caches/account_cache.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/caches/account_cache.rs
@@ -189,7 +189,7 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
                 }
                 // appearance mark
                 if observe {
-                    x.element_properties_mut().mark_value_as_known();
+                    x.element_properties_mut().mark_value_as_observed();
                 }
 
                 Ok(x)
@@ -220,7 +220,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
 
         let cur = account_data.current().value().balance;
         let new = update_fn(&cur)?;
-        account_data.element_properties_mut().mark_value_as_known();
+        account_data
+            .element_properties_mut()
+            .mark_value_as_observed();
         account_data.update(|cache_record| {
             cache_record.update(|v, _| {
                 v.balance = new;
@@ -389,7 +391,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
         let mut account_data = self
             .materialize_element::<PROOF_ENV>(ee_type, resources, address, oracle, false, true)?;
         // we are actually going to use account properties, so we should mark it so
-        account_data.element_properties_mut().mark_value_as_known();
+        account_data
+            .element_properties_mut()
+            .mark_value_as_observed();
         let element_properties = account_data.element_properties();
         let full_data = account_data.current().value();
 
@@ -476,7 +480,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
 
         let nonce = account_data.current().value().nonce;
         if let Some(new_nonce) = nonce.checked_add(increment_by) {
-            account_data.element_properties_mut().mark_value_as_known();
+            account_data
+                .element_properties_mut()
+                .mark_value_as_observed();
             account_data.update(|cache_record| {
                 cache_record.update(|x, _| {
                     if x.bytecode_hash.is_zero() {
@@ -604,7 +610,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
             WARM_ACCOUNT_CACHE_WRITE_EXTRA_NATIVE_COST,
         )))?;
 
-        account_data.element_properties_mut().mark_value_as_known();
+        account_data
+            .element_properties_mut()
+            .mark_value_as_observed();
         account_data.update(|cache_record| {
             cache_record.update(|v, m| {
                 v.bytecode_hash = bytecode_hash;
@@ -647,7 +655,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
             account_data.current().metadata().deployed_in_tx == Some(cur_tx) || in_constructor;
 
         if should_be_deconstructed {
-            account_data.element_properties_mut().mark_value_as_known();
+            account_data
+                .element_properties_mut()
+                .mark_value_as_observed();
             account_data.update(|data| {
                 data.update_metadata(|metadata| {
                     metadata.is_marked_for_deconstruction = true;
@@ -756,7 +766,9 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
             WARM_ACCOUNT_CACHE_WRITE_EXTRA_NATIVE_COST,
         )))?;
 
-        account_data.element_properties_mut().mark_value_as_known();
+        account_data
+            .element_properties_mut()
+            .mark_value_as_observed();
         account_data.update(|cache_record| {
             cache_record.update(|v, _m| {
                 v.bytecode_hash = bytecode_hash;
@@ -781,7 +793,7 @@ impl<A: Allocator + Clone, R: Resources, SF: StackFactory<N>, const N: usize>
 
                     // NOTE: Balance will be zeroed out if deconstruction happens here
                     let initially_empty = cache_appearance.is_new_element();
-                    assert!(cache_appearance.is_value_known());
+                    assert!(cache_appearance.is_value_observed());
                     current.value.update(|x, metadata| {
                         metadata.is_marked_for_deconstruction = false;
                         if initially_empty {

--- a/basic_system/src/system_implementation/ethereum_storage_model/caches/full_storage_cache.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/caches/full_storage_cache.rs
@@ -168,7 +168,7 @@ impl<
             let current_record = item.current();
             let initial_record = item.initial();
             let is_new_storage_slot = item.key_properties().is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             (
                 *item.key(),
                 // Using the WarmStorageValue temporarily till it's outed from the codebase. We're

--- a/basic_system/src/system_implementation/ethereum_storage_model/persist_changes.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/persist_changes.rs
@@ -555,7 +555,7 @@ impl EthereumStoragePersister {
                         .cache
                         .get_mut((&active_address).into())
                         .expect("account with storage address must be cached");
-                    e.element_properties_mut().mark_value_as_known();
+                    e.element_properties_mut().mark_value_as_observed();
                 }
 
                 // recompute new root
@@ -687,7 +687,7 @@ impl EthereumStoragePersister {
                 addr.0.as_uint()
             );
 
-            if !key_properties.is_value_known() {
+            if !key_properties.is_value_observed() {
                 // whatever it was - it's unobservable, we can just skip it
                 assert_eq!(initial.value(), current.value());
 

--- a/basic_system/src/system_implementation/ethereum_storage_model/storage_model.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/storage_model.rs
@@ -414,7 +414,7 @@ impl<
         self.storage_cache.slot_values.cache.get(key).map(|item| {
             let key_properties = item.key_properties();
             let is_new_storage_slot = key_properties.is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             let current_record = item.current();
             let initial_record = item.initial();
 
@@ -433,7 +433,7 @@ impl<
         self.storage_cache.slot_values.cache.iter().map(|item| {
             let key_properties = item.key_properties();
             let is_new_storage_slot = key_properties.is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             let current_record = item.current();
             let initial_record = item.initial();
             (

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -264,7 +264,7 @@ impl<
                     .basic
                     .considered_warm(self.current_tx_id);
                 if observe {
-                    x.element_properties_mut().mark_value_as_known();
+                    x.element_properties_mut().mark_value_as_observed();
                 }
                 if is_warm == false {
                     if initialized_element == false {
@@ -1160,7 +1160,9 @@ impl<
             || in_constructor;
 
         if should_be_deconstructed {
-            account_data.element_properties_mut().mark_value_as_known();
+            account_data
+                .element_properties_mut()
+                .mark_value_as_observed();
             account_data.update(|data| {
                 data.update_metadata(|metadata| {
                     metadata.basic.is_marked_for_deconstruction = true;
@@ -1234,7 +1236,7 @@ impl<
                 if current.value.metadata().basic.is_marked_for_deconstruction {
                     // NOTE: it can only happen if the account is initially empty,
                     // so we need to make sure that it was observed earlier - when bytecode was deployed
-                    assert!(cache_appearance.is_value_known());
+                    assert!(cache_appearance.is_value_observed());
                     current.value.update(|x, metadata| {
                         metadata.basic.is_marked_for_deconstruction = false;
                         *x = AccountProperties::TRIVIAL_VALUE;

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -263,6 +263,9 @@ impl<
                     .metadata()
                     .basic
                     .considered_warm(self.current_tx_id);
+                if observe {
+                    x.element_properties_mut().mark_value_as_known();
+                }
                 if is_warm == false {
                     if initialized_element == false {
                         // Element exists in cache, but wasn't touched in current tx yet

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -472,7 +472,7 @@ impl<
     fn get_storage_diff<'a>(&'a self, key: Self::StorageKey<'a>) -> Option<Self::StorageDiff<'a>> {
         self.storage_cache.0.cache.get(key).map(|item| {
             let is_new_storage_slot = item.key_properties().is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             let current_record = item.current();
             let initial_record = item.initial();
 
@@ -491,7 +491,7 @@ impl<
     ) -> impl ExactSizeIterator<Item = (Self::StorageKey<'a>, Self::StorageDiff<'a>)> + Clone {
         self.storage_cache.0.cache.iter().map(|item| {
             let is_new_storage_slot = item.key_properties().is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             let current_record = item.current();
             let initial_record = item.initial();
             (

--- a/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
@@ -223,7 +223,7 @@ impl<
     {
         self.0.cache.iter().map(|item| {
             let is_new_storage_slot = item.key_properties().is_new_element();
-            let initial_value_used = item.key_properties().is_value_known();
+            let initial_value_used = item.key_properties().is_value_observed();
             let current_record = item.current();
             let initial_record = item.initial();
             (


### PR DESCRIPTION
## What ❔

Current account cache doesn't set the account as observed on a read if it was previously touched. This PR fixes that. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.