### PR TITLE
fix: use EvmError from zk_ee instead of zksync_os_evm_errors in evm_interpreter

### DIFF
--- a/evm_interpreter/Cargo.toml
+++ b/evm_interpreter/Cargo.toml
@@ -20,7 +20,6 @@ either = { version = "*", default-features = false }
 cycle_marker = { path = "../cycle_marker" }
 strum_macros = "0.27.1"
 paste = "1.0.15"
-zksync_os_evm_errors = { workspace = true, default-features = false }
 
 [features]
 point_eval_precompile = []

--- a/evm_interpreter/src/evm_stack.rs
+++ b/evm_interpreter/src/evm_stack.rs
@@ -7,9 +7,9 @@ use alloc::boxed::Box;
 use core::{alloc::Allocator, mem::MaybeUninit};
 use ruint::aliases::U256;
 use zk_ee::logger_log;
+use zk_ee::system::evm::EvmError;
 use zk_ee::system::evm::EvmStackInterface;
 use zk_ee::system::logger::Logger;
-use zksync_os_evm_errors::EvmError;
 
 pub struct EvmStack<A: Allocator> {
     buffer: Box<[MaybeUninit<U256>; STACK_SIZE], A>,
@@ -372,7 +372,7 @@ mod tests {
     use crate::STACK_SIZE;
     use ruint::aliases::U256;
     use std::alloc::Global;
-    use zksync_os_evm_errors::EvmError;
+    use zk_ee::system::evm::EvmError;
 
     #[test]
     fn push_then_pop_works() {

--- a/evm_interpreter/src/gas.rs
+++ b/evm_interpreter/src/gas.rs
@@ -4,8 +4,8 @@
 //! including the "native" (proving) resource, which reflects the actual cost of proving.
 //! As a result, there is an element of double accounting.
 
+use zk_ee::system::evm::EvmError;
 use zk_ee::system::{Computational, Ergs, EthereumLikeTypes, Resource, Resources, SystemTypes};
-use zksync_os_evm_errors::EvmError;
 
 use crate::{
     native_resource_constants::{
@@ -116,8 +116,8 @@ impl<S: EthereumLikeTypes> Gas<S> {
 }
 
 pub mod gas_utils {
+    use zk_ee::system::evm::EvmError;
     use zk_ee::system::Ergs;
-    use zksync_os_evm_errors::EvmError;
 
     use crate::{ExitCode, ERGS_PER_GAS};
 

--- a/evm_interpreter/src/lib.rs
+++ b/evm_interpreter/src/lib.rs
@@ -45,7 +45,8 @@ use zk_ee::system::{Ergs, EthereumLikeTypes, Resource, Resources, System, System
 use alloc::vec::Vec;
 use zk_ee::utils::*;
 use zk_ee::{internal_error, types_config::*};
-use zksync_os_evm_errors::EvmError;
+
+use zk_ee::system::evm::EvmError;
 
 mod ee_trait_impl;
 pub mod errors;

--- a/forward_system/src/run/convert.rs
+++ b/forward_system/src/run/convert.rs
@@ -3,8 +3,10 @@ use alloy::consensus::{Header, Sealed};
 use alloy::primitives::Log;
 use basic_bootloader::bootloader::block_header::BlockHeader;
 use zk_ee::common_structs::GenericEventContent;
+use zk_ee::system::evm::EvmError as ZkEvmError;
 use zk_ee::system::metadata::zk_metadata::{BlockHashes, BlockMetadataFromOracle};
 use zk_ee::types_config::EthereumIOTypesConfig;
+use zksync_os_evm_errors::EvmError as InterfaceEvmError;
 use zksync_os_interface::error::InvalidTransaction;
 use zksync_os_interface::types::{BlockContext, L2ToL1Log};
 
@@ -14,6 +16,66 @@ pub trait FromInterface<T> {
 
 pub trait IntoInterface<T> {
     fn into_interface(self) -> T;
+}
+
+impl IntoInterface<InterfaceEvmError> for ZkEvmError {
+    fn into_interface(self) -> InterfaceEvmError {
+        match self {
+            ZkEvmError::Revert => InterfaceEvmError::Revert,
+            ZkEvmError::OutOfGas => InterfaceEvmError::OutOfGas,
+            ZkEvmError::InvalidJump => InterfaceEvmError::InvalidJump,
+            ZkEvmError::ReturnDataOutOfBounds => InterfaceEvmError::ReturnDataOutOfBounds,
+            ZkEvmError::InvalidOpcode(opcode) => InterfaceEvmError::InvalidOpcode(opcode),
+            ZkEvmError::StackUnderflow => InterfaceEvmError::StackUnderflow,
+            ZkEvmError::StackOverflow => InterfaceEvmError::StackOverflow,
+            ZkEvmError::CallNotAllowedInsideStatic => InterfaceEvmError::CallNotAllowedInsideStatic,
+            ZkEvmError::StateChangeDuringStaticCall => {
+                InterfaceEvmError::StateChangeDuringStaticCall
+            }
+            ZkEvmError::MemoryLimitOOG => InterfaceEvmError::MemoryLimitOOG,
+            ZkEvmError::InvalidOperandOOG => InterfaceEvmError::InvalidOperandOOG,
+            ZkEvmError::CodeStoreOutOfGas => InterfaceEvmError::CodeStoreOutOfGas,
+            ZkEvmError::CallTooDeep => InterfaceEvmError::CallTooDeep,
+            ZkEvmError::InsufficientBalance => InterfaceEvmError::InsufficientBalance,
+            ZkEvmError::CreateCollision => InterfaceEvmError::CreateCollision,
+            ZkEvmError::NonceOverflow => InterfaceEvmError::NonceOverflow,
+            ZkEvmError::CreateContractSizeLimit => InterfaceEvmError::CreateContractSizeLimit,
+            ZkEvmError::CreateInitcodeSizeLimit => InterfaceEvmError::CreateInitcodeSizeLimit,
+            ZkEvmError::CreateContractStartingWithEF => {
+                InterfaceEvmError::CreateContractStartingWithEF
+            }
+        }
+    }
+}
+
+impl FromInterface<InterfaceEvmError> for ZkEvmError {
+    fn from_interface(value: InterfaceEvmError) -> Self {
+        match value {
+            InterfaceEvmError::Revert => ZkEvmError::Revert,
+            InterfaceEvmError::OutOfGas => ZkEvmError::OutOfGas,
+            InterfaceEvmError::InvalidJump => ZkEvmError::InvalidJump,
+            InterfaceEvmError::ReturnDataOutOfBounds => ZkEvmError::ReturnDataOutOfBounds,
+            InterfaceEvmError::InvalidOpcode(opcode) => ZkEvmError::InvalidOpcode(opcode),
+            InterfaceEvmError::StackUnderflow => ZkEvmError::StackUnderflow,
+            InterfaceEvmError::StackOverflow => ZkEvmError::StackOverflow,
+            InterfaceEvmError::CallNotAllowedInsideStatic => ZkEvmError::CallNotAllowedInsideStatic,
+            InterfaceEvmError::StateChangeDuringStaticCall => {
+                ZkEvmError::StateChangeDuringStaticCall
+            }
+            InterfaceEvmError::MemoryLimitOOG => ZkEvmError::MemoryLimitOOG,
+            InterfaceEvmError::InvalidOperandOOG => ZkEvmError::InvalidOperandOOG,
+            InterfaceEvmError::CodeStoreOutOfGas => ZkEvmError::CodeStoreOutOfGas,
+            InterfaceEvmError::CallTooDeep => ZkEvmError::CallTooDeep,
+            InterfaceEvmError::InsufficientBalance => ZkEvmError::InsufficientBalance,
+            InterfaceEvmError::CreateCollision => ZkEvmError::CreateCollision,
+            InterfaceEvmError::NonceOverflow => ZkEvmError::NonceOverflow,
+            InterfaceEvmError::CreateContractSizeLimit => ZkEvmError::CreateContractSizeLimit,
+            InterfaceEvmError::CreateInitcodeSizeLimit => ZkEvmError::CreateInitcodeSizeLimit,
+            InterfaceEvmError::CreateContractStartingWithEF => {
+                ZkEvmError::CreateContractStartingWithEF
+            }
+        }
+    }
 }
 
 impl FromInterface<BlockContext> for BlockMetadataFromOracle {

--- a/forward_system/src/run/tracing_impl.rs
+++ b/forward_system/src/run/tracing_impl.rs
@@ -1,8 +1,9 @@
+use crate::run::convert::IntoInterface;
 use crate::run::convert_alloy::IntoAlloy;
 use alloy::primitives::{Address, U256};
 use std::marker::PhantomData;
 use zk_ee::execution_environment_type::ExecutionEnvironmentType;
-use zk_ee::system::evm::EvmFrameInterface;
+use zk_ee::system::evm::{EvmError as ZkEEEvmError, EvmFrameInterface};
 use zk_ee::system::tracer::evm_tracer::EvmTracer;
 use zk_ee::system::tracer::Tracer;
 use zk_ee::system::{
@@ -10,7 +11,7 @@ use zk_ee::system::{
     Resources, SystemTypes,
 };
 use zk_ee::types_config::SystemIOTypesConfig;
-use zksync_os_evm_errors::EvmError;
+use zksync_os_evm_errors::EvmError as InterfaceEvmError;
 use zksync_os_interface::tracing::{EvmRequest, EvmResources};
 
 /// Wrapper around interface `EvmTracer` to make it compatible with `zk_ee` tracing API.
@@ -183,13 +184,17 @@ impl<'a, T: zksync_os_interface::tracing::EvmTracer, S: EthereumLikeTypes> EvmTr
         )
     }
 
-    fn on_opcode_error(&mut self, error: &EvmError, frame_state: &impl EvmFrameInterface<S>) {
-        self.0
-            .on_opcode_error(error, EvmFrameInterfaceWrapped::from(frame_state))
+    fn on_opcode_error(&mut self, error: &ZkEEEvmError, frame_state: &impl EvmFrameInterface<S>) {
+        let interface_error: InterfaceEvmError = error.clone().into_interface();
+        self.0.on_opcode_error(
+            &interface_error,
+            EvmFrameInterfaceWrapped::from(frame_state),
+        )
     }
 
-    fn on_call_error(&mut self, error: &EvmError) {
-        self.0.on_call_error(error)
+    fn on_call_error(&mut self, error: &ZkEEEvmError) {
+        let interface_error: InterfaceEvmError = error.clone().into_interface();
+        self.0.on_call_error(&interface_error)
     }
 
     fn on_selfdestruct(
@@ -327,7 +332,9 @@ impl<'a> zksync_os_interface::tracing::EvmStackInterface for EvmStackInterfaceWr
         self.inner.len()
     }
 
-    fn peek_n(&self, index: usize) -> Result<&U256, EvmError> {
-        self.inner.peek_n(index)
+    fn peek_n(&self, index: usize) -> Result<&U256, InterfaceEvmError> {
+        self.inner
+            .peek_n(index)
+            .map_err(|error| error.into_interface())
     }
 }

--- a/forward_system/src/system/tracers/call_tracer.rs
+++ b/forward_system/src/system/tracers/call_tracer.rs
@@ -14,14 +14,13 @@
 use evm_interpreter::ERGS_PER_GAS;
 use ruint::aliases::{B160, U256};
 use zk_ee::system::{
-    evm::EvmFrameInterface,
+    evm::{EvmError, EvmFrameInterface},
     tracer::{evm_tracer::EvmTracer, Tracer},
     CallModifier, CallResult, EthereumLikeTypes, ExecutionEnvironmentLaunchParams, Resources,
     SystemTypes,
 };
 use zk_ee::types_config::SystemIOTypesConfig;
 use zk_ee::utils::Bytes32;
-use zksync_os_evm_errors::EvmError;
 
 #[derive(Default, Debug)]
 pub enum CallType {

--- a/forward_system/src/system/tracers/evm_opcodes_logger.rs
+++ b/forward_system/src/system/tracers/evm_opcodes_logger.rs
@@ -17,14 +17,13 @@ use evm_interpreter::{opcodes::OpCode, ERGS_PER_GAS};
 use ruint::aliases::U256;
 use zk_ee::{
     system::{
-        evm::{EvmFrameInterface, EvmStackInterface},
+        evm::{EvmError, EvmFrameInterface, EvmStackInterface},
         tracer::{evm_tracer::EvmTracer, Tracer},
         CallResult, EthereumLikeTypes, ExecutionEnvironmentLaunchParams, Resources, SystemTypes,
     },
     types_config::SystemIOTypesConfig,
     utils::Bytes32,
 };
-use zksync_os_evm_errors::EvmError;
 
 #[derive(Default, Debug)]
 #[allow(dead_code)]

--- a/zk_ee/Cargo.toml
+++ b/zk_ee/Cargo.toml
@@ -22,7 +22,6 @@ bitflags = { version = "2.6.0", default-features = false }
 cycle_marker = { path = "../cycle_marker" }
 strum_macros = "0.27.1"
 paste = "1.0.15"
-zksync_os_evm_errors = { workspace = true, default-features = false }
 
 [features]
 # serde derivation has to be disabled for risc-v target until we update ruint version

--- a/zk_ee/src/system/execution_environment/evm/mod.rs
+++ b/zk_ee/src/system/execution_environment/evm/mod.rs
@@ -1,6 +1,8 @@
 use crate::{system::SystemTypes, types_config::SystemIOTypesConfig};
 use ruint::aliases::U256;
-use zksync_os_evm_errors::EvmError;
+
+pub mod errors;
+pub use errors::EvmError;
 
 /// Expected interface of and EVM frame state. This trait simplifies versioning and integration of tracers.
 pub trait EvmFrameInterface<S: SystemTypes> {

--- a/zk_ee/src/system/tracer/evm_tracer.rs
+++ b/zk_ee/src/system/tracer/evm_tracer.rs
@@ -1,8 +1,10 @@
 use crate::{
-    system::{evm::EvmFrameInterface, SystemTypes},
+    system::{
+        evm::{EvmError, EvmFrameInterface},
+        SystemTypes,
+    },
     types_config::SystemIOTypesConfig,
 };
-use zksync_os_evm_errors::EvmError;
 
 pub trait EvmTracer<S: SystemTypes> {
     /// Called before opcode execution


### PR DESCRIPTION


## What ❔
Avoids making changes to the interface errors alter the proving binary.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.