### PR TITLE
test: Introduce TestingFramework struct

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: read-all
 
+env:
+    ZKSYNC_RISC_V_RUN: true
+    CI: true
+
 # Cancel previous runs that might be caused by appbin update
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ permissions: read-all
 
 env:
     CARGO_INCREMENTAL: 0
+    ZKSYNC_PROVING_RUN: true
+    CI: true
 
 # Cancel previous runs that might be caused by appbin update
 concurrency:
@@ -41,7 +43,7 @@ jobs:
             - name: Compile
               run: cargo test --release --no-run
             - name: Run rust tests
-              run: cargo test --release -j 3 -- --skip verify_default_binaries
+              run: cargo test --release -j 3
     crypto_test:
         name: crypto crate tests
         runs-on: [matterlabs-ci-runner]
@@ -101,7 +103,7 @@ jobs:
                   ./dump_bin.sh --type singleblock-batch
                   ./dump_bin.sh --type multiblock-batch
             - name: Run binary checker
-              run: cargo test -p binary_checker -- --nocapture
+              run: cargo test -p binary_checker -- --nocapture -- --ignored
 
     e2e_prove:
         name: e2e_prove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
                   ./dump_bin.sh --type singleblock-batch
                   ./dump_bin.sh --type multiblock-batch
             - name: Run binary checker
-              run: cargo test -p binary_checker -- --nocapture -- --ignored
+              run: cargo test -p binary_checker -- --nocapture --ignored
 
     e2e_prove:
         name: e2e_prove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 env:
     CARGO_INCREMENTAL: 0
-    ZKSYNC_PROVING_RUN: true
+    ZKSYNC_RISC_V_RUN: true
     CI: true
 
 # Cancel previous runs that might be caused by appbin update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,6 @@ jobs:
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
-            - name: Compile for RISC-V
-              working-directory: ./zksync_os
-              run: |
-                  rustup target add riscv32i-unknown-none-elf
-                  cargo install cargo-binutils
-                  rustup component add llvm-tools-preview
-                  rustup component add rust-src
-                  ./dump_bin.sh --type for-tests
-                  ./dump_bin.sh --type multiblock-batch
             - name: Compile
               run: cargo test --release --no-run
             - name: Run rust tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
+            - name: Compile for RISC-V
+              working-directory: ./zksync_os
+              run: |
+                  rustup target add riscv32i-unknown-none-elf
+                  cargo install cargo-binutils
+                  rustup component add llvm-tools-preview
+                  rustup component add rust-src
+                  ./dump_bin.sh --type for-tests
+                  ./dump_bin.sh --type multiblock-batch
             - name: Compile
               run: cargo test --release --no-run
             - name: Run rust tests

--- a/.github/workflows/evm_terster_proof_run.yml
+++ b/.github/workflows/evm_terster_proof_run.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: read-all
 
+env:
+    ZKSYNC_RISC_V_RUN: true
+    CI: true
+
 jobs:
     evm_state_tests:
         name: EF EVM state tests with proof run

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 env:
-    ZKSYNC_PROVING_RUN: true
+    ZKSYNC_RISC_V_RUN: true
     CI: true
 
 jobs:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: read-all
 
+env:
+    ZKSYNC_PROVING_RUN: true
+    CI: true
+
 jobs:
     build-fuzz-targets:
         name: Build fuzz targets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,9 @@ To run rig-based tests without detailed executions logs use:
 cargo test -p <crate-name> --features rig/no_print
 ```
 
-By default, local rig runs skip RISC-V simulation unless `ZKSYNC_PROVING_RUN` or `CI` is set. To force proving-mode simulation locally use:
+By default, local rig runs skip RISC-V simulation unless `ZKSYNC_RISC_V_RUN` or `CI` is set. To force proving-mode simulation locally use:
 ```bash
-ZKSYNC_PROVING_RUN=true cargo test -p <crate-name>
+ZKSYNC_RISC_V_RUN=true cargo test -p <crate-name>
 ```
 
 #### EVM tester

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,17 @@ cd zksync_os && ./dump_bin.sh --type for-tests
 ### Testing Infrastructure
 
 #### Integration tests
-The project uses a custom testing rig located in `tests/rig/` with the main abstraction being the `Chain` struct for in-memory chain state testing. Tests are organized in `tests/instances/` and follow this pattern:
+The project uses a custom testing rig located in `tests/rig/` with the main abstraction being the `ZKsyncOSTester` struct. Tests are organized in `tests/instances/` and follow this pattern:
 1. Set up initial chain state (predeployed contracts, balances)
 2. Define transactions to execute
-3. Call `run_block` to execute (typically runs both forward and proof systems, unless configured otherwise)
+3. Call `execute_block` to execute (typically runs both forward and proof systems, unless configured otherwise)
+
+Avoid direct `Chain` usage in test instances unless a low-level path is explicitly needed.
+
+To run rig-based tests without detailed executions logs use:
+```bash
+cargo test -p <crate-name> --features rig/no_print
+```
 
 #### EVM tester
 The EVM tester is used to run the Ethereum execution spec tests to check the EVM compatibility of ZKsync OS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ cd zksync_os && ./dump_bin.sh --type for-tests
 ### Testing Infrastructure
 
 #### Integration tests
-The project uses a custom testing rig located in `tests/rig/` with the main abstraction being the `ZKsyncOSTester` struct. Tests are organized in `tests/instances/` and follow this pattern:
+The project uses a custom testing rig located in `tests/rig/` with the main abstraction being the `TestingFramework` struct. Tests are organized in `tests/instances/` and follow this pattern:
 1. Set up initial chain state (predeployed contracts, balances)
 2. Define transactions to execute
 3. Call `execute_block` to execute (typically runs both forward and proof systems, unless configured otherwise)
@@ -82,6 +82,11 @@ Avoid direct `Chain` usage in test instances unless a low-level path is explicit
 To run rig-based tests without detailed executions logs use:
 ```bash
 cargo test -p <crate-name> --features rig/no_print
+```
+
+By default, local rig runs skip RISC-V simulation unless `ZKSYNC_PROVING_RUN` or `CI` is set. To force proving-mode simulation locally use:
+```bash
+ZKSYNC_PROVING_RUN=true cargo test -p <crate-name>
 ```
 
 #### EVM tester

--- a/tests/binary_checker/src/lib.rs
+++ b/tests/binary_checker/src/lib.rs
@@ -39,6 +39,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "runs only on CI / explicit opt-in"]
     fn verify_default_binaries() {
         verify_binary("singleblock_batch.text");
         verify_binary("multiblock_batch.text")

--- a/tests/common/src/zksync_tx/mod.rs
+++ b/tests/common/src/zksync_tx/mod.rs
@@ -17,6 +17,7 @@ pub mod service_tx;
 pub mod upgrade_tx;
 
 /// Wrapper over all tx envelope kinds we feed into ZKsync OS.
+#[derive(Clone)]
 pub enum ZKsyncTxEnvelope {
     /// Standard Ethereum typed envelope signed by the corresponding address.
     Ethereum(TxEnvelope, Address),
@@ -114,6 +115,7 @@ impl From<ZKsyncServiceTx> for ZKsyncTxEnvelope {
 }
 
 /// ZKsync OS specific transactions wrapper.
+#[derive(Clone)]
 pub enum ZKsyncSpecificTxEnvelope {
     L1(ZKsyncL1Tx),
     Upgrade(ZKsyncUpgradeTx),

--- a/tests/evm_tester/Cargo.lock
+++ b/tests/evm_tester/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,17 +22,6 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
 
 [[package]]
 name = "ahash"
@@ -109,10 +88,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "num_enum",
- "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -266,33 +243,9 @@ dependencies = [
  "c-kzg",
  "derive_more 2.0.1",
  "either",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "sha2 0.10.9",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-evm"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "auto_impl",
- "derive_more 2.0.1",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "op-revm",
- "revm",
+ "sha2",
  "thiserror 2.0.17",
 ]
 
@@ -309,19 +262,6 @@ dependencies = [
  "borsh",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
 ]
 
 [[package]]
@@ -597,11 +537,9 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "rand 0.8.5",
  "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -896,7 +834,7 @@ dependencies = [
  "rustls 0.23.35",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -923,7 +861,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -1014,7 +952,6 @@ checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
- "ark-r1cs-std",
  "ark-std 0.5.0",
 ]
 
@@ -1181,35 +1118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-r1cs-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
-dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-relations",
- "ark-std 0.5.0",
- "educe",
- "num-bigint",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
-dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,27 +1199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
 ]
 
 [[package]]
@@ -1376,16 +1269,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "aurora-engine-modexp"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
-dependencies = [
- "hex",
- "num",
-]
 
 [[package]]
 name = "auto_impl"
@@ -1462,7 +1345,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.18.1",
+ "uuid",
 ]
 
 [[package]]
@@ -1527,7 +1410,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2 0.10.9",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -1722,22 +1605,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "az"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1782,7 +1653,7 @@ dependencies = [
  "ruint",
  "serde",
  "serde-big-array",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zk_ee",
 ]
@@ -1808,17 +1679,11 @@ dependencies = [
  "ruint",
  "serde",
  "storage_models",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zerocopy",
  "zk_ee",
 ]
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bigint_with_control"
@@ -1848,27 +1713,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1915,7 +1765,6 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
- "serde",
  "tap",
  "wyz",
 ]
@@ -1946,15 +1795,6 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "unroll",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -2002,16 +1842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2 0.10.9",
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,26 +1885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "c-kzg"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,46 +1917,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -2176,16 +1952,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -2248,58 +2014,6 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
-
-[[package]]
-name = "coins-bip32"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
-dependencies = [
- "bs58",
- "coins-core",
- "digest 0.10.7",
- "hmac",
- "k256",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-bip39"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
-dependencies = [
- "bitvec",
- "coins-bip32",
- "hmac",
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-core"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bs58",
- "digest 0.10.7",
- "generic-array",
- "hex",
- "ripemd",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "sha3",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "coins-ledger"
@@ -2402,25 +2116,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c50fcfdf972929aff202c16b80086aa3cfc6a3a820af714096c58c7c1d0582"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -2491,12 +2190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,7 +2250,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "zeroize",
 ]
@@ -2610,27 +2303,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "cycle_marker"
 version = "0.0.0"
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
 
 [[package]]
 name = "darling"
@@ -2638,22 +2312,8 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.111",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2673,22 +2333,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.111",
 ]
@@ -2746,23 +2395,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-where"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -2771,31 +2409,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -2804,7 +2422,6 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -2826,52 +2443,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2967,39 +2542,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enr"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "hex",
- "k256",
- "log",
- "rand 0.8.5",
- "rlp",
- "serde",
- "sha3",
- "zeroize",
 ]
 
 [[package]]
@@ -3034,19 +2582,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
@@ -3075,28 +2610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest 0.10.7",
- "hex",
- "hmac",
- "pbkdf2 0.11.0",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3",
- "thiserror 1.0.69",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,10 +2634,8 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
  "impl-rlp",
  "impl-serde",
- "scale-info",
  "tiny-keccak",
 ]
 
@@ -3136,300 +2647,10 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
  "impl-rlp",
  "impl-serde",
  "primitive-types",
- "scale-info",
  "uint",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "ethers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "once_cell",
- "pin-project 1.1.10",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core",
- "ethers-etherscan",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "syn 2.0.111",
- "toml",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "syn 2.0.111",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest 0.11.27",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http 0.2.12",
- "instant",
- "jsonwebtoken 8.3.0",
- "once_cell",
- "pin-project 1.1.10",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.20.1",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve",
- "eth-keystore",
- "ethers-core",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
 ]
 
 [[package]]
@@ -3488,9 +2709,8 @@ dependencies = [
  "either",
  "paste",
  "ruint",
- "strum_macros 0.27.2",
+ "strum_macros",
  "zk_ee",
- "zksync_os_evm_errors",
 ]
 
 [[package]]
@@ -3504,16 +2724,6 @@ dependencies = [
  "serde_json",
  "trace_and_split",
  "verifier_common",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -3615,12 +2825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,22 +2878,12 @@ dependencies = [
  "paste",
  "ruint",
  "serde",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zk_ee",
  "zksync_os_evm_errors",
  "zksync_os_interface",
  "zksync_os_runner",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3747,16 +2941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,10 +2968,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -3814,15 +2994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "gcloud-sdk"
 version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,7 +3004,7 @@ dependencies = [
  "chrono",
  "futures",
  "hyper 1.8.1",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -3901,28 +3072,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "group"
@@ -4005,15 +3154,6 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
 ]
 
 [[package]]
@@ -4181,12 +3321,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -4484,12 +3618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,7 +3651,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
- "env_logger 0.11.8",
+ "env_logger",
  "indexmap 2.12.1",
  "itoa",
  "log",
@@ -4532,15 +3660,6 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -4584,17 +3703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,15 +3713,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4667,16 +3766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,28 +3792,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem 3.0.6",
- "ring 0.17.14",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4741,8 +3816,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -4762,36 +3836,6 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -4825,16 +3869,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
-]
 
 [[package]]
 name = "libusb1-sys"
@@ -4930,16 +3964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,12 +4035,6 @@ name = "modexp"
 version = "0.1.0"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,20 +4053,6 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5057,15 +4061,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5090,28 +4085,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -5151,7 +4124,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -5199,7 +4171,6 @@ version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
- "critical-section",
  "portable-atomic",
 ]
 
@@ -5210,91 +4181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.0.1",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "derive_more 2.0.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "op-alloy-consensus",
- "snap",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "op-revm"
-version = "12.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31622d03b29c826e48800f4c8f389c8a9c440eb796a3e35203561a288f12985"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "oracle_provider"
@@ -5319,7 +4209,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -5372,58 +4262,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "pem"
@@ -5461,16 +4303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.12.1",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5478,91 +4310,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -5684,22 +4431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,7 +4449,6 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -5728,7 +4458,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5792,8 +4522,8 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
@@ -5874,7 +4604,7 @@ name = "prover"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "blake2s_u32",
  "cs",
  "fft",
@@ -6056,17 +4786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "reduced_risc_v_log_23_machine"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
@@ -6229,429 +4948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-chainspec"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "auto_impl",
- "derive_more 2.0.1",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
- "serde_json",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "bytes",
- "reth-primitives-traits",
- "serde",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
- "rustc-hash",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-primitives-traits",
- "reth-zstd-compressors",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "derive_more 2.0.1",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
- "revm",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "secp256k1 0.30.0",
- "serde_with",
- "thiserror 2.0.17",
- "url",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more 2.0.1",
- "once_cell",
- "op-alloy-consensus",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "serde",
- "strum 0.27.2",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "revm",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "reth-trie-common",
- "serde",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "revm-database",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.0.1",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
- "revm-database-interface",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-trie",
- "arrayvec",
- "bytes",
- "derive_more 2.0.1",
- "itertools 0.14.0",
- "nybbles",
- "reth-primitives-traits",
- "revm-database",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "revm"
-version = "31.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
-dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
-]
-
-[[package]]
-name = "revm-bytecode"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
-dependencies = [
- "bitvec",
- "phf 0.13.1",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
-name = "revm-context"
-version = "11.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92850e150f4f99d46c05a20ad0cd09286a7ad4ee21866fffb87101de6e602231"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-database"
-version = "9.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
-dependencies = [
- "alloy-eips",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-database-interface"
-version = "8.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
-dependencies = [
- "auto_impl",
- "either",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-handler"
-version = "12.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "12.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
-dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
- "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968b124028960201abf6d6bf8e223f15fadebb4307df6b7dc9244a0aab5d2d05"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "blst",
- "c-kzg",
- "cfg-if",
- "k256",
- "p256",
- "revm-primitives",
- "ripemd",
- "rug",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
-version = "8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
-dependencies = [
- "bitflags 2.10.0",
- "revm-bytecode",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6708,13 +5004,11 @@ dependencies = [
  "alloy-sol-types",
  "basic_bootloader",
  "basic_system",
- "bincode",
  "callable_oracles",
  "crypto",
- "env_logger 0.11.8",
+ "env_logger",
  "evm_interpreter",
  "forward_system",
- "futures",
  "hex",
  "log",
  "once_cell",
@@ -6722,29 +5016,11 @@ dependencies = [
  "risc_v_simulator",
  "ruint",
  "system_hooks",
- "tokio",
  "zk_ee",
- "zksync-web3-rs",
  "zksync_os_api",
  "zksync_os_interface",
- "zksync_os_revm_runner",
  "zksync_os_runner",
  "zksync_os_tests_common",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -6757,7 +5033,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6814,19 +5090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6839,18 +5103,6 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]
@@ -6965,7 +5217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -6978,7 +5230,7 @@ checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.8",
  "subtle",
@@ -7021,8 +5273,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7031,9 +5283,9 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -7081,48 +5333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7162,25 +5372,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2 0.11.0",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7220,17 +5418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.9.2",
- "secp256k1-sys 0.11.0",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7244,15 +5431,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -7322,12 +5500,6 @@ dependencies = [
 
 [[package]]
 name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
-name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
@@ -7383,21 +5555,11 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7437,7 +5599,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -7515,19 +5677,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -7564,15 +5713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7601,12 +5741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7633,12 +5767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7657,26 +5785,6 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf 0.11.3",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -7721,18 +5829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7764,33 +5860,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.111",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7820,26 +5894,6 @@ dependencies = [
  "proc-macro2",
  "rhai",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs",
- "fs2",
- "hex",
- "once_cell",
- "reqwest 0.11.27",
- "semver 1.0.23",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
- "zip",
 ]
 
 [[package]]
@@ -7932,7 +5986,7 @@ dependencies = [
  "evm_interpreter",
  "paste",
  "ruint",
- "strum_macros 0.27.2",
+ "strum_macros",
  "zk_ee",
 ]
 
@@ -7953,26 +6007,6 @@ dependencies = [
  "once_cell",
  "rustix 1.1.2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -8114,7 +6148,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -8165,21 +6198,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.1",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -8190,7 +6208,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.26.2",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -8208,27 +6226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8239,26 +6236,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.12.1",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
@@ -8271,12 +6254,6 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -8420,26 +6397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.1.10",
- "tracing",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "tracing-core",
 ]
 
 [[package]]
@@ -8467,26 +6424,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls 0.21.12",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -8625,12 +6562,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -8670,16 +6601,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.16",
- "serde",
-]
 
 [[package]]
 name = "uuid"
@@ -8752,16 +6673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -8955,37 +6866,6 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -9335,7 +7215,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 2.0.17",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -9367,12 +7247,6 @@ dependencies = [
  "encoding_rs",
  "hashlink",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yoke"
@@ -9492,26 +7366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
 name = "zk_ee"
 version = "0.1.0"
 dependencies = [
@@ -9523,39 +7377,7 @@ dependencies = [
  "paste",
  "ruint",
  "serde",
- "strum_macros 0.27.2",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "zksync-os-revm"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-os-revm?tag=v0.0.3#063e00193f143c30af7bfe7aa6f85d8d54967c5b"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
-
-[[package]]
-name = "zksync-web3-rs"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs.git#56653345d14331e0865a6785c77cdda63c94eeba"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap 4.5.53",
- "env_logger 0.10.2",
- "ethers",
- "ethers-contract",
- "hex",
- "lazy_static",
- "log",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "tokio",
+ "strum_macros",
 ]
 
 [[package]]
@@ -9597,24 +7419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zksync_os_revm_runner"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "anyhow",
- "basic_system",
- "blake2",
- "forward_system",
- "reth-revm",
- "reth-storage-api",
- "ruint",
- "zk_ee",
- "zksync-os-revm",
- "zksync_os_interface",
- "zksync_os_tests_common",
-]
-
-[[package]]
 name = "zksync_os_runner"
 version = "0.1.0"
 dependencies = [
@@ -9631,51 +7435,4 @@ dependencies = [
  "alloy",
  "ruint",
  "zksync_os_interface",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/tests/evm_tester/Cargo.lock
+++ b/tests/evm_tester/Cargo.lock
@@ -5009,7 +5009,6 @@ dependencies = [
  "env_logger",
  "evm_interpreter",
  "forward_system",
- "hex",
  "log",
  "once_cell",
  "oracle_provider",

--- a/tests/evm_tester/src/vm/zk_ee/mod.rs
+++ b/tests/evm_tester/src/vm/zk_ee/mod.rs
@@ -101,7 +101,7 @@ impl ZKsyncOS {
 
         let run_config = RunConfig {
             app: Some("evm_tester".to_string()),
-            only_forward: !proof_run,
+            do_riscv_run: proof_run,
             check_storage_diff_hashes: proof_run,
             ..Default::default()
         };

--- a/tests/fuzzer/fuzz/fuzz_targets/precompiles/common/mod.rs
+++ b/tests/fuzzer/fuzz/fuzz_targets/precompiles/common/mod.rs
@@ -68,7 +68,7 @@ pub fn run_precompile(id: &str, input: &[u8]) -> BlockOutput {
 
     let run_config = rig::chain::RunConfig {
         app: Some("for_tests".to_string()),
-        only_forward: false,
+        do_riscv_run: true,
         check_storage_diff_hashes: true,
         ..Default::default()
     };

--- a/tests/instances/bench/src/lib.rs
+++ b/tests/instances/bench/src/lib.rs
@@ -1,11 +1,11 @@
 #![cfg(test)]
 use rig::{
     alloy::{self, primitives::TxKind, rpc::types::TransactionRequest},
-    forward_system::run::convert_alloy::FromAlloy,
-    ruint::aliases::{B160, U256},
+    ruint::aliases::U256,
+    ZKsyncOSTester,
 };
 use std::path::PathBuf;
-use zksync_os_tests_common::zksync_tx::{encoding::ZKsyncOsEncodable, ZKsyncTxEnvelope};
+use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 // WASM disabled for now
 // #[test]
@@ -87,17 +87,14 @@ use zksync_os_tests_common::zksync_tx::{encoding::ZKsyncOsEncodable, ZKsyncTxEnv
 
 #[test]
 fn fibish_sol() {
-    let mut chain = rig::Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let c_addr = alloy::primitives::Address::from(alloy::primitives::U160::from(1));
     let c_bytes = rig::utils::load_sol_bytecode("bench", "arith");
-    chain
-        .set_evm_bytecode(B160::from_alloy(c_addr), &c_bytes)
-        .set_balance(
-            B160::from_alloy(wallet.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+    tester = tester
+        .with_evm_contract(c_addr, &c_bytes)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     let tx = TransactionRequest {
         to: Some(TxKind::Call(c_addr)),
@@ -116,7 +113,7 @@ fn fibish_sol() {
         ..Default::default()
     };
 
-    let encoded_tx = ZKsyncTxEnvelope::from_eth_tx_from_req(tx, wallet).encode();
+    let tx = ZKsyncTxEnvelope::from_eth_tx_from_req(tx, wallet);
 
     let mut pc = rig::ProfilerConfig::new(PathBuf::from(format!(
         "{}/os_profile_fibish_sol.svg",
@@ -127,5 +124,6 @@ fn fibish_sol() {
         profiler_config: Some(pc),
         ..Default::default()
     };
-    chain.run_block(vec![encoded_tx], None, None, Some(run_config));
+    tester = tester.with_run_config(run_config);
+    tester.execute_block(vec![tx]);
 }

--- a/tests/instances/bench/src/lib.rs
+++ b/tests/instances/bench/src/lib.rs
@@ -2,7 +2,7 @@
 use rig::{
     alloy::{self, primitives::TxKind, rpc::types::TransactionRequest},
     ruint::aliases::U256,
-    ZKsyncOSTester,
+    TestingFramework,
 };
 use std::path::PathBuf;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
@@ -87,7 +87,7 @@ use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[test]
 fn fibish_sol() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let c_addr = alloy::primitives::Address::from(alloy::primitives::U160::from(1));

--- a/tests/instances/erc20/src/lib.rs
+++ b/tests/instances/erc20/src/lib.rs
@@ -5,14 +5,14 @@ use rig::{
         rpc::types::TransactionRequest,
     },
     ruint::aliases::U256,
-    ZKsyncOSTester,
+    TestingFramework,
 };
 use std::path::PathBuf;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[test]
 fn get_name_sol() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let erc20_addr = address!("0000000000000000000000000000000000000001");
@@ -81,7 +81,7 @@ fn get_name_sol() {
 
 #[test]
 fn balance_of_sol() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let erc20_addr = address!("0000000000000000000000000000000000000001");
@@ -193,7 +193,7 @@ fn balance_of_sol() {
 
 #[test]
 fn transfer_sol() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet_a = tester.random_signer();
     let wallet_b = tester.random_signer();
 

--- a/tests/instances/erc20/src/lib.rs
+++ b/tests/instances/erc20/src/lib.rs
@@ -4,25 +4,22 @@ use rig::{
         primitives::{address, TxKind},
         rpc::types::TransactionRequest,
     },
-    forward_system::run::convert_alloy::FromAlloy,
-    ruint::aliases::{B160, U256},
+    ruint::aliases::U256,
+    ZKsyncOSTester,
 };
 use std::path::PathBuf;
-use zksync_os_tests_common::zksync_tx::{encoding::ZKsyncOsEncodable, ZKsyncTxEnvelope};
+use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[test]
 fn get_name_sol() {
-    let mut chain = rig::Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let erc20_addr = address!("0000000000000000000000000000000000000001");
     let erc20_bytecode = rig::utils::load_sol_bytecode("erc20", "erc20");
-    chain
-        .set_evm_bytecode(B160::from_alloy(erc20_addr), &erc20_bytecode)
-        .set_balance(
-            B160::from_alloy(wallet.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+    tester = tester
+        .with_evm_contract(erc20_addr, &erc20_bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     let tx_get_name = ZKsyncTxEnvelope::from_eth_tx_from_req(
         TransactionRequest {
@@ -34,8 +31,7 @@ fn get_name_sol() {
             ..Default::default()
         },
         wallet,
-    )
-    .encode();
+    );
 
     let mut pc = rig::ProfilerConfig::new(PathBuf::from(format!(
         "{}/os_profile_get_name_sol.svg",
@@ -46,7 +42,8 @@ fn get_name_sol() {
         profiler_config: Some(pc),
         ..Default::default()
     };
-    chain.run_block(vec![tx_get_name], None, None, Some(run_config));
+    tester = tester.with_run_config(run_config);
+    tester.execute_block(vec![tx_get_name]);
 }
 
 // WASM disabled for now
@@ -84,17 +81,14 @@ fn get_name_sol() {
 
 #[test]
 fn balance_of_sol() {
-    let mut chain = rig::Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let erc20_addr = address!("0000000000000000000000000000000000000001");
     let erc20_bytecode = rig::utils::load_sol_bytecode("erc20", "erc20");
-    chain
-        .set_evm_bytecode(B160::from_alloy(erc20_addr), &erc20_bytecode)
-        .set_balance(
-            B160::from_alloy(wallet.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+    tester = tester
+        .with_evm_contract(erc20_addr, &erc20_bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     let tx_mint = ZKsyncTxEnvelope::from_eth_tx_from_req(
         TransactionRequest {
@@ -113,8 +107,7 @@ fn balance_of_sol() {
             ..Default::default()
         },
         wallet.clone(),
-    )
-    .encode();
+    );
 
     let tx_balance = ZKsyncTxEnvelope::from_eth_tx_from_req(
         TransactionRequest {
@@ -130,8 +123,7 @@ fn balance_of_sol() {
             ..Default::default()
         },
         wallet,
-    )
-    .encode();
+    );
 
     let mut pc = rig::ProfilerConfig::new(PathBuf::from(format!(
         "{}/os_profile_balance_of_sol.svg",
@@ -142,7 +134,8 @@ fn balance_of_sol() {
         profiler_config: Some(pc),
         ..Default::default()
     };
-    chain.run_block(vec![tx_mint, tx_balance], None, None, Some(run_config));
+    tester = tester.with_run_config(run_config);
+    tester.execute_block(vec![tx_mint, tx_balance]);
 }
 
 // WASM disabled for now
@@ -200,18 +193,15 @@ fn balance_of_sol() {
 
 #[test]
 fn transfer_sol() {
-    let mut chain = rig::Chain::empty(None);
-    let wallet_a = chain.random_signer();
-    let wallet_b = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet_a = tester.random_signer();
+    let wallet_b = tester.random_signer();
 
     let erc20_addr = address!("0000000000000000000000000000000000000001");
     let erc20_bytecode = rig::utils::load_sol_bytecode("erc20", "erc20");
-    chain
-        .set_evm_bytecode(B160::from_alloy(erc20_addr), &erc20_bytecode)
-        .set_balance(
-            B160::from_alloy(wallet_a.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+    tester = tester
+        .with_evm_contract(erc20_addr, &erc20_bytecode)
+        .with_balance(wallet_a.address(), U256::from(1_000_000_000_000_000_u64));
 
     let tx_mint = ZKsyncTxEnvelope::from_eth_tx_from_req(
         TransactionRequest {
@@ -230,8 +220,7 @@ fn transfer_sol() {
             ..Default::default()
         },
         wallet_a.clone(),
-    )
-    .encode();
+    );
 
     let tx_transfer = ZKsyncTxEnvelope::from_eth_tx_from_req(
         TransactionRequest {
@@ -250,8 +239,7 @@ fn transfer_sol() {
             ..Default::default()
         },
         wallet_a,
-    )
-    .encode();
+    );
 
     let mut pc = rig::ProfilerConfig::new(PathBuf::from(format!(
         "{}/os_profile_transfer_sol.svg",
@@ -262,7 +250,8 @@ fn transfer_sol() {
         profiler_config: Some(pc),
         ..Default::default()
     };
-    chain.run_block(vec![tx_mint, tx_transfer], None, None, Some(run_config));
+    tester = tester.with_run_config(run_config);
+    tester.execute_block(vec![tx_mint, tx_transfer]);
 }
 
 // WASM disabled for now

--- a/tests/instances/eth_runner/Cargo.lock
+++ b/tests/instances/eth_runner/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,17 +22,6 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
 
 [[package]]
 name = "ahash"
@@ -111,7 +90,7 @@ checksum = "ef3a72a2247c34a8545ee99e562b1b9b69168e5000567257ae51e91b4e6b1193"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -269,7 +248,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 2.0.18",
 ]
 
@@ -418,7 +397,7 @@ dependencies = [
  "lru",
  "parking_lot 0.12.5",
  "pin-project 1.1.10",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -487,7 +466,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project 1.1.10",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -587,7 +566,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "rand 0.8.5",
  "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -858,7 +837,7 @@ checksum = "0a18b541a6197cf9a084481498a766fdf32fefda0c35ea6096df7d511025e9f1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -897,7 +876,7 @@ dependencies = [
  "http 1.4.0",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
  "ws_stream_wasm",
 ]
@@ -1265,15 +1244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,7 +1380,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.19.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1477,7 +1447,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2 0.10.9",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -1647,7 +1617,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1666,7 +1636,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -1676,12 +1646,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1726,7 +1690,7 @@ dependencies = [
  "ruint",
  "serde",
  "serde-big-array",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zk_ee",
 ]
@@ -1752,17 +1716,11 @@ dependencies = [
  "ruint",
  "serde",
  "storage_models",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zerocopy",
  "zk_ee",
 ]
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bigint_with_control"
@@ -1812,27 +1770,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1910,15 +1853,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1959,16 +1893,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2 0.10.9",
- "tinyvec",
 ]
 
 [[package]]
@@ -2015,26 +1939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "c-kzg"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,38 +1968,6 @@ dependencies = [
  "risc_v_simulator",
  "ruint",
  "zk_ee",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2136,16 +2008,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -2206,13 +2068,13 @@ dependencies = [
  "base64 0.21.7",
  "blake2s_u32",
  "clap",
- "env_logger 0.11.8",
+ "env_logger",
  "execution_utils",
  "field",
  "gpu_prover",
  "prover",
  "prover_examples",
- "reqwest 0.12.28",
+ "reqwest",
  "risc_v_cycles",
  "serde",
  "serde_json",
@@ -2230,58 +2092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "coins-bip32"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
-dependencies = [
- "bs58",
- "coins-core",
- "digest 0.10.7",
- "hmac",
- "k256",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-bip39"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
-dependencies = [
- "bitvec",
- "coins-bip32",
- "hmac",
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-core"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bs58",
- "digest 0.10.7",
- "generic-array",
- "hex",
- "ripemd",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "sha3",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2393,12 +2203,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -2567,7 +2371,7 @@ dependencies = [
  "p256",
  "ripemd",
  "ruint",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "zeroize",
 ]
@@ -2638,15 +2442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -2789,31 +2584,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.1.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -2845,52 +2620,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2995,39 +2728,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enr"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "hex",
- "k256",
- "log",
- "rand 0.8.5",
- "rlp",
- "serde",
- "sha3",
- "zeroize",
 ]
 
 [[package]]
@@ -3058,19 +2764,6 @@ checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -3123,28 +2816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest 0.10.7",
- "hex",
- "hmac",
- "pbkdf2 0.11.0",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "sha3",
- "thiserror 1.0.69",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "eth_runner"
 version = "0.1.0"
 dependencies = [
@@ -3156,8 +2827,7 @@ dependencies = [
  "bincode 2.0.1",
  "clap",
  "csv",
- "hex",
- "reqwest 0.12.28",
+ "reqwest",
  "rig",
  "ruint",
  "serde",
@@ -3168,55 +2838,7 @@ dependencies = [
  "ureq",
  "zerocopy",
  "zk_ee",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "scale-info",
- "uint",
+ "zstd",
 ]
 
 [[package]]
@@ -3226,8 +2848,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
- "ring 0.17.14",
- "sha2 0.10.9",
+ "ring",
+ "sha2",
 ]
 
 [[package]]
@@ -3271,254 +2893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "once_cell",
- "pin-project 1.1.10",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core",
- "ethers-etherscan",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "syn 2.0.114",
- "toml",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "syn 2.0.114",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest 0.11.27",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http 0.2.12",
- "instant",
- "jsonwebtoken 8.3.0",
- "once_cell",
- "pin-project 1.1.10",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.20.1",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve",
- "eth-keystore",
- "ethers-core",
- "rand 0.8.5",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
-]
-
-[[package]]
 name = "evm_interpreter"
 version = "0.1.0"
 dependencies = [
@@ -3528,9 +2902,8 @@ dependencies = [
  "either",
  "paste",
  "ruint",
- "strum_macros 0.27.2",
+ "strum_macros",
  "zk_ee",
- "zksync_os_evm_errors",
 ]
 
 [[package]]
@@ -3544,16 +2917,6 @@ dependencies = [
  "serde_json",
  "trace_and_split",
  "verifier_common",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -3655,12 +3018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,7 +3080,7 @@ dependencies = [
  "paste",
  "ruint",
  "serde",
- "strum_macros 0.27.2",
+ "strum_macros",
  "system_hooks",
  "zk_ee",
  "zksync_os_evm_errors",
@@ -3796,16 +3153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,16 +3174,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -3881,12 +3218,12 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hyper 1.8.1",
- "jsonwebtoken 9.3.1",
+ "hyper",
+ "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.28",
+ "reqwest",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -3954,18 +3291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gpu_prover"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
@@ -3999,25 +3324,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -4074,15 +3380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4128,15 +3425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4207,36 +3495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,7 +3504,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4261,32 +3519,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.5",
 ]
@@ -4297,7 +3541,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4312,7 +3556,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4333,13 +3577,13 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -4488,24 +3732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,12 +3741,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -4556,7 +3776,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
- "env_logger 0.11.8",
+ "env_logger",
  "indexmap 2.13.0",
  "itoa",
  "log",
@@ -4565,15 +3785,6 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -4617,17 +3828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4638,15 +3838,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4730,28 +3921,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem 3.0.6",
- "ring 0.17.14",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -4768,8 +3945,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -4790,42 +3966,6 @@ dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-rv32-asm"
@@ -4852,16 +3992,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
-]
 
 [[package]]
 name = "libusb1-sys"
@@ -4953,16 +4083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5043,12 +4163,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -5139,7 +4253,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5206,37 +4319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5287,12 +4369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "oracle_provider"
 version = "0.1.0"
 dependencies = [
@@ -5315,7 +4391,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -5395,58 +4471,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "pem"
@@ -5484,16 +4512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5501,48 +4519,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -5664,22 +4640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,9 +4656,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -5708,7 +4665,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5748,8 +4705,8 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
@@ -5863,7 +4820,7 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "bincode 1.3.3",
- "bit-set 0.8.0",
+ "bit-set",
  "blake2s_u32",
  "cs",
  "fft",
@@ -5932,7 +4889,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
@@ -5950,9 +4907,9 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
- "ring 0.17.14",
+ "ring",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6121,17 +5078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "reduced_risc_v_log_23_machine"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
@@ -6212,47 +5158,6 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -6263,12 +5168,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -6279,16 +5184,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -6358,44 +5263,24 @@ dependencies = [
  "alloy-sol-types",
  "basic_bootloader",
  "basic_system",
- "bincode 1.3.3",
  "callable_oracles",
  "cli",
  "crypto",
- "env_logger 0.11.8",
+ "env_logger",
  "evm_interpreter",
  "forward_system",
- "futures",
  "gpu_prover",
- "hex",
  "log",
  "once_cell",
  "oracle_provider",
  "risc_v_simulator",
  "ruint",
  "system_hooks",
- "tokio",
  "zk_ee",
- "zksync-web3-rs",
  "zksync_os_api",
  "zksync_os_interface",
  "zksync_os_runner",
  "zksync_os_tests_common",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -6408,7 +5293,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6465,19 +5350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6575,27 +5448,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.14",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -6613,15 +5474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6633,23 +5485,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -6697,48 +5539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6776,28 +5576,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2 0.11.0",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "sec1"
@@ -6898,10 +5676,6 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "semver-parser"
@@ -6911,12 +5685,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -6980,15 +5748,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7078,19 +5837,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -7137,16 +5883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7173,12 +5909,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -7243,26 +5973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7305,18 +6015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot 0.12.5",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7324,33 +6022,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.114",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7380,26 +6056,6 @@ dependencies = [
  "proc-macro2",
  "rhai",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs",
- "fs2",
- "hex",
- "once_cell",
- "reqwest 0.11.27",
- "semver 1.0.27",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
- "zip",
 ]
 
 [[package]]
@@ -7438,12 +6094,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -7464,34 +6114,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -7513,7 +6142,7 @@ dependencies = [
  "evm_interpreter",
  "paste",
  "ruint",
- "strum_macros 0.27.2",
+ "strum_macros",
  "zk_ee",
 ]
 
@@ -7534,26 +6163,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -7686,7 +6295,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -7715,21 +6323,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 
@@ -7747,32 +6345,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.1",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
- "tungstenite 0.26.2",
+ "tokio-rustls",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -7790,27 +6373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7821,26 +6383,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
@@ -7855,12 +6403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7870,11 +6412,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7883,7 +6425,7 @@ dependencies = [
  "rustls-native-certs",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -7902,7 +6444,7 @@ dependencies = [
  "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -8010,16 +6552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.1.10",
- "tracing",
-]
-
-[[package]]
 name = "transcript"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
@@ -8072,26 +6604,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls 0.21.12",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -8102,7 +6614,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -8134,7 +6646,7 @@ dependencies = [
  "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
@@ -8234,12 +6746,6 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -8261,7 +6767,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8317,16 +6823,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.17",
- "serde",
-]
 
 [[package]]
 name = "uuid"
@@ -8405,16 +6901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -8549,12 +7035,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -8592,15 +7072,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -8680,15 +7151,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8712,21 +7174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -8764,12 +7211,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8782,12 +7223,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8797,12 +7232,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8830,12 +7259,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8845,12 +7268,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8866,12 +7283,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8881,12 +7292,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8907,16 +7312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8952,7 +7347,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -8973,12 +7368,6 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yoke"
@@ -9098,26 +7487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
 name = "zk_ee"
 version = "0.1.0"
 dependencies = [
@@ -9129,29 +7498,7 @@ dependencies = [
  "paste",
  "ruint",
  "serde",
- "strum_macros 0.27.2",
- "zksync_os_evm_errors",
-]
-
-[[package]]
-name = "zksync-web3-rs"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs.git#56653345d14331e0865a6785c77cdda63c94eeba"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "env_logger 0.10.2",
- "ethers",
- "ethers-contract",
- "hex",
- "lazy_static",
- "log",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "tokio",
+ "strum_macros",
 ]
 
 [[package]]
@@ -9219,30 +7566,11 @@ checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/tests/instances/eth_runner/Cargo.toml
+++ b/tests/instances/eth_runner/Cargo.toml
@@ -15,14 +15,13 @@ ruint = { version = "1.16", default-features = false }
 
 alloy = { version = "1", features = ["full", "ssz"]}
 alloy-rpc-types-eth = { version = "*", features = ["serde"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["unbounded_depth"] }
 rig = { path = "../../rig", features = ["eth_runner"]}
 zk_ee = { path = "../../../zk_ee" }
 basic_system = { path = "../../../basic_system" }
 system_hooks = {path = "../../../system_hooks" }
 clap = { version = "4.4", features = ["derive"] }
 anyhow = "=1.0.89"
-hex = "*"
 ureq = { version = "3", features = ["json", "gzip"] }
 sled = {version = "0.34" }
 bincode = { version = "2", features = ["serde"] }

--- a/tests/instances/eth_runner/src/live_run/block_execution.rs
+++ b/tests/instances/eth_runner/src/live_run/block_execution.rs
@@ -125,7 +125,7 @@ pub fn run_block(
     
     let run_config = rig::chain::RunConfig {
         witness_output_file: output_path,
-        only_forward,
+        do_riscv_run: !only_forward,
         app: Some("evm_replay".to_string()),
         check_storage_diff_hashes: true,
         ..Default::default()

--- a/tests/instances/eth_runner/src/single_run.rs
+++ b/tests/instances/eth_runner/src/single_run.rs
@@ -42,7 +42,7 @@ fn run<const RANDOMIZED: bool>(
     });
     let run_config = rig::chain::RunConfig {
         witness_output_file: output_path,
-        only_forward: false,
+        do_riscv_run: true,
         app: Some("evm_replay".to_string()),
         check_storage_diff_hashes: true,
         ..Default::default()

--- a/tests/instances/evm/src/lib.rs
+++ b/tests/instances/evm/src/lib.rs
@@ -9,7 +9,6 @@ use rig::alloy::hex::FromHex;
 use rig::alloy::primitives::FixedBytes;
 use rig::alloy_sol_types::sol;
 use rig::alloy_sol_types::SolCall;
-use rig::default_run_config;
 use rig::zksync_os_interface::types::ExecutionOutput;
 use rig::zksync_os_interface::types::ExecutionResult;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
@@ -104,8 +103,7 @@ fn test_blockhash() {
     }
     tester = tester
         .with_block_number(block_number)
-        .with_block_hashes(block_hashes)
-        .with_run_config(default_run_config());
+        .with_block_hashes(block_hashes);
 
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok(),);
@@ -393,7 +391,6 @@ fn bench_addmod() {
         .collect();
 
     // Run them all in one block
-    tester = tester.with_run_config(default_run_config());
     let _result = tester.execute_block(txs);
 }
 
@@ -768,7 +765,6 @@ fn bench_mulmod() {
         .collect();
 
     // Run all calls in one block
-    tester = tester.with_run_config(default_run_config());
     let _result = tester.execute_block(txs);
 }
 
@@ -893,7 +889,6 @@ fn bench_signextend() {
         })
         .collect();
 
-    tester = tester.with_run_config(default_run_config());
     let _result = tester.execute_block(txs);
 }
 
@@ -955,9 +950,7 @@ fn test_eip4844_blobhash() {
         blob_fee: U256::from(1000),
         ..Default::default()
     };
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    tester = tester.with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok(),);
     let tx_result = result.tx_results[0].as_ref().unwrap();

--- a/tests/instances/evm/src/lib.rs
+++ b/tests/instances/evm/src/lib.rs
@@ -102,7 +102,7 @@ fn test_blockhash() {
         block_hashes[i as usize] = U256::from(n);
     }
     tester = tester
-        .with_block_number(block_number)
+        .with_next_block_number(block_number)
         .with_block_hashes(block_hashes);
 
     let result = tester.execute_block(vec![tx]);

--- a/tests/instances/evm/src/lib.rs
+++ b/tests/instances/evm/src/lib.rs
@@ -13,13 +13,13 @@ use rig::zksync_os_interface::types::ExecutionOutput;
 use rig::zksync_os_interface::types::ExecutionResult;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 use rig::BlockContext;
-use rig::{alloy::primitives::address, ruint::aliases::U256, ZKsyncOSTester};
+use rig::{alloy::primitives::address, ruint::aliases::U256, TestingFramework};
 
 #[test]
 fn test_blockhash() {
     // Check that all the last 256 block hashes are accessible and the previous to that/
     // current are out of range.
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
 
     // Code of contract used for testing
     //   contract BlockhashTester {
@@ -137,7 +137,7 @@ fn bench_addmod() {
     }
 
     // Chain setup
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
     tester = tester
@@ -735,7 +735,7 @@ fn bench_mulmod() {
     ];
 
     // --- Chain setup
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
 
@@ -860,7 +860,7 @@ fn bench_signextend() {
     ];
 
     // --- Chain setup + deploy
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
 
@@ -894,7 +894,7 @@ fn bench_signextend() {
 
 #[test]
 fn test_eip4844_blobhash() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
 
     // Test funding signer
     let wallet = tester.random_signer();

--- a/tests/instances/evm/src/lib.rs
+++ b/tests/instances/evm/src/lib.rs
@@ -9,23 +9,18 @@ use rig::alloy::hex::FromHex;
 use rig::alloy::primitives::FixedBytes;
 use rig::alloy_sol_types::sol;
 use rig::alloy_sol_types::SolCall;
-use rig::forward_system::run::convert_alloy::FromAlloy;
+use rig::default_run_config;
 use rig::zksync_os_interface::types::ExecutionOutput;
 use rig::zksync_os_interface::types::ExecutionResult;
-use rig::zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 use rig::BlockContext;
-use rig::Chain;
-use rig::{
-    alloy::primitives::address,
-    ruint::aliases::{B160, U256},
-};
+use rig::{alloy::primitives::address, ruint::aliases::U256, ZKsyncOSTester};
 
 #[test]
 fn test_blockhash() {
     // Check that all the last 256 block hashes are accessible and the previous to that/
     // current are out of range.
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::new();
 
     // Code of contract used for testing
     //   contract BlockhashTester {
@@ -78,16 +73,14 @@ fn test_blockhash() {
         call.abi_encode()
     };
 
-    let wallet = chain.random_signer();
+    let wallet = tester.random_signer();
 
     let to = address!("0x1000000000000000000000000000000000000000");
 
     // Set a reasonable balance that would be sufficient for normal transactions
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(to, &bytecode);
 
     let tx = ZKsyncTxEnvelope::from_eth_tx(
         TxLegacy {
@@ -100,27 +93,21 @@ fn test_blockhash() {
             input: calldata.into(),
         },
         wallet.clone(),
-    )
-    .encode();
+    );
 
     // We set block number to 300, to have > 256 block hashes to query
     let block_number = 300;
-    chain.set_last_block_number(block_number - 1);
-
     let mut block_hashes = [U256::ZERO; 256];
     for i in 0..256 {
         let n = block_number - (256 - i);
         block_hashes[i as usize] = U256::from(n);
     }
-    chain.set_block_hashes(block_hashes);
+    tester = tester
+        .with_block_number(block_number)
+        .with_block_hashes(block_hashes)
+        .with_run_config(default_run_config());
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    let result = chain.run_block(vec![tx], None, None, Some(run_config));
+    let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok(),);
 
     let tx_result = result.tx_results[0].as_ref().unwrap();
@@ -152,18 +139,16 @@ fn bench_addmod() {
     }
 
     // Chain setup
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000u64))
+        .with_evm_contract(to, &bytecode);
 
     // Some handy builders for U256
     let shl = |bits: u32| U256::from(1u64) << bits;
-    let ones = |bits: u32| (shl(bits) - U256::from(1u64)); // ((1<<bits) - 1)
+    let ones = |bits: u32| shl(bits) - U256::from(1u64); // ((1<<bits) - 1)
     let max = ones(256);
 
     // “Interesting” vectors that tickle 32-bit costs (carry storms, divider sizes, edge cases)
@@ -404,18 +389,12 @@ fn bench_addmod() {
                 },
                 wallet.clone(),
             )
-            .encode()
         })
         .collect();
 
     // Run them all in one block
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    let _result = chain.run_block(txs, None, None, Some(run_config));
+    tester = tester.with_run_config(default_run_config());
+    let _result = tester.execute_block(txs);
 }
 
 #[ignore = "benchmark for native constants"]
@@ -434,7 +413,7 @@ fn bench_mulmod() {
 
     // Helpers for vectors
     let shl = |bits: u32| U256::from(1u64) << bits;
-    let ones = |bits: u32| (shl(bits) - U256::from(1u64));
+    let ones = |bits: u32| shl(bits) - U256::from(1u64);
     let max = ones(256);
 
     // Byte-pattern helpers that keep limb0 ≠ 0
@@ -759,15 +738,13 @@ fn bench_mulmod() {
     ];
 
     // --- Chain setup
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000u64))
+        .with_evm_contract(to, &bytecode);
 
     // Build txs with unique nonces
     let txs: Vec<_> = vectors
@@ -787,18 +764,12 @@ fn bench_mulmod() {
                 },
                 wallet.clone(),
             )
-            .encode()
         })
         .collect();
 
     // Run all calls in one block
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    let _result = chain.run_block(txs, None, None, Some(run_config));
+    tester = tester.with_run_config(default_run_config());
+    let _result = tester.execute_block(txs);
 }
 
 #[test]
@@ -893,15 +864,13 @@ fn bench_signextend() {
     ];
 
     // --- Chain setup + deploy
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let to = address!("0x1000000000000000000000000000000000000000");
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000u64))
+        .with_evm_contract(to, &bytecode);
 
     // Build signed txs (unique nonces)
     let txs: Vec<_> = vectors
@@ -921,25 +890,19 @@ fn bench_signextend() {
                 },
                 wallet.clone(),
             )
-            .encode()
         })
         .collect();
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    let _result = chain.run_block(txs, None, None, Some(run_config));
+    tester = tester.with_run_config(default_run_config());
+    let _result = tester.execute_block(txs);
 }
 
 #[test]
 fn test_eip4844_blobhash() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::new();
 
     // Test funding signer
-    let wallet = chain.random_signer();
+    let wallet = tester.random_signer();
 
     // Deploy address for the contract in this test (set to some deterministic slot)
     let inspector_addr = address!("0000000000000000000000000000000000010003");
@@ -957,11 +920,9 @@ fn test_eip4844_blobhash() {
     // }
     let bytecode: Vec<u8> = hex::decode("608060405260043610601b575f3560e01c8063ab3ae25514601f575b5f5ffd5b60356004803603810190603191906073565b6037565b005b8049805f5260205ff35b5f5ffd5b5f819050919050565b6055816045565b8114605e575f5ffd5b50565b5f81359050606d81604e565b92915050565b5f6020828403121560855760846041565b5b5f6090848285016061565b9150509291505056fea26469706673582212209d46704950c75b3505742b2236950b59adbcc17d023f976acb6b5c43bca401fc64736f6c634300081e0033").unwrap();
 
-    chain.set_evm_bytecode(B160::from_alloy(inspector_addr), &bytecode);
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester
+        .with_evm_contract(inspector_addr, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     sol! {
         contract BlobHashEcho {
@@ -988,19 +949,16 @@ fn test_eip4844_blobhash() {
         blob_versioned_hashes: vec![versioned_hash],
         max_fee_per_blob_gas: 1_000,
     };
-    let tx = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode();
+    let tx = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone());
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
     let block_context = BlockContext {
         blob_fee: U256::from(1000),
         ..Default::default()
     };
-    let result = chain.run_block(vec![tx], Some(block_context), None, Some(run_config));
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(default_run_config());
+    let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok(),);
     let tx_result = result.tx_results[0].as_ref().unwrap();
     assert!(tx_result.is_success(), "Transaction should be successful");

--- a/tests/instances/forge_tests/src/lib.rs
+++ b/tests/instances/forge_tests/src/lib.rs
@@ -2,31 +2,24 @@
 use alloy::consensus::{TxEip1559, TxEip2930};
 use alloy::primitives::{address, TxKind, U256};
 use alloy::signers::local::PrivateKeySigner;
-use rig::forward_system::run::convert_alloy::FromAlloy;
-use rig::ruint::aliases::B160;
-use rig::zksync_os_interface::traits::EncodedTx;
+use rig::alloy;
+use rig::ruint;
 use rig::zksync_os_interface::types::BlockOutput;
-use rig::zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use rig::{alloy, ruint};
 use std::collections::HashSet;
 use std::str::FromStr;
 use zk_ee::common_structs::derive_flat_storage_key;
 use zk_ee::utils::Bytes32;
 
 ///
-/// Mints base tokens to `eoa_address` and runs `encoded_txs`
+/// Mints base tokens to `eoa_address` and runs `txs`
 ///
 fn run_transactions_as_eoa(
     eoa_address: alloy::primitives::Address,
-    encoded_txs: Vec<EncodedTx>,
+    txs: Vec<ZKsyncTxEnvelope>,
 ) -> BlockOutput {
-    let mut chain = rig::Chain::empty(None);
-    chain.set_balance(
-        B160::from_alloy(eoa_address),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.run_block(encoded_txs, None, None, None)
+    let mut tester = rig::ZKsyncOSTester::new().with_prefunded_account(eoa_address);
+    tester.execute_block(txs)
 }
 
 fn address_to_bytecodehash_key(address: &alloy::primitives::Address) -> Bytes32 {
@@ -61,8 +54,7 @@ fn run_forge_test_create_many_contracts() {
             .unwrap()
             .into(),
     };
-    let encoded_deployment_tx =
-        ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone()).encode();
+    let encoded_deployment_tx = ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone());
 
     let run_tx = TxEip1559 {
         chain_id: 37u64,
@@ -76,7 +68,7 @@ fn run_forge_test_create_many_contracts() {
         // 'run()'
         input: hex::decode("c0406226").unwrap().into(),
     };
-    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone()).encode();
+    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone());
 
     let output = run_transactions_as_eoa(
         eoa_wallet.address(),
@@ -129,8 +121,7 @@ fn run_forge_test_create_in_constructor() {
             .unwrap()
             .into(),
     };
-    let encoded_deployment_tx =
-        ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone()).encode();
+    let encoded_deployment_tx = ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone());
 
     let run_tx = TxEip1559 {
         chain_id: 37u64,
@@ -144,7 +135,7 @@ fn run_forge_test_create_in_constructor() {
         // 'run()'
         input: hex::decode("c0406226").unwrap().into(),
     };
-    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone()).encode();
+    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone());
 
     let output = run_transactions_as_eoa(
         eoa_wallet.address(),
@@ -202,8 +193,7 @@ fn run_forge_test_delegate_calls() {
             .unwrap()
             .into(),
     };
-    let encoded_deployment_tx =
-        ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone()).encode();
+    let encoded_deployment_tx = ZKsyncTxEnvelope::from_eth_tx(deployment_tx, eoa_wallet.clone());
 
     let run_tx = TxEip1559 {
         chain_id: 37u64,
@@ -217,7 +207,7 @@ fn run_forge_test_delegate_calls() {
         // 'run()'
         input: hex::decode("c0406226").unwrap().into(),
     };
-    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone()).encode();
+    let encoded_run_tx = ZKsyncTxEnvelope::from_eth_tx(run_tx, eoa_wallet.clone());
 
     let output = run_transactions_as_eoa(
         eoa_wallet.address(),

--- a/tests/instances/forge_tests/src/lib.rs
+++ b/tests/instances/forge_tests/src/lib.rs
@@ -18,7 +18,7 @@ fn run_transactions_as_eoa(
     eoa_address: alloy::primitives::Address,
     txs: Vec<ZKsyncTxEnvelope>,
 ) -> BlockOutput {
-    let mut tester = rig::ZKsyncOSTester::new().with_prefunded_account(eoa_address);
+    let mut tester = rig::TestingFramework::new().with_prefunded_account(eoa_address);
     tester.execute_block(txs)
 }
 

--- a/tests/instances/header/src/lib.rs
+++ b/tests/instances/header/src/lib.rs
@@ -7,14 +7,13 @@ use basic_bootloader::bootloader::block_header::EMPTY_OMMER_ROOT_HASH;
 use basic_bootloader::bootloader::constants::MAX_BLOCK_GAS_LIMIT;
 use rig::alloy::primitives::{Address, B256};
 use rig::ruint::aliases::{B160, U256};
-use rig::utils::run_block_of_erc20;
-use rig::{zk_ee::utils::Bytes32, Chain};
+use rig::ZKsyncOSTester;
 
 // Run a block of ERC20 transactions and check invariants on the block header.
 #[test]
 fn test_block_header_invariants() {
-    let mut chain = Chain::empty(None);
-    let output = run_block_of_erc20::<false>(&mut chain, 10, None);
+    let mut tester = ZKsyncOSTester::new();
+    let output = tester.run_block_of_erc20(10, None);
     let header = output.header;
 
     // Check invariants on header for genesis block.
@@ -54,7 +53,7 @@ fn test_block_header_invariants() {
         gas_limit,
         ..Default::default()
     };
-    let output = run_block_of_erc20::<false>(&mut chain, 10, Some(block_context));
+    let output = tester.run_block_of_erc20(10, Some(block_context));
     let header = output.header;
     assert_eq!(header.parent_hash, genesis_hash);
     assert_eq!(header.ommers_hash, EMPTY_OMMER_ROOT_HASH);

--- a/tests/instances/header/src/lib.rs
+++ b/tests/instances/header/src/lib.rs
@@ -7,12 +7,12 @@ use basic_bootloader::bootloader::block_header::EMPTY_OMMER_ROOT_HASH;
 use basic_bootloader::bootloader::constants::MAX_BLOCK_GAS_LIMIT;
 use rig::alloy::primitives::{Address, B256};
 use rig::ruint::aliases::{B160, U256};
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 
 // Run a block of ERC20 transactions and check invariants on the block header.
 #[test]
 fn test_block_header_invariants() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let output = tester.run_block_of_erc20(10, None);
     let header = output.header;
 

--- a/tests/instances/multiblock_batch/src/lib.rs
+++ b/tests/instances/multiblock_batch/src/lib.rs
@@ -41,11 +41,7 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
     let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(RunConfig {
-            do_riscv_run: true,
-            check_storage_diff_hashes: true,
-            ..Default::default()
-        })
+        .with_run_config(RunConfig::with_riscv_run())
         .with_da_commitment_scheme(da_commitment_scheme);
 
     let block1_result = tester.execute_block(vec![mint_tx]);

--- a/tests/instances/multiblock_batch/src/lib.rs
+++ b/tests/instances/multiblock_batch/src/lib.rs
@@ -5,44 +5,26 @@
 
 use alloy::consensus::{TxEip1559, TxLegacy};
 use alloy::primitives::TxKind;
-use alloy::signers::local::PrivateKeySigner;
 use rig::alloy::primitives::address;
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::run::generate_batch_proof_input;
 use rig::log::debug;
-use rig::ruint::aliases::{B160, U256};
+use rig::ruint::aliases::U256;
 use rig::utils::{ERC_20_BYTECODE, ERC_20_MINT_CALLDATA, ERC_20_TRANSFER_CALLDATA};
 use rig::zk_ee::common_structs::DACommitmentScheme;
-use rig::zk_ee::system::tracer::NopTracer;
-use rig::zk_ee::system::validator::NopTxValidator;
-use rig::zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use rig::{alloy, zksync_web3_rs, Chain};
+use rig::{alloy, signer_from_key, ZKsyncOSTester};
 use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use std::path::PathBuf;
-use std::str::FromStr;
-use zksync_web3_rs::signers::{LocalWallet, Signer};
 
 fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
-    let mut chain = Chain::empty(None);
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
+    let wallet =
+        signer_from_key("dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7");
 
-    let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-
-    let encoded_mint_tx = {
+    let mint_tx = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -52,19 +34,21 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let block1_result = chain
-        .run_block_with_extra_stats(
-            vec![encoded_mint_tx],
-            None,
-            Some(da_commitment_scheme),
-            None,
-            &mut NopTracer::default(),
-            &mut NopTxValidator::default(),
-        )
-        .unwrap();
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(to, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_da_commitment_scheme(da_commitment_scheme);
+
+    let block1_result = tester.execute_block(vec![mint_tx]);
+    let block1_proof_input = tester
+        .last_executed_block_info()
+        .unwrap()
+        .proof_input
+        .clone();
+
     let encoded_transfer_tx = {
         let transfer_tx = TxEip1559 {
             chain_id: 37u64,
@@ -77,26 +61,22 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone())
     };
 
-    let block2_result = chain
-        .run_block_with_extra_stats(
-            vec![encoded_transfer_tx],
-            None,
-            Some(da_commitment_scheme),
-            None,
-            &mut NopTracer::default(),
-            &mut NopTxValidator::default(),
-        )
-        .unwrap();
+    let block2_result = tester.execute_block(vec![encoded_transfer_tx]);
+    let block2_proof_input = tester
+        .last_executed_block_info()
+        .unwrap()
+        .proof_input
+        .clone();
 
     let batch_input = generate_batch_proof_input(
-        vec![block1_result.2.as_slice(), block2_result.2.as_slice()],
+        vec![&block1_proof_input, &block2_proof_input],
         da_commitment_scheme,
         vec![
-            block1_result.0.pubdata.as_slice(),
-            block2_result.0.pubdata.as_slice(),
+            block1_result.pubdata.as_slice(),
+            block2_result.pubdata.as_slice(),
         ],
     );
 

--- a/tests/instances/multiblock_batch/src/lib.rs
+++ b/tests/instances/multiblock_batch/src/lib.rs
@@ -13,13 +13,12 @@ use rig::ruint::aliases::U256;
 use rig::utils::{ERC_20_BYTECODE, ERC_20_MINT_CALLDATA, ERC_20_TRANSFER_CALLDATA};
 use rig::zk_ee::common_structs::DACommitmentScheme;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use rig::{alloy, signer_from_key, TestingFramework};
+use rig::{alloy, testing_signer, TestingFramework};
 use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use std::path::PathBuf;
 
 fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
-    let wallet =
-        signer_from_key("dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7");
+    let wallet = testing_signer(0);
 
     let to = address!("0000000000000000000000000000000000010002");
 

--- a/tests/instances/multiblock_batch/src/lib.rs
+++ b/tests/instances/multiblock_batch/src/lib.rs
@@ -6,6 +6,7 @@
 use alloy::consensus::{TxEip1559, TxLegacy};
 use alloy::primitives::TxKind;
 use rig::alloy::primitives::address;
+use rig::chain::RunConfig;
 use rig::forward_system::run::generate_batch_proof_input;
 use rig::log::debug;
 use rig::ruint::aliases::U256;
@@ -40,6 +41,11 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
     let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_run_config(RunConfig {
+            do_riscv_run: true,
+            check_storage_diff_hashes: true,
+            ..Default::default()
+        })
         .with_da_commitment_scheme(da_commitment_scheme);
 
     let block1_result = tester.execute_block(vec![mint_tx]);
@@ -48,6 +54,10 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
         .unwrap()
         .proof_input
         .clone();
+    assert!(
+        !block1_proof_input.is_empty(),
+        "block1 proof input must be non-empty; proving run is required"
+    );
 
     let encoded_transfer_tx = {
         let transfer_tx = TxEip1559 {
@@ -70,6 +80,10 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
         .unwrap()
         .proof_input
         .clone();
+    assert!(
+        !block2_proof_input.is_empty(),
+        "block2 proof input must be non-empty; proving run is required"
+    );
 
     let batch_input = generate_batch_proof_input(
         vec![&block1_proof_input, &block2_proof_input],

--- a/tests/instances/multiblock_batch/src/lib.rs
+++ b/tests/instances/multiblock_batch/src/lib.rs
@@ -12,7 +12,7 @@ use rig::ruint::aliases::U256;
 use rig::utils::{ERC_20_BYTECODE, ERC_20_MINT_CALLDATA, ERC_20_TRANSFER_CALLDATA};
 use rig::zk_ee::common_structs::DACommitmentScheme;
 use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use rig::{alloy, signer_from_key, ZKsyncOSTester};
+use rig::{alloy, signer_from_key, TestingFramework};
 use risc_v_simulator::abstractions::non_determinism::QuasiUARTSource;
 use std::path::PathBuf;
 
@@ -37,7 +37,7 @@ fn run_multiblock_batch_proof_run(da_commitment_scheme: DACommitmentScheme) {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
         .with_da_commitment_scheme(da_commitment_scheme);

--- a/tests/instances/precompiles/src/lib.rs
+++ b/tests/instances/precompiles/src/lib.rs
@@ -5,7 +5,6 @@ use rig::alloy::consensus::TxLegacy;
 use rig::utils::{calldata_for_forwarder, FORWARDER_BYTECODE};
 use rig::zksync_os_interface::types::BlockOutput;
 use rig::zksync_os_interface::types::ExecutionResult::Revert;
-use rig::{BlockContext, default_run_config};
 use rig::{
     alloy::{
         primitives::{address, Address, TxKind},
@@ -14,6 +13,7 @@ use rig::{
     ruint::aliases::U256,
     ZKsyncOSTester,
 };
+use rig::{default_run_config, BlockContext};
 use std::assert_matches::assert_matches;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 

--- a/tests/instances/precompiles/src/lib.rs
+++ b/tests/instances/precompiles/src/lib.rs
@@ -2,20 +2,19 @@
 #![feature(assert_matches)]
 
 use rig::alloy::consensus::TxLegacy;
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::utils::{calldata_for_forwarder, FORWARDER_BYTECODE};
 use rig::zksync_os_interface::types::BlockOutput;
 use rig::zksync_os_interface::types::ExecutionResult::Revert;
-use rig::BlockContext;
+use rig::{BlockContext, default_run_config};
 use rig::{
     alloy::{
         primitives::{address, Address, TxKind},
         rpc::types::TransactionRequest,
     },
-    ruint::aliases::{B160, U256},
+    ruint::aliases::U256,
+    ZKsyncOSTester,
 };
 use std::assert_matches::assert_matches;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// Performs two calls:
@@ -26,19 +25,14 @@ use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockOutput {
     let gas = gas.unwrap_or(1 << 27);
 
-    let mut chain = rig::Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let target = Address::from_slice(hex::decode(precompile_id).unwrap().as_slice());
     let forwarder = address!("0x1000000000000000000000000000000000000000");
 
-    chain.set_balance(
-        FromAlloy::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(
-        FromAlloy::from_alloy(forwarder),
-        &hex::decode(FORWARDER_BYTECODE).unwrap(),
-    );
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(forwarder, &hex::decode(FORWARDER_BYTECODE).unwrap());
 
     let direct_tx = ZKsyncTxEnvelope::from_eth_tx(
         TxLegacy {
@@ -51,8 +45,7 @@ fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockO
             input: input.to_vec().into(),
         },
         wallet.clone(),
-    )
-    .encode();
+    );
 
     let calldata = calldata_for_forwarder(target, input);
     let forwarded_tx = ZKsyncTxEnvelope::from_eth_tx(
@@ -66,8 +59,7 @@ fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockO
             input: calldata.into(),
         },
         wallet.clone(),
-    )
-    .encode();
+    );
 
     // We use a very high native per gas ratio
     let block_context = BlockContext {
@@ -76,18 +68,12 @@ fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockO
         ..Default::default()
     };
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    chain.run_block(
-        vec![direct_tx, forwarded_tx],
-        Some(block_context),
-        None,
-        Some(run_config),
-    )
+    let run_config = default_run_config();
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config);
+
+    tester.execute_block(vec![direct_tx, forwarded_tx])
 }
 
 struct Test {
@@ -6130,13 +6116,9 @@ fn test_precompile_parses_input_correctly() {
         let empty_input = [0u8; 193];
 
         for i in length {
-            let mut chain = rig::Chain::empty(None);
-            let wallet = chain.random_signer();
-
-            chain.set_balance(
-                B160::from_alloy(wallet.address()),
-                U256::from(1_000_000_000_000_000_u64),
-            );
+            let mut tester = ZKsyncOSTester::new();
+            let wallet = tester.random_signer();
+            tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
             let tx = ZKsyncTxEnvelope::from_eth_tx_from_req(
                 TransactionRequest {
@@ -6148,10 +6130,9 @@ fn test_precompile_parses_input_correctly() {
                     ..Default::default()
                 },
                 wallet,
-            )
-            .encode();
+            );
 
-            let _block_output = chain.run_block(vec![tx], None, None, None);
+            let _block_output = tester.execute_block(vec![tx]);
         }
     }
 }
@@ -6413,8 +6394,8 @@ fn bench_modexp() {
 
 #[test]
 fn test_regression_p256_is_warm() {
-    let mut chain = rig::Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let target = Address::from_slice(
         hex::decode("0000000000000000000000000000000000000100")
             .unwrap()
@@ -6422,14 +6403,9 @@ fn test_regression_p256_is_warm() {
     );
     let forwarder = address!("0x1000000000000000000000000000000000000000");
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(
-        B160::from_alloy(forwarder),
-        &hex::decode(FORWARDER_BYTECODE).unwrap(),
-    );
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(forwarder, &hex::decode(FORWARDER_BYTECODE).unwrap());
 
     // Just enough for tx to succeed if the address is warm
     let gas_limit = 54707;
@@ -6447,8 +6423,7 @@ fn test_regression_p256_is_warm() {
             input: calldata.into(),
         },
         wallet.clone(),
-    )
-    .encode();
+    );
 
     // We use a very high native per gas ratio
     let block_context = BlockContext {
@@ -6463,12 +6438,11 @@ fn test_regression_p256_is_warm() {
         check_storage_diff_hashes: true,
         ..Default::default()
     };
-    let res = chain.run_block(
-        vec![forwarded_tx],
-        Some(block_context),
-        None,
-        Some(run_config),
-    );
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config);
+
+    let res = tester.execute_block(vec![forwarded_tx]);
     let tx_res = res
         .tx_results
         .first()

--- a/tests/instances/precompiles/src/lib.rs
+++ b/tests/instances/precompiles/src/lib.rs
@@ -6358,6 +6358,7 @@ fn all_ones_bits(n: usize) -> Vec<u8> {
     vec![0xFF; 4 * n]
 }
 
+#[allow(dead_code)]
 fn all_ones_except_top_bit(n: usize) -> Vec<u8> {
     let mut v = vec![0xFF; 4 * n];
     v[0] &= 0x7F; // clear the top (MSB) bit in the first byte

--- a/tests/instances/precompiles/src/lib.rs
+++ b/tests/instances/precompiles/src/lib.rs
@@ -5,6 +5,7 @@ use rig::alloy::consensus::TxLegacy;
 use rig::utils::{calldata_for_forwarder, FORWARDER_BYTECODE};
 use rig::zksync_os_interface::types::BlockOutput;
 use rig::zksync_os_interface::types::ExecutionResult::Revert;
+use rig::BlockContext;
 use rig::{
     alloy::{
         primitives::{address, Address, TxKind},
@@ -13,7 +14,6 @@ use rig::{
     ruint::aliases::U256,
     ZKsyncOSTester,
 };
-use rig::{default_run_config, BlockContext};
 use std::assert_matches::assert_matches;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -68,10 +68,7 @@ fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockO
         ..Default::default()
     };
 
-    let run_config = default_run_config();
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(run_config);
+    tester = tester.with_block_context(block_context);
 
     tester.execute_block(vec![direct_tx, forwarded_tx])
 }
@@ -6433,15 +6430,7 @@ fn test_regression_p256_is_warm() {
         ..Default::default()
     };
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(run_config);
+    tester = tester.with_block_context(block_context);
 
     let res = tester.execute_block(vec![forwarded_tx]);
     let tx_res = res

--- a/tests/instances/precompiles/src/lib.rs
+++ b/tests/instances/precompiles/src/lib.rs
@@ -12,7 +12,7 @@ use rig::{
         rpc::types::TransactionRequest,
     },
     ruint::aliases::U256,
-    ZKsyncOSTester,
+    TestingFramework,
 };
 use std::assert_matches::assert_matches;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
@@ -25,7 +25,7 @@ use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 fn run_precompile(precompile_id: &str, gas: Option<u64>, input: &[u8]) -> BlockOutput {
     let gas = gas.unwrap_or(1 << 27);
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target = Address::from_slice(hex::decode(precompile_id).unwrap().as_slice());
     let forwarder = address!("0x1000000000000000000000000000000000000000");
@@ -6113,7 +6113,7 @@ fn test_precompile_parses_input_correctly() {
         let empty_input = [0u8; 193];
 
         for i in length {
-            let mut tester = ZKsyncOSTester::new();
+            let mut tester = TestingFramework::new();
             let wallet = tester.random_signer();
             tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
@@ -6392,7 +6392,7 @@ fn bench_modexp() {
 
 #[test]
 fn test_regression_p256_is_warm() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target = Address::from_slice(
         hex::decode("0000000000000000000000000000000000000100")

--- a/tests/instances/system_hooks/src/lib.rs
+++ b/tests/instances/system_hooks/src/lib.rs
@@ -6,44 +6,23 @@
 use alloy_sol_types::{sol, SolEvent};
 use rig::alloy::primitives::address;
 use rig::alloy::primitives::Address;
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::ruint::aliases::B160;
 use rig::ruint::aliases::U256;
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::system_hooks::addresses_constants::SYSTEM_CONTEXT_ADDRESS;
 use rig::testing_utils::call_address_and_measure_gas_cost;
-use rig::testing_utils::install_system_contracts;
+use rig::tx_failed;
+use rig::tx_succeeded;
 use rig::utils::{
     address_into_special_storage_key, AccountProperties, L1TxBuilder,
     ACCOUNT_PROPERTIES_STORAGE_ADDRESS,
 };
 use rig::zk_ee::utils::Bytes32;
-use rig::zksync_os_interface::types::{BlockOutput, ExecutionResult};
-use rig::{alloy, Chain};
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
-
-fn bal(chain: &mut Chain, addr: alloy::primitives::Address) -> alloy::primitives::U256 {
-    chain
-        .get_account_properties(&B160::from_be_bytes(addr.into_array()))
-        .balance
-}
-
-fn tx_succeeded(output: &BlockOutput, idx: usize) -> bool {
-    output.tx_results[idx]
-        .as_ref()
-        .ok()
-        .map(|o| o.is_success())
-        .unwrap_or(false)
-}
-
-fn tx_failed(output: &BlockOutput, idx: usize) -> bool {
-    !tx_succeeded(output, idx)
-}
+use rig::zksync_os_interface::types::ExecutionResult;
+use rig::{alloy, ZKsyncOSTester};
 
 #[test]
 fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
-    let mut chain = Chain::empty(None);
-
     let sender = address!("1234567890123456789012345678901234567890");
     let recipient = address!("2222567890123456789012345678901234567890");
 
@@ -51,9 +30,9 @@ fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::MAX;
 
-    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
 
-    let encoded = L1TxBuilder::new()
+    let tx = L1TxBuilder::new()
         .from(sender)
         .to(recipient)
         .input(Vec::new())
@@ -62,9 +41,8 @@ fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
         .gas_price(0)
         .gas_limit(200_000)
         .nonce(0)
-        .build()
-        .encode();
-    let output = chain.run_block(vec![encoded], None, None, None);
+        .build();
+    let output = tester.execute_block(vec![tx]);
 
     assert!(
         tx_failed(&output, 0),
@@ -73,12 +51,12 @@ fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
 
     // Balances must be unchanged (no fees).
     assert_eq!(
-        bal(&mut chain, sender),
+        tester.get_balance(&sender),
         initial_sender,
         "sender balance must not change"
     );
     assert_eq!(
-        bal(&mut chain, recipient),
+        tester.get_balance(&recipient),
         alloy::primitives::U256::ZERO,
         "recipient must not receive value"
     );
@@ -86,8 +64,6 @@ fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
 
 #[test]
 fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
-    let mut chain = Chain::empty(None);
-
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
@@ -96,7 +72,7 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
 
-    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
 
     // withdraw(address) selector 0x51cff8d9
     let mut calldata = Vec::new();
@@ -104,7 +80,7 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
     calldata.extend_from_slice(&[0u8; 12]);
     calldata.extend_from_slice(l1_receiver.as_slice());
 
-    let encoded = L1TxBuilder::new()
+    let tx = L1TxBuilder::new()
         .from(sender)
         .to(l2_base_token_address)
         .input(calldata)
@@ -112,9 +88,8 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
         .gas_price(0)
         .gas_limit(200_000)
         .nonce(0)
-        .build()
-        .encode();
-    let output = chain.run_block(vec![encoded], None, None, None);
+        .build();
+    let output = tester.execute_block(vec![tx]);
 
     assert!(
         tx_failed(&output, 0),
@@ -123,7 +98,7 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
 
     // Balances unchanged
     assert_eq!(
-        bal(&mut chain, sender),
+        tester.get_balance(&sender),
         initial_sender,
         "sender balance must not change"
     );
@@ -150,8 +125,6 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
 
 #[test]
 fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
-    let mut chain = Chain::empty(None);
-
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
@@ -161,7 +134,7 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
 
-    chain.set_balance(B160::from_be_bytes(sender.into_array()), initial_sender);
+    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
 
     // withdrawWithMessage(address,bytes) selector 0x84bc3eb0
     let mut calldata = Vec::new();
@@ -184,7 +157,7 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
         calldata.extend_from_slice(&vec![0u8; padding_needed]);
     }
 
-    let encoded = L1TxBuilder::new()
+    let tx = L1TxBuilder::new()
         .from(sender)
         .to(l2_base_token_address)
         .input(calldata)
@@ -192,9 +165,8 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
         .gas_price(0)
         .gas_limit(300_000)
         .nonce(0)
-        .build()
-        .encode();
-    let output = chain.run_block(vec![encoded], None, None, None);
+        .build();
+    let output = tester.execute_block(vec![tx]);
 
     assert!(
         tx_failed(&output, 0),
@@ -203,7 +175,7 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
 
     // Balances unchanged
     assert_eq!(
-        bal(&mut chain, sender),
+        tester.get_balance(&sender),
         initial_sender,
         "sender balance must not change"
     );
@@ -233,16 +205,14 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
 /// transfer funds to the recipient (spending from sender’s L2 balance).
 #[test]
 fn test_l1_value_transfer_spends_from_l2_balance() {
-    let mut chain = Chain::empty(None);
-
     let sender = address!("1234567890123456789012345678901234567890");
     let recipient = address!("2222567890123456789012345678901234567890");
     let value = alloy::primitives::U256::from(1_000_000_000_000_000_000u64); // 1 ETH
 
     // Fund sender so `msg.value` can be paid from L2 balance.
-    chain.set_balance(B160::from_be_bytes(sender.into_array()), value);
+    let mut tester = ZKsyncOSTester::new().with_balance(sender, value);
 
-    let encoded = L1TxBuilder::new()
+    let tx = L1TxBuilder::new()
         .from(sender)
         .to(recipient)
         .input(Vec::new())
@@ -251,16 +221,15 @@ fn test_l1_value_transfer_spends_from_l2_balance() {
         .gas_price(0)
         .gas_limit(200_000)
         .nonce(0)
-        .build()
-        .encode();
-    let output = chain.run_block(vec![encoded], None, None, None);
+        .build();
+    let output = tester.execute_block(vec![tx]);
 
     assert!(
         tx_succeeded(&output, 0),
         "tx must succeed with sufficient L2 balance"
     );
     assert_eq!(
-        bal(&mut chain, recipient),
+        tester.get_balance(&recipient),
         value,
         "recipient must receive msg.value"
     );
@@ -268,8 +237,6 @@ fn test_l1_value_transfer_spends_from_l2_balance() {
 
 #[test]
 fn test_set_bytecode_details_evm() {
-    let mut chain = Chain::empty(None);
-
     let contract_deployer_address = address!("0000000000000000000000000000000000008006");
     let contract_deployer_hook_address = address!("0000000000000000000000000000000000007002");
 
@@ -280,29 +247,26 @@ fn test_set_bytecode_details_evm() {
             .try_into()
             .unwrap(),
     );
-    chain.set_preimage(code_hash, &bytecode);
     let calldata =
         hex::decode("00000000000000000000000000000000000000000000000000000000000100021c4be3dec3ba88b69a8d3cd5cedd2b22f3da89b1ff9c8fd453c5a6e10c23d6f7000000000000000000000000000000000000000000000000000000000000000579fad56e6cf52d0c8c2c033d568fc36856ba2b556774960968d79274b0e6b944")
             .unwrap();
 
-    chain.set_balance(
-        B160::from_alloy(contract_deployer_address),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_preimage(code_hash, &bytecode)
+        .with_balance(
+            contract_deployer_address,
+            U256::from(1_000_000_000_000_000_u64),
+        );
 
-    let encoded_tx = {
-        let tx = L1TxBuilder::new()
-            .from(contract_deployer_address)
-            .to(contract_deployer_hook_address)
-            .input(calldata)
-            .gas_price(1000)
-            .gas_limit(200_000)
-            .build();
-        tx.encode()
-    };
-    let transactions = vec![encoded_tx];
+    let tx = L1TxBuilder::new()
+        .from(contract_deployer_address)
+        .to(contract_deployer_hook_address)
+        .input(calldata)
+        .gas_price(1000)
+        .gas_limit(200_000)
+        .build();
 
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert all txs succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -334,9 +298,6 @@ fn test_set_bytecode_details_evm() {
 
 #[test]
 fn test_set_deployed_bytecode_evm_unauthorized() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, false, false, true);
-
     let bytecode = hex::decode("0123456789").unwrap();
     let code_hash = Bytes32::from_array(
         hex::decode("1c4be3dec3ba88b69a8d3cd5cedd2b22f3da89b1ff9c8fd453c5a6e10c23d6f7")
@@ -344,7 +305,9 @@ fn test_set_deployed_bytecode_evm_unauthorized() {
             .try_into()
             .unwrap(),
     );
-    chain.set_preimage(code_hash, &bytecode);
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(false, false, true)
+        .with_preimage(code_hash, &bytecode);
 
     let from = address!("000000000000000000000000000000000000800e");
     let contract_deployer_address = address!("0000000000000000000000000000000000008006");
@@ -352,19 +315,15 @@ fn test_set_deployed_bytecode_evm_unauthorized() {
         hex::decode("231b395700000000000000000000000000000000000000000000000000000000000100021c4be3dec3ba88b69a8d3cd5cedd2b22f3da89b1ff9c8fd453c5a6e10c23d6f7000000000000000000000000000000000000000000000000000000000000000579fad56e6cf52d0c8c2c033d568fc36856ba2b556774960968d79274b0e6b9440000000000000000000000000000000000000000000000000000000000000005")
             .unwrap();
 
-    let encoded_tx = {
-        let tx = L1TxBuilder::new()
-            .from(from)
-            .to(contract_deployer_address)
-            .input(calldata)
-            .gas_price(1000)
-            .gas_limit(200_000)
-            .build();
-        tx.encode()
-    };
-    let transactions = vec![encoded_tx];
+    let tx = L1TxBuilder::new()
+        .from(from)
+        .to(contract_deployer_address)
+        .input(calldata)
+        .gas_price(1000)
+        .gas_limit(200_000)
+        .build();
 
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     let result = &output
         .tx_results
@@ -379,9 +338,8 @@ fn test_set_deployed_bytecode_evm_unauthorized() {
 
 #[test]
 fn test_l1_messenger_hook_succeeds() {
-    let mut chain = Chain::empty(None);
     // making sure hooks are installed
-    install_system_contracts(&mut chain, false, false, true);
+    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
 
     let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
 
@@ -401,10 +359,7 @@ fn test_l1_messenger_hook_succeeds() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     let tx_result = &output
         .tx_results
@@ -426,9 +381,8 @@ fn test_l1_messenger_hook_succeeds() {
 
 #[test]
 fn test_l1_messenger_hook_fails_with_invalid_calldata() {
-    let mut chain = Chain::empty(None);
     // making sure hooks are installed
-    install_system_contracts(&mut chain, false, false, true);
+    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
 
     let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
 
@@ -445,10 +399,7 @@ fn test_l1_messenger_hook_fails_with_invalid_calldata() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     let tx_result = &output
         .tx_results
@@ -463,9 +414,8 @@ fn test_l1_messenger_hook_fails_with_invalid_calldata() {
 
 #[test]
 fn test_l1_messenger_hook_unauthorized_sender_ignored() {
-    let mut chain = Chain::empty(None);
     // making sure hooks are installed
-    install_system_contracts(&mut chain, false, false, true);
+    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
 
     // ❌ this should NOT be the L1Messenger system contract address
     let unauthorized_from = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -489,10 +439,7 @@ fn test_l1_messenger_hook_unauthorized_sender_ignored() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     let tx_result = &output
         .tx_results
@@ -507,16 +454,15 @@ fn test_l1_messenger_hook_unauthorized_sender_ignored() {
 
 #[test]
 fn test_l2_base_token_withdraw_events() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, true, true, false);
-
     // L2 base token address is 0x800a
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
     let withdrawal_amount = alloy::primitives::U256::from(1000000000000000000u64); // 1 ETH
 
-    chain.set_balance(B160::from_alloy(sender), withdrawal_amount);
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(true, true, false)
+        .with_balance(sender, withdrawal_amount);
 
     // Prepare withdraw(address) calldata
     // withdraw(address) has selector 0x51cff8d9
@@ -534,10 +480,7 @@ fn test_l2_base_token_withdraw_events() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -576,9 +519,6 @@ fn test_l2_base_token_withdraw_events() {
 
 #[test]
 fn test_l2_base_token_withdraw_with_message_events() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, true, true, false);
-
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
@@ -586,7 +526,9 @@ fn test_l2_base_token_withdraw_with_message_events() {
     let additional_data = b"test message data";
 
     // Set up initial balance for the sender
-    chain.set_balance(B160::from_alloy(sender), withdrawal_amount);
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(true, true, false)
+        .with_balance(sender, withdrawal_amount);
 
     // Prepare withdrawWithMessage(address,bytes) calldata
     // withdrawWithMessage(address,bytes) has selector 0x84bc3eb0
@@ -619,10 +561,7 @@ fn test_l2_base_token_withdraw_with_message_events() {
         .gas_limit(300_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -666,9 +605,6 @@ fn test_l2_base_token_withdraw_with_message_events() {
 
 #[test]
 fn test_l2_base_token_withdraw_with_dirty_address() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, true, true, false);
-
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
@@ -676,7 +612,9 @@ fn test_l2_base_token_withdraw_with_dirty_address() {
 
     // Deliberately set invalid balance (insufficient funds)
     // Set up initial balance for the sender
-    chain.set_balance(B160::from_alloy(sender), withdrawal_amount);
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(true, true, false)
+        .with_balance(sender, withdrawal_amount);
 
     // Prepare withdraw(address) calldata
     let mut calldata = Vec::new();
@@ -693,10 +631,7 @@ fn test_l2_base_token_withdraw_with_dirty_address() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction failed due to insufficient balance
     assert!(
@@ -713,9 +648,6 @@ fn test_l2_base_token_withdraw_with_dirty_address() {
 
 #[test]
 fn test_l2_base_token_withdraw_with_message_with_dirty_address() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, true, true, false);
-
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let l1_receiver = address!("0987654321098765432109876543210987654321");
@@ -723,7 +655,9 @@ fn test_l2_base_token_withdraw_with_message_with_dirty_address() {
     let additional_data = b"test message data";
 
     // Set up initial balance for the sender
-    chain.set_balance(B160::from_alloy(sender), withdrawal_amount);
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(true, true, false)
+        .with_balance(sender, withdrawal_amount);
 
     // Prepare withdrawWithMessage(address,bytes) calldata
     // withdrawWithMessage(address,bytes) has selector 0x84bc3eb0
@@ -756,10 +690,7 @@ fn test_l2_base_token_withdraw_with_message_with_dirty_address() {
         .gas_limit(300_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction failed due to insufficient balance
     assert!(
@@ -776,15 +707,13 @@ fn test_l2_base_token_withdraw_with_message_with_dirty_address() {
 
 #[test]
 fn test_l2_base_token_no_mint_event_regression() {
-    let mut chain = Chain::empty(None);
-
     // L2 base token address is 0x800a
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
     let sender = address!("1234567890123456789012345678901234567890");
     let recipient = address!("2222567890123456789012345678901234567890");
     let mint_amount = alloy::primitives::U256::from(5000000000000000000u64); // 5 ETH
 
-    chain.set_balance(B160::from_be_bytes(sender.into_array()), mint_amount);
+    let mut tester = ZKsyncOSTester::new().with_balance(sender, mint_amount);
 
     // Prepare mint calldata - typically this would be called by the bootloader or bridge
     // For testing purposes, we'll simulate a mint by sending ETH value to the base token contract
@@ -800,10 +729,7 @@ fn test_l2_base_token_no_mint_event_regression() {
         .gas_limit(100_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -954,9 +880,7 @@ fn test_l2_base_token_withdraw_with_message_gas_charging() {
 
 #[test]
 fn test_mint_base_token_hook() {
-    let mut chain = Chain::empty(None);
-
-    chain.mint_tokens_to_treasury(); // to properly reflect the initial balance
+    let mut tester = ZKsyncOSTester::new().with_minted_tokens_to_treasury();
 
     // L2 base token address is the only address allowed to call the mint hook
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
@@ -965,8 +889,8 @@ fn test_mint_base_token_hook() {
     let mint_amount = alloy::primitives::U256::from(3000000000000000000u64); // 3 ETH
 
     // Check initial balance of L2_BASE_TOKEN_ADDRESS is zero
-    let initial_balance = chain
-        .get_account_properties(&B160::from_alloy(l2_base_token_address))
+    let initial_balance = tester
+        .get_account_properties(&l2_base_token_address)
         .balance;
 
     // Prepare calldata: 32 bytes containing the mint amount as U256 big-endian
@@ -982,10 +906,7 @@ fn test_mint_base_token_hook() {
         .gas_limit(200_000)
         .build();
 
-    let encoded_tx = tx.encode();
-    let transactions = vec![encoded_tx];
-
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.execute_block(vec![tx]);
 
     // Assert transaction succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -997,8 +918,8 @@ fn test_mint_base_token_hook() {
     }));
 
     // Check that the caller's (L2_BASE_TOKEN_ADDRESS) balance was increased by the mint amount
-    let final_balance = chain
-        .get_account_properties(&B160::from_alloy(l2_base_token_address))
+    let final_balance = tester
+        .get_account_properties(&l2_base_token_address)
         .balance;
 
     let actually_minted_amount = final_balance
@@ -1013,10 +934,7 @@ fn test_mint_base_token_hook() {
 #[test]
 fn test_event_hooks_empty_topics() {
     for test_contract_address in [L2_INTEROP_ROOT_STORAGE_ADDRESS, SYSTEM_CONTEXT_ADDRESS] {
-        let mut chain = Chain::empty(None);
-
         // Contract that emits a log with empty topics array - this should be handled gracefully
-        // Before the fix, this would cause a panic due to missing bounds check
         let test_contract = Address::from(test_contract_address.to_be_bytes());
 
         // Bytecode that emits LOG0 (no topics)
@@ -1025,6 +943,8 @@ fn test_event_hooks_empty_topics() {
         // LOG0          -> a0    (emit log with no topics)
         // STOP          -> 00
         let test_contract_bytecode = hex::decode("60006000a000").unwrap();
+        let mut tester =
+            ZKsyncOSTester::new().with_evm_contract(test_contract, &test_contract_bytecode);
 
         let tx = L1TxBuilder::new()
             .from(address!("1234567890123456789012345678901234567890"))
@@ -1034,15 +954,7 @@ fn test_event_hooks_empty_topics() {
             .gas_limit(200_000)
             .build();
 
-        chain.set_evm_bytecode(
-            B160::from_be_bytes(test_contract.clone().into_array()),
-            &test_contract_bytecode,
-        );
-
-        let encoded_tx = tx.encode();
-        let transactions = vec![encoded_tx];
-
-        let output = chain.run_block(transactions, None, None, None);
+        let output = tester.execute_block(vec![tx]);
 
         // Transaction should succeed - empty topics should be handled gracefully
         assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {

--- a/tests/instances/system_hooks/src/lib.rs
+++ b/tests/instances/system_hooks/src/lib.rs
@@ -19,7 +19,7 @@ use rig::utils::{
 };
 use rig::zk_ee::utils::Bytes32;
 use rig::zksync_os_interface::types::ExecutionResult;
-use rig::{alloy, ZKsyncOSTester};
+use rig::{alloy, TestingFramework};
 
 #[test]
 fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
@@ -30,7 +30,7 @@ fn test_value_transfer_fails_if_insufficient_balance_max_msg_value() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::MAX;
 
-    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
+    let mut tester = TestingFramework::new().with_balance(sender, initial_sender);
 
     let tx = L1TxBuilder::new()
         .from(sender)
@@ -72,7 +72,7 @@ fn test_l2_base_token_withdraw_fails_if_insufficient_balance() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
 
-    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
+    let mut tester = TestingFramework::new().with_balance(sender, initial_sender);
 
     // withdraw(address) selector 0x51cff8d9
     let mut calldata = Vec::new();
@@ -134,7 +134,7 @@ fn test_l2_base_token_withdraw_with_message_fails_if_insufficient_balance() {
     let initial_sender = alloy::primitives::U256::from(1u64);
     let value = alloy::primitives::U256::from(2000000000000000000u64); // 2 ETH
 
-    let mut tester = ZKsyncOSTester::new().with_balance(sender, initial_sender);
+    let mut tester = TestingFramework::new().with_balance(sender, initial_sender);
 
     // withdrawWithMessage(address,bytes) selector 0x84bc3eb0
     let mut calldata = Vec::new();
@@ -210,7 +210,7 @@ fn test_l1_value_transfer_spends_from_l2_balance() {
     let value = alloy::primitives::U256::from(1_000_000_000_000_000_000u64); // 1 ETH
 
     // Fund sender so `msg.value` can be paid from L2 balance.
-    let mut tester = ZKsyncOSTester::new().with_balance(sender, value);
+    let mut tester = TestingFramework::new().with_balance(sender, value);
 
     let tx = L1TxBuilder::new()
         .from(sender)
@@ -251,7 +251,7 @@ fn test_set_bytecode_details_evm() {
         hex::decode("00000000000000000000000000000000000000000000000000000000000100021c4be3dec3ba88b69a8d3cd5cedd2b22f3da89b1ff9c8fd453c5a6e10c23d6f7000000000000000000000000000000000000000000000000000000000000000579fad56e6cf52d0c8c2c033d568fc36856ba2b556774960968d79274b0e6b944")
             .unwrap();
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_preimage(code_hash, &bytecode)
         .with_balance(
             contract_deployer_address,
@@ -305,7 +305,7 @@ fn test_set_deployed_bytecode_evm_unauthorized() {
             .try_into()
             .unwrap(),
     );
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(false, false, true)
         .with_preimage(code_hash, &bytecode);
 
@@ -339,7 +339,7 @@ fn test_set_deployed_bytecode_evm_unauthorized() {
 #[test]
 fn test_l1_messenger_hook_succeeds() {
     // making sure hooks are installed
-    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
+    let mut tester = TestingFramework::new().with_system_contracts(false, false, true);
 
     let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
 
@@ -382,7 +382,7 @@ fn test_l1_messenger_hook_succeeds() {
 #[test]
 fn test_l1_messenger_hook_fails_with_invalid_calldata() {
     // making sure hooks are installed
-    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
+    let mut tester = TestingFramework::new().with_system_contracts(false, false, true);
 
     let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
 
@@ -415,7 +415,7 @@ fn test_l1_messenger_hook_fails_with_invalid_calldata() {
 #[test]
 fn test_l1_messenger_hook_unauthorized_sender_ignored() {
     // making sure hooks are installed
-    let mut tester = ZKsyncOSTester::new().with_system_contracts(false, false, true);
+    let mut tester = TestingFramework::new().with_system_contracts(false, false, true);
 
     // ❌ this should NOT be the L1Messenger system contract address
     let unauthorized_from = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -460,7 +460,7 @@ fn test_l2_base_token_withdraw_events() {
     let l1_receiver = address!("0987654321098765432109876543210987654321");
     let withdrawal_amount = alloy::primitives::U256::from(1000000000000000000u64); // 1 ETH
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(true, true, false)
         .with_balance(sender, withdrawal_amount);
 
@@ -526,7 +526,7 @@ fn test_l2_base_token_withdraw_with_message_events() {
     let additional_data = b"test message data";
 
     // Set up initial balance for the sender
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(true, true, false)
         .with_balance(sender, withdrawal_amount);
 
@@ -612,7 +612,7 @@ fn test_l2_base_token_withdraw_with_dirty_address() {
 
     // Deliberately set invalid balance (insufficient funds)
     // Set up initial balance for the sender
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(true, true, false)
         .with_balance(sender, withdrawal_amount);
 
@@ -655,7 +655,7 @@ fn test_l2_base_token_withdraw_with_message_with_dirty_address() {
     let additional_data = b"test message data";
 
     // Set up initial balance for the sender
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(true, true, false)
         .with_balance(sender, withdrawal_amount);
 
@@ -713,7 +713,7 @@ fn test_l2_base_token_no_mint_event_regression() {
     let recipient = address!("2222567890123456789012345678901234567890");
     let mint_amount = alloy::primitives::U256::from(5000000000000000000u64); // 5 ETH
 
-    let mut tester = ZKsyncOSTester::new().with_balance(sender, mint_amount);
+    let mut tester = TestingFramework::new().with_balance(sender, mint_amount);
 
     // Prepare mint calldata - typically this would be called by the bootloader or bridge
     // For testing purposes, we'll simulate a mint by sending ETH value to the base token contract
@@ -880,7 +880,7 @@ fn test_l2_base_token_withdraw_with_message_gas_charging() {
 
 #[test]
 fn test_mint_base_token_hook() {
-    let mut tester = ZKsyncOSTester::new().with_minted_tokens_to_treasury();
+    let mut tester = TestingFramework::new().with_minted_tokens_to_treasury();
 
     // L2 base token address is the only address allowed to call the mint hook
     let l2_base_token_address = address!("000000000000000000000000000000000000800a");
@@ -944,7 +944,7 @@ fn test_event_hooks_empty_topics() {
         // STOP          -> 00
         let test_contract_bytecode = hex::decode("60006000a000").unwrap();
         let mut tester =
-            ZKsyncOSTester::new().with_evm_contract(test_contract, &test_contract_bytecode);
+            TestingFramework::new().with_evm_contract(test_contract, &test_contract_bytecode);
 
         let tx = L1TxBuilder::new()
             .from(address!("1234567890123456789012345678901234567890"))

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -16,7 +16,7 @@ use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
 use rig::{alloy, ZKsyncOSTester};
 
-use super::{common_target_address, run_config};
+use super::{common_target_address, default_run_config};
 
 /// Test that an L1 transaction with gas limit below intrinsic gas (21k) is
 /// processed gracefully instead of causing a validation error.
@@ -43,7 +43,7 @@ fn test_l1_tx_gas_limit_below_intrinsic() {
     // The block should complete without panicking (no internal error)
     let mut tester = ZKsyncOSTester::new()
         .with_balance(from, U256::from(u64::MAX))
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     let result = tester.execute_block_no_panic(vec![tx]);
     assert!(
         result.is_ok(),
@@ -96,7 +96,7 @@ fn test_l1_tx_gas_price_overflow_native_per_gas() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_balance(from, U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     // The block should complete without panicking (no internal error)
     let result = tester.execute_block_no_panic(vec![tx]);
@@ -134,8 +134,9 @@ fn test_l1_tx_intrinsic_gas_overflow() {
         .into();
 
     // Test L1 transaction - this triggers the overflow scenario
-    let mut tester =
-        ZKsyncOSTester::new().with_balance(from_address, U256::from(1_000_000_000_000_000_u64));
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(from_address, U256::from(1_000_000_000_000_000_u64))
+        .with_run_config(default_run_config());
     let result_l1 = tester.execute_block(vec![overflow_l1_tx]);
 
     assert!(result_l1.tx_results[0].is_ok());

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -14,7 +14,7 @@
 use rig::alloy::primitives::address;
 use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
-use rig::{alloy, ZKsyncOSTester};
+use rig::{alloy, TestingFramework};
 
 use super::common_target_address;
 
@@ -41,7 +41,7 @@ fn test_l1_tx_gas_limit_below_intrinsic() {
         .into();
 
     // The block should complete without panicking (no internal error)
-    let mut tester = ZKsyncOSTester::new().with_balance(from, U256::from(u64::MAX));
+    let mut tester = TestingFramework::new().with_balance(from, U256::from(u64::MAX));
     let result = tester.execute_block_no_panic(vec![tx]);
     assert!(
         result.is_ok(),
@@ -93,7 +93,7 @@ fn test_l1_tx_gas_price_overflow_native_per_gas() {
         .into();
 
     let mut tester =
-        ZKsyncOSTester::new().with_balance(from, U256::from(1_000_000_000_000_000_u64));
+        TestingFramework::new().with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     // The block should complete without panicking (no internal error)
     let result = tester.execute_block_no_panic(vec![tx]);
@@ -132,7 +132,7 @@ fn test_l1_tx_intrinsic_gas_overflow() {
 
     // Test L1 transaction - this triggers the overflow scenario
     let mut tester =
-        ZKsyncOSTester::new().with_balance(from_address, U256::from(1_000_000_000_000_000_u64));
+        TestingFramework::new().with_balance(from_address, U256::from(1_000_000_000_000_000_u64));
     let result_l1 = tester.execute_block(vec![overflow_l1_tx]);
 
     assert!(result_l1.tx_results[0].is_ok());

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -12,20 +12,11 @@
 //!
 
 use rig::alloy::primitives::address;
-use rig::forward_system::run::convert_alloy::FromAlloy;
-use rig::ruint::aliases::{B160, U256};
+use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
-use rig::{alloy, Chain};
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::{alloy, ZKsyncOSTester};
 
-fn run_config() -> Option<rig::chain::RunConfig> {
-    Some(rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    })
-}
+use super::{common_target_address, run_config};
 
 /// Test that an L1 transaction with gas limit below intrinsic gas (21k) is
 /// processed gracefully instead of causing a validation error.
@@ -35,30 +26,25 @@ fn run_config() -> Option<rig::chain::RunConfig> {
 /// and the transaction proceeds.
 #[test]
 fn test_l1_tx_gas_limit_below_intrinsic() {
-    let mut chain = Chain::empty(None);
-
     let from = address!("1234000000000000000000000000000000000000");
-    let to = address!("4242000000000000000000000000000000000000");
-
-    // Give the sender some balance
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    let to = common_target_address();
 
     // Create an L1 transaction with gas limit below intrinsic gas (21000)
     // The intrinsic gas for L1 txs is L1_TX_INTRINSIC_L2_GAS = 21_000
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(from)
-            .to(to)
-            .gas_price(1500)
-            .gas_limit(20_000)
-            .value(alloy::primitives::U256::from(100))
-            .build();
-
-        tx.encode()
-    };
+    let tx = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(1500)
+        .gas_limit(20_000)
+        .value(alloy::primitives::U256::from(100))
+        .build()
+        .into();
 
     // The block should complete without panicking (no internal error)
-    let result = chain.run_block_no_panic(vec![tx], None, None, run_config());
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(from, U256::from(u64::MAX))
+        .with_run_config(run_config());
+    let result = tester.execute_block_no_panic(vec![tx]);
     assert!(
         result.is_ok(),
         "Block should complete without internal error, got: {:?}",
@@ -91,35 +77,29 @@ fn test_l1_tx_gas_limit_below_intrinsic() {
 /// via saturating arithmetic.
 #[test]
 fn test_l1_tx_gas_price_overflow_native_per_gas() {
-    let mut chain = Chain::empty(None);
-
     let from = address!("1234000000000000000000000000000000000000");
-    let to = address!("4242000000000000000000000000000000000000");
-
-    // Give the sender a reasonable balance (not MAX to avoid overflow issues elsewhere)
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let to = common_target_address();
 
     // L1_TX_NATIVE_PRICE = 10
     // To overflow u64 in native_per_gas calculation: gas_price / 10 > u64::MAX
     // So gas_price > u64::MAX * 10
     let overflow_gas_price = u128::from(u64::MAX) * 11;
 
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(from)
-            .to(to)
-            .gas_price(overflow_gas_price)
-            .gas_limit(100_000)
-            .value(alloy::primitives::U256::from(100))
-            .build();
-        tx.encode()
-    };
+    let tx = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(overflow_gas_price)
+        .gas_limit(100_000)
+        .value(alloy::primitives::U256::from(100))
+        .build()
+        .into();
+
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(from, U256::from(1_000_000_000_000_000_u64))
+        .with_run_config(run_config());
 
     // The block should complete without panicking (no internal error)
-    let result = chain.run_block_no_panic(vec![tx], None, None, run_config());
+    let result = tester.execute_block_no_panic(vec![tx]);
     assert!(
         result.is_ok(),
         "Block should complete without internal error, got: {:?}",
@@ -138,31 +118,25 @@ fn test_l1_tx_gas_price_overflow_native_per_gas() {
 
 #[test]
 fn test_l1_tx_intrinsic_gas_overflow() {
-    let mut chain = Chain::empty(None);
     let from_address = address!("1234000000000000000000000000000000000000");
-    let to_address = address!("4242000000000000000000000000000000000000");
+    let to_address = common_target_address();
 
     // Create an L1 transaction that will cause gas overflow
     // L1 transactions bypass the intrinsic gas check that would normally prevent this
-    let overflow_l1_tx = {
-        let tx = L1TxBuilder::new()
-            .from(from_address)
-            .to(to_address)
-            .gas_price(1000)
-            .gas_limit(200000) // Gas limit that should not be sufficient for the input data
-            .value(alloy::primitives::U256::from(100))
-            .input(vec![0u8; 50_000].into()) // Very large input data to increase intrinsic cost
-            .build();
-        tx.encode()
-    };
+    let overflow_l1_tx = L1TxBuilder::new()
+        .from(from_address)
+        .to(to_address)
+        .gas_price(1000)
+        .gas_limit(200000) // Gas limit that should not be sufficient for the input data
+        .value(alloy::primitives::U256::from(100))
+        .input(vec![0u8; 50_000].into()) // Very large input data to increase intrinsic cost
+        .build()
+        .into();
 
-    // Set up balances
-    chain.set_balance(
-        B160::from_alloy(from_address),
-        rig::ruint::aliases::U256::from(1_000_000_000_000_000_u64),
-    );
     // Test L1 transaction - this triggers the overflow scenario
-    let result_l1 = chain.run_block(vec![overflow_l1_tx], None, None, None);
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(from_address, U256::from(1_000_000_000_000_000_u64));
+    let result_l1 = tester.execute_block(vec![overflow_l1_tx]);
 
     assert!(result_l1.tx_results[0].is_ok());
 

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -16,7 +16,7 @@ use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
 use rig::{alloy, ZKsyncOSTester};
 
-use super::{common_target_address, default_run_config};
+use super::common_target_address;
 
 /// Test that an L1 transaction with gas limit below intrinsic gas (21k) is
 /// processed gracefully instead of causing a validation error.
@@ -41,9 +41,7 @@ fn test_l1_tx_gas_limit_below_intrinsic() {
         .into();
 
     // The block should complete without panicking (no internal error)
-    let mut tester = ZKsyncOSTester::new()
-        .with_balance(from, U256::from(u64::MAX))
-        .with_run_config(default_run_config());
+    let mut tester = ZKsyncOSTester::new().with_balance(from, U256::from(u64::MAX));
     let result = tester.execute_block_no_panic(vec![tx]);
     assert!(
         result.is_ok(),
@@ -94,9 +92,8 @@ fn test_l1_tx_gas_price_overflow_native_per_gas() {
         .build()
         .into();
 
-    let mut tester = ZKsyncOSTester::new()
-        .with_balance(from, U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(default_run_config());
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     // The block should complete without panicking (no internal error)
     let result = tester.execute_block_no_panic(vec![tx]);
@@ -134,9 +131,8 @@ fn test_l1_tx_intrinsic_gas_overflow() {
         .into();
 
     // Test L1 transaction - this triggers the overflow scenario
-    let mut tester = ZKsyncOSTester::new()
-        .with_balance(from_address, U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(default_run_config());
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(from_address, U256::from(1_000_000_000_000_000_u64));
     let result_l1 = tester.execute_block(vec![overflow_l1_tx]);
 
     assert!(result_l1.tx_results[0].is_ok());

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -17,7 +17,6 @@ use rig::zksync_os_interface::error::InvalidTransaction;
 use rig::{alloy, zksync_web3_rs, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
 use zksync_os_tests_common::zksync_tx::upgrade_tx::ZKsyncUpgradeTx;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
@@ -167,20 +166,16 @@ fn run_base_system() {
 
     let tester = ZKsyncOSTester::<false>::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_balance(
-            B160::from_be_bytes(from.0),
-            U256::from(1_000_000_000_000_000_u64),
-        )
-        .with_balance(
-            B160::from_alloy(eoa_wallet.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        )
+        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_prefunded_account(B160::from_alloy(eoa_wallet.address()))
         .with_balance(
             B160::from_alloy(address!("1234000000000000000000000000000000000000")),
             U256::from(100),
         );
 
-    let output = tester.with_run_config(run_config().unwrap()).execute_block(transactions);
+    let output = tester
+        .with_run_config(run_config().unwrap())
+        .execute_block(transactions);
 
     // Assert all txs succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -194,13 +189,13 @@ fn run_base_system() {
 
 #[test]
 fn test_block_of_erc20() {
-    let mut tester = ZKsyncOSTester::<true>::new();
+    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
     tester.run_block_of_erc20(10, None);
 }
 
 #[test]
 fn test_gas_price_zero_fee_zero() {
-    let mut tester = ZKsyncOSTester::<true>::new();
+    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
@@ -222,7 +217,7 @@ fn test_gas_price_zero_fee_zero() {
 
 #[test]
 fn test_gas_price_zero_fee_one() {
-    let mut tester = ZKsyncOSTester::<true>::new();
+    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
@@ -232,9 +227,6 @@ fn test_gas_price_zero_fee_one() {
 
 #[test]
 fn test_withdrawal() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-    tester.install_system_contracts(true, false, false);
-
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -260,7 +252,7 @@ fn test_withdrawal() {
             value: U256::from(10),
             input: withdrawal_calldata.into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let mut withdrawal_with_message_calldata =
@@ -283,31 +275,22 @@ fn test_withdrawal() {
             value: U256::from(5),
             input: withdrawal_with_message_calldata.into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![withdrawal_tx, withdrawal_with_message_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_system_contracts(true, true, false)
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_run_config(run_config().unwrap());
 
-    tester.install_system_contracts(false, true, false);
+    let output = tester.execute_block(transactions);
 
-    let output = tester.run_block(transactions, None, None, run_config());
-
-    // Assert all txs succeeded
-    assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
-        let success = r.clone().is_ok_and(|o| o.is_success());
-        if !success {
-            println!("Transaction {i} failed with: {r:?}")
-        }
-        success
-    }));
+    tester.assert_all_txs_succeded(&output);
 
     // Check preimage of withdrawal
     let mut expected_preimage =
@@ -329,8 +312,6 @@ fn test_withdrawal() {
 
 #[test]
 fn test_tx_with_access_list() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -360,31 +341,27 @@ fn test_tx_with_access_list() {
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
             access_list,
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![encoded_mint_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_run_config(run_config().unwrap());
 
-    let output = tester.run_block(transactions, None, None, run_config());
+    let output = tester.execute_block(transactions);
 
-    // Assert all txs succeeded
-    let result0 = output.tx_results.first().unwrap().clone();
-    assert!(result0.is_ok_and(|o| o.is_success()));
+    tester.assert_all_txs_succeded(&output);
 }
 
 #[test]
 fn test_tx_with_authorization_list() {
     use rig::alloy::eips::eip7702::*;
     use rig::alloy::signers::SignerSync;
-    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -424,37 +401,24 @@ fn test_tx_with_authorization_list() {
             access_list: Default::default(),
             authorization_list,
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
-
-    let transactions = vec![encoded_mint_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(erc_20_contract), &bytecode);
 
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(erc_20_contract), &bytecode)
+        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_run_config(run_config().unwrap());
 
-    let run_config = rig::chain::RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        ..Default::default()
-    };
-    let output = tester.run_block(transactions, None, None, Some(run_config));
+    let output = tester.execute_block(vec![encoded_mint_tx]);
 
-    // Assert all txs succeeded
-    let result0 = output.tx_results.first().unwrap().clone();
-    assert!(result0.is_ok_and(|o| o.is_success()));
+    tester.assert_all_txs_succeded(&output);
 }
 
 // Test that slots made warm in a tx are cold in the next tx
 #[test]
 fn test_cold_in_new_tx() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -477,7 +441,7 @@ fn test_cold_in_new_tx() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     // Gas is just enough to succeed.
@@ -491,7 +455,7 @@ fn test_cold_in_new_tx() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     // Any lower gas amount should fail
@@ -505,28 +469,21 @@ fn test_cold_in_new_tx() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![encoded_mint_tx, encoded_mint1_tx, encoded_mint_tx2];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_run_config(run_config().unwrap());
 
-    let output = tester.run_block(transactions, None, None, run_config());
+    let output = tester.execute_block(transactions);
 
-    // Assert all txs succeeded
-    let result0 = output.tx_results.first().unwrap().clone();
-    let result1 = output.tx_results.get(1).unwrap().clone();
-    let result2 = output.tx_results.get(2).unwrap().clone();
-    assert!(result0.is_ok_and(|o| o.is_success()));
-    assert!(result1.is_ok_and(|o| o.is_success()));
-    assert!(result2.is_ok_and(|o| !o.is_success()));
+    tester.assert_all_txs_succeded(&output);
 }
 
 #[test]
@@ -559,7 +516,7 @@ fn test_independent_txs_have_same_pubdata() {
             input: Default::default(),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet1.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet1.clone())
     };
 
     let encoded_tx_2 = {
@@ -574,7 +531,7 @@ fn test_independent_txs_have_same_pubdata() {
             input: Default::default(),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet2.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet2.clone())
     };
 
     let transactions = vec![encoded_tx_1, encoded_tx_2];
@@ -589,7 +546,7 @@ fn test_independent_txs_have_same_pubdata() {
             U256::from(1_000_000_000_000_000_u64),
         );
 
-    let output = tester.run_block(transactions, None, None, run_config());
+    let output = tester.execute_block_with(transactions, None, None, run_config());
 
     // Assert all txs succeeded and compare pubdata len
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -630,7 +587,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
     let withdrawal_tx = {
         let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
@@ -654,7 +611,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
             .nonce(0)
             .build();
 
-        tx.encode()
+        tx.into()
     };
 
     let transactions = vec![encoded_mint1_tx, withdrawal_tx];
@@ -664,7 +621,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = tester.run_block(transactions, None, None, None);
+    let output = tester.execute_block_with(transactions, None, None, None);
 
     // Assert tx succeeded/failed
     let result0 = output.tx_results.first().unwrap().clone();
@@ -706,7 +663,7 @@ fn test_invalid_tx_does_not_affect_native() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let mut tester = ZKsyncOSTester::<false>::new();
@@ -716,7 +673,7 @@ fn test_invalid_tx_does_not_affect_native() {
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
-    let output = tester.run_block(transactions, None, None, None);
+    let output = tester.execute_block_with(transactions, None, None, None);
 
     // Assert tx succeeded
     let result = output.tx_results.first().unwrap().clone();
@@ -737,7 +694,7 @@ fn test_invalid_tx_does_not_affect_native() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let mut tester = ZKsyncOSTester::<false>::new();
@@ -747,7 +704,7 @@ fn test_invalid_tx_does_not_affect_native() {
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
-    let output = tester.run_block(transactions, None, None, None);
+    let output = tester.execute_block_with(transactions, None, None, None);
 
     // Assert tx succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -813,7 +770,7 @@ fn test_regression_returndata_empty_3541() {
             value: Default::default(),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![encoded_tx];
@@ -826,7 +783,7 @@ fn test_regression_returndata_empty_3541() {
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = tester.run_block(transactions, None, None, run_config());
+    let output = tester.execute_block_with(transactions, None, None, run_config());
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -864,7 +821,7 @@ fn test_balance_overflow_protection() {
             value: U256::from(100u64), // Small value
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Test 2: Transaction with value + fee_amount overflow
@@ -879,10 +836,10 @@ fn test_balance_overflow_protection() {
             value: U256::MAX, // Maximum value will cause overflow when adding fees
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let output = tester.run_block(
+    let output = tester.execute_block_with(
         vec![overflow_fee_tx, overflow_total_tx],
         None,
         None,
@@ -920,10 +877,10 @@ fn test_upgrade_tx_revert_internal_error() {
         ..Default::default()
     });
 
-    let transactions = vec![upgrade_tx.encode()];
+    let transactions = vec![upgrade_tx];
 
     // Use run_block_no_panic to catch the error instead of panicking
-    let result = tester.run_block_no_panic(transactions, None, None, None);
+    let result = tester.execute_block_no_panic_with(transactions, None, None, None);
 
     // The upgrade transaction should fail with an internal error (not validation error)
     assert!(result.is_err());
@@ -956,10 +913,10 @@ fn test_upgrade_tx_succeeds() {
         ..Default::default()
     });
 
-    let transactions = vec![upgrade_tx.encode()];
+    let transactions = vec![upgrade_tx];
 
     // Use run_block_no_panic to catch the error instead of panicking
-    let result = tester.run_block_no_panic(transactions, None, None, None);
+    let result = tester.execute_block_no_panic_with(transactions, None, None, None);
     assert!(result.is_ok());
     let tx_output = result.as_ref().unwrap().tx_results[0].as_ref().unwrap();
     assert!(tx_output.is_success());
@@ -995,8 +952,8 @@ fn test_invalid_transaction_type_failure() {
             tx_type,
         );
 
-        let transactions = vec![invalid_tx.encode()];
-        let result = tester.run_block(transactions, None, None, run_config());
+        let transactions = vec![invalid_tx];
+        let result = tester.execute_block_with(transactions, None, None, run_config());
         assert!(
             result.tx_results[0].is_err(),
             "Transaction with invalid type should fail"
@@ -1054,7 +1011,7 @@ fn test_modexp_intermediate_zero_block() {
             input: input_data.into(),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![encoded_tx];
@@ -1064,7 +1021,7 @@ fn test_modexp_intermediate_zero_block() {
         U256::from(10u64.pow(18)),
     );
 
-    let result = tester.run_block(transactions, None, None, None);
+    let result = tester.execute_block_with(transactions, None, None, None);
 
     // The transaction should succeed
     assert!(
@@ -1129,7 +1086,7 @@ fn test_point_eval_call() {
             input: input_data.into(),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
     let transactions = vec![encoded_tx];
@@ -1139,7 +1096,7 @@ fn test_point_eval_call() {
         U256::from(10u64.pow(18)),
     );
 
-    let result = tester.run_block(transactions, None, None, None);
+    let result = tester.execute_block_with(transactions, None, None, None);
 
     // The transaction should succeed
     assert!(result.tx_results[0].is_ok(), "Transaction should succeed");
@@ -1197,7 +1154,7 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    let result = tester.run_block(vec![tx_request.encode()], None, None, run_config());
+    let result = tester.execute_block_with(vec![tx_request], None, None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
     let gas_used = res0.clone().unwrap().gas_used;
@@ -1231,10 +1188,10 @@ fn test_reject_caller_with_code_behavior() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let result_simulation = tester.simulate_encoded_block(vec![from_contract_tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![from_contract_tx.clone()], None);
 
     // In simulation mode, the transaction should succeed
     assert!(result_simulation.tx_results[0].is_ok(),);
@@ -1246,7 +1203,7 @@ fn test_reject_caller_with_code_behavior() {
     );
 
     // But in normal mode it should fail
-    let result_normal = tester.run_block(vec![from_contract_tx], None, None, run_config());
+    let result_normal = tester.execute_block_with(vec![from_contract_tx], None, None, run_config());
     assert!(matches!(
         result_normal.tx_results[0],
         Err(InvalidTransaction::RejectCallerWithCode)
@@ -1277,7 +1234,7 @@ fn test_expensive_pubdata() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Validation uses 40 bytes of pubdata, we want the validation
@@ -1294,7 +1251,7 @@ fn test_expensive_pubdata() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
@@ -1321,7 +1278,7 @@ fn test_check_pubdata_encoding_version() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     let native_price = U256::from(100);
@@ -1334,7 +1291,7 @@ fn test_check_pubdata_encoding_version() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1363,7 +1320,7 @@ fn test_check_pubdata_has_timestamp() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     let native_price = U256::from(100);
@@ -1378,7 +1335,7 @@ fn test_check_pubdata_has_timestamp() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1401,14 +1358,13 @@ fn test_simple_service_transaction() {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 0,
-    })
-    .encode();
+    });
 
     let block_context = BlockContext {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
@@ -1428,15 +1384,14 @@ fn test_simple_service_transaction_whitelist() {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 0,
-    })
-    .encode();
+    });
 
     let block_context = BlockContext {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
     // Check tx succeeds
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_err(), "Tx should fail");
 }
@@ -1450,8 +1405,7 @@ fn test_service_tx_gas_limit_exceeds_block() {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 0,
-    })
-    .encode();
+    });
 
     let block_context = BlockContext {
         gas_limit: 30_000_000,
@@ -1459,7 +1413,7 @@ fn test_service_tx_gas_limit_exceeds_block() {
         ..Default::default()
     };
 
-    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
     assert!(result.tx_results[0].is_ok());
 }
 
@@ -1478,34 +1432,36 @@ fn test_service_block_invariants() {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 0,
-    })
-    .encode();
+    });
     let tx2 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 1,
-    })
-    .encode();
+    });
     let tx3 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
         to: alloy::primitives::Address::from_slice(&target_address),
         input: Default::default(),
         salt: 2,
-    })
-    .encode();
+    });
 
     let block_context = BlockContext {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
     // Check txs succeed
-    let result = tester.run_block(vec![tx1, tx2, tx3], Some(block_context), None, run_config());
+    let result =
+        tester.execute_block_with(vec![tx1, tx2, tx3], Some(block_context), None, run_config());
     assert!(
         result.tx_results.iter().all(|res| res.is_ok()),
         "All txs should succeed"
     );
 
     // Check that a service block with a non-service tx fails
-    let tx4 = encode_service_tx(&target_address, &[], 3);
+    let tx4 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
+        to: alloy::primitives::Address::from_slice(&target_address),
+        input: Default::default(),
+        salt: 3,
+    });
     let tx_non_service = {
         let tx = TxEip1559 {
             chain_id: 37u64,
@@ -1518,14 +1474,14 @@ fn test_service_block_invariants() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     let block_context = BlockContext {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
     tester
-        .run_block_no_panic(
+        .execute_block_no_panic_with(
             vec![tx4.clone(), tx_non_service.clone()],
             Some(block_context),
             None,
@@ -1539,7 +1495,7 @@ fn test_service_block_invariants() {
         ..Default::default()
     };
     tester
-        .run_block_no_panic(
+        .execute_block_no_panic_with(
             vec![tx_non_service, tx4],
             Some(block_context),
             None,
@@ -1568,11 +1524,11 @@ fn test_simulation_skips_nonce_check() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // In simulation mode, the transaction should succeed (nonce check skipped)
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction should pass validation in simulation mode, got: {:?}",
@@ -1580,7 +1536,7 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    let result_normal = tester.run_block(vec![tx], None, None, run_config());
+    let result_normal = tester.execute_block_with(vec![tx], None, None, run_config());
     assert!(
         matches!(
             result_normal.tx_results[0],
@@ -1613,9 +1569,9 @@ fn test_simulation_balance_check() {
             value: U256::from(1),
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee and value should fail validation in simulation mode"
@@ -1632,9 +1588,9 @@ fn test_simulation_balance_check() {
             value: Default::default(),
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee should fail validation in simulation mode"
@@ -1651,9 +1607,9 @@ fn test_simulation_balance_check() {
             value: U256::from(1),
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with value should fail validation in simulation mode"
@@ -1670,9 +1626,9 @@ fn test_simulation_balance_check() {
             value: Default::default(),
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction with no fee/value should pass validation in simulation mode"
@@ -1700,14 +1656,14 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
         )],
         max_fee_per_blob_gas: 0,
     };
-    let encoded_tx = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode();
+    let encoded_tx = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone());
 
     let block_context = BlockContext {
         blob_fee: U256::from(1),
         ..Default::default()
     };
 
-    let result_simulation = tester.simulate_encoded_block(vec![encoded_tx], Some(block_context));
+    let result_simulation = tester.simulate_block_with(vec![encoded_tx], Some(block_context));
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "EIP-4844 tx should pass simulation when blob_fee > 0 and max_fee_per_blob_gas = 0, got: {:?}",
@@ -1734,7 +1690,7 @@ fn test_simulation_gas_and_native_used() {
         access_list: Default::default(),
     };
 
-    let encoded_for_simulation = ZKsyncTxEnvelope::from_eth_tx(tx.clone(), wallet.clone()).encode();
+    let encoded_for_simulation = ZKsyncTxEnvelope::from_eth_tx(tx.clone(), wallet.clone());
 
     // We use a very low native per gas ratio to force the transaction to require extra gas
     let block_context = BlockContext {
@@ -1744,7 +1700,7 @@ fn test_simulation_gas_and_native_used() {
     };
 
     let result_simulation =
-        tester.simulate_encoded_block(vec![encoded_for_simulation], Some(block_context.clone()));
+        tester.simulate_block_with(vec![encoded_for_simulation], Some(block_context.clone()));
     let tx_result_simulation = result_simulation.tx_results[0]
         .clone()
         .expect("Simulation must succeed");
@@ -1753,9 +1709,10 @@ fn test_simulation_gas_and_native_used() {
         gas_limit: tx_result_simulation.gas_used,
         ..tx
     };
-    let encoded = ZKsyncTxEnvelope::from_eth_tx(tx, wallet).encode();
+    let encoded = ZKsyncTxEnvelope::from_eth_tx(tx, wallet);
 
-    let result_normal = tester.run_block(vec![encoded], Some(block_context), None, run_config());
+    let result_normal =
+        tester.execute_block_with(vec![encoded], Some(block_context), None, run_config());
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
         .expect("Normal execution must succeed");
@@ -1792,7 +1749,7 @@ fn test_simulation_gas_used_regression() {
             value: U256::ZERO,
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     let block_context = BlockContext {
         eip1559_basefee: U256::from(91161500u64),
@@ -1801,7 +1758,7 @@ fn test_simulation_gas_used_regression() {
         ..Default::default()
     };
     let result_simulation =
-        tester.simulate_encoded_block(vec![tx.clone()], Some(block_context.clone()));
+        tester.simulate_block_with(vec![tx.clone()], Some(block_context.clone()));
     let first_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1817,10 +1774,10 @@ fn test_simulation_gas_used_regression() {
             value: U256::ZERO,
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], Some(block_context));
+    let result_simulation = tester.simulate_block_with(vec![tx.clone()], Some(block_context));
     let second_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1875,7 +1832,7 @@ fn test_treasury_based_token_distribution_regression() {
     // Credit L1 sender with enough balance for the value transfer
     tester.set_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
 
-    let l1_tx = {
+    let l1_tx: ZKsyncTxEnvelope = {
         let tx = L1TxBuilder::new()
             .from(l1_sender)
             .to(l1_recipient)
@@ -1884,14 +1841,14 @@ fn test_treasury_based_token_distribution_regression() {
             .value(value_to_transfer)
             .build();
 
-        tx.encode()
+        tx.into()
     };
 
     let block_context = BlockContext {
         coinbase: B160::from_alloy(coinbase),
         ..Default::default()
     };
-    let output = tester.run_block(vec![l1_tx], Some(block_context), None, None);
+    let output = tester.execute_block_with(vec![l1_tx], Some(block_context), None, None);
 
     // Verify transaction succeeded
     assert!(
@@ -1985,7 +1942,7 @@ fn test_treasury_insufficient_balance_failure() {
     let gas_limit = 100_000u64;
     let value_to_transfer = U256::from(500_000u64); // More than treasury can cover
 
-    let l1_tx = {
+    let l1_tx: ZKsyncTxEnvelope = {
         let tx = L1TxBuilder::new()
             .from(l1_sender)
             .to(l1_recipient)
@@ -1993,7 +1950,7 @@ fn test_treasury_insufficient_balance_failure() {
             .gas_limit(gas_limit.into())
             .value(value_to_transfer)
             .build();
-        tx.encode()
+        tx.into()
     };
 
     let config = RunConfig {
@@ -2002,7 +1959,7 @@ fn test_treasury_insufficient_balance_failure() {
     };
 
     // This should fail due to insufficient treasury balance
-    let result = tester.run_block_no_panic(vec![l1_tx], None, None, Some(config));
+    let result = tester.execute_block_no_panic_with(vec![l1_tx], None, None, Some(config));
 
     // Verify transaction fails due to treasury insufficient balance
     assert!(
@@ -2062,7 +2019,7 @@ fn test_pubdata_native_calculation_overflow() {
             value: U256::from(1000),
             ..Default::default()
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Set extremely high native_per_pubdata to trigger overflow in current_pubdata_spent.checked_mul(native_per_pubdata)
@@ -2076,7 +2033,7 @@ fn test_pubdata_native_calculation_overflow() {
         ..Default::default()
     };
 
-    let result = tester.run_block(vec![tx], Some(block_context), None, None);
+    let result = tester.execute_block_with(vec![tx], Some(block_context), None, None);
 
     // Verify the specific error is OutOfNativeResources
     match &result.tx_results[0].as_ref().unwrap().execution_result {

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -164,7 +164,7 @@ fn run_base_system() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let tester = ZKsyncOSTester::<false>::new()
+    let tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
         .with_prefunded_account(B160::from_be_bytes(from.0))
         .with_prefunded_account(B160::from_alloy(eoa_wallet.address()))
@@ -490,8 +490,6 @@ fn test_cold_in_new_tx() {
 // Test that if we send 2 simple transfers from and to different addresses,
 // the length of the pubdata from both is the same.
 fn test_independent_txs_have_same_pubdata() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     let wallet1 = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -501,6 +499,7 @@ fn test_independent_txs_have_same_pubdata() {
         "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
     .unwrap();
+
     let to1 = address!("0000000000000000000000000000000000010002");
     let to2 = address!("0000000000000000000000000000000000010003");
 
@@ -536,26 +535,22 @@ fn test_independent_txs_have_same_pubdata() {
 
     let transactions = vec![encoded_tx_1, encoded_tx_2];
 
-    tester
-        .set_balance(
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(
             B160::from_alloy(wallet1.address()),
             U256::from(1_000_000_000_000_000_u64),
         )
-        .set_balance(
+        .with_balance(
             B160::from_alloy(wallet2.address()),
             U256::from(1_000_000_000_000_000_u64),
-        );
+        )
+        .with_run_config(run_config().unwrap());
 
-    let output = tester.execute_block_with(transactions, None, None, run_config());
+    let output = tester.execute_block(transactions);
 
     // Assert all txs succeeded and compare pubdata len
-    assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
-        let success = r.clone().is_ok_and(|o| o.is_success());
-        if !success {
-            println!("Transaction {i} failed with: {r:?}",)
-        }
-        success
-    }));
+    tester.assert_all_txs_succeded(&output);
+
     let result1 = output.tx_results.first().unwrap().clone();
     let result2 = output.tx_results.get(1).unwrap().clone();
     let pubdata_used_1 = result1.unwrap().pubdata_used;
@@ -574,7 +569,8 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
+    let l1_messenger_hook = address!("0000000000000000000000000000000000007001");
 
     // Invalid tx first
     let encoded_mint1_tx = {
@@ -590,14 +586,6 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
     let withdrawal_tx = {
-        let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
-        let l1_messenger_hook = address!("0000000000000000000000000000000000007001");
-
-        tester.set_balance(
-            B160::from_alloy(l1_messenger_contract),
-            U256::from(1_000_000_000_000_000_u64),
-        );
-
         let withdrawal_calldata =
             hex::decode("51cff8d9000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
                 .unwrap();
@@ -615,13 +603,18 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     };
 
     let transactions = vec![encoded_mint1_tx, withdrawal_tx];
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
 
-    let output = tester.execute_block_with(transactions, None, None, None);
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(
+            B160::from_alloy(l1_messenger_contract),
+            U256::from(1_000_000_000_000_000_u64),
+        )
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_balance(
+            B160::from_be_bytes(from.0),
+            U256::from(1_000_000_000_000_000_u64),
+        );
+    let output = tester.execute_block(transactions);
 
     // Assert tx succeeded/failed
     let result0 = output.tx_results.first().unwrap().clone();
@@ -666,20 +659,26 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let mut tester = ZKsyncOSTester::<false>::new();
     let transactions = vec![encoded_mint_tx.clone()];
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    let output = tester.execute_block_with(transactions, None, None, None);
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_balance(
+            B160::from_be_bytes(from.0),
+            U256::from(1_000_000_000_000_000_u64),
+        );
+
+    let output = tester.execute_block(transactions);
 
     // Assert tx succeeded
-    let result = output.tx_results.first().unwrap().clone();
-    assert!(result.as_ref().is_ok_and(|o| o.is_success()));
+    tester.assert_all_txs_succeded(&output);
 
-    let native_used_reference = result.unwrap().native_used;
+    let native_used_reference = output
+        .tx_results
+        .first()
+        .unwrap()
+        .clone()
+        .unwrap()
+        .native_used;
 
     // Same tx but with a huge gas limit, which makes it invalid
     // We run this one first and then the valid one, and check that
@@ -697,14 +696,14 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_balance(
+            B160::from_be_bytes(from.0),
+            U256::from(1_000_000_000_000_000_u64),
+        );
     let transactions = vec![encoded_mint1_tx, encoded_mint_tx];
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    let output = tester.execute_block_with(transactions, None, None, None);
+    let output = tester.execute_block(transactions);
 
     // Assert tx succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -721,8 +720,6 @@ fn test_invalid_tx_does_not_affect_native() {
 // TODO: find better place for regression tests
 #[test]
 fn test_regression_returndata_empty_3541() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -757,6 +754,14 @@ fn test_regression_returndata_empty_3541() {
     let from = wallet_ethers.address();
 
     let to = address!("0000000000000000000000000000000000010002");
+    let bytecode = hex::decode(BYTECODE).unwrap();
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_balance(
+            B160::from_be_bytes(from.0),
+            U256::from(1_000_000_000_000_000_u64),
+        )
+        .with_run_config(run_config().unwrap());
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
@@ -775,15 +780,7 @@ fn test_regression_returndata_empty_3541() {
 
     let transactions = vec![encoded_tx];
 
-    let bytecode = hex::decode(BYTECODE).unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-
-    tester.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-
-    let output = tester.execute_block_with(transactions, None, None, run_config());
+    let output = tester.execute_block(transactions);
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -793,8 +790,6 @@ fn test_regression_returndata_empty_3541() {
 /// Test that transactions with balance calculation overflow are properly rejected
 #[test]
 fn test_balance_overflow_protection() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -802,12 +797,12 @@ fn test_balance_overflow_protection() {
 
     let from = alloy::primitives::Address::from_slice(&wallet.address().as_slice());
     let to = address!("0000000000000000000000000000000000010002");
-
-    // Set a reasonable balance that would be sufficient for normal transactions
-    tester.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(
+            B160::from_alloy(from),
+            U256::from(1_000_000_000_000_000_u64),
+        )
+        .with_run_config(run_config().unwrap());
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
     let overflow_fee_tx = {
@@ -839,12 +834,7 @@ fn test_balance_overflow_protection() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let output = tester.execute_block_with(
-        vec![overflow_fee_tx, overflow_total_tx],
-        None,
-        None,
-        run_config(),
-    );
+    let output = tester.execute_block(vec![overflow_fee_tx, overflow_total_tx]);
 
     assert!(
         output.tx_results.get(0).unwrap().is_err(),
@@ -860,13 +850,12 @@ fn test_balance_overflow_protection() {
 /// instead of a validation error.
 #[test]
 fn test_upgrade_tx_revert_internal_error() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     // Create a contract that always reverts
     let revert_contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does REVERT(0, 0)
     let revert_bytecode = hex::decode("60006000fd").unwrap(); // PUSH1 0, PUSH1 0, REVERT
-    tester.set_evm_bytecode(B160::from_alloy(revert_contract_address), &revert_bytecode);
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(revert_contract_address), &revert_bytecode);
 
     // Create a proper upgrade transaction that calls the reverting contract
 
@@ -879,8 +868,8 @@ fn test_upgrade_tx_revert_internal_error() {
 
     let transactions = vec![upgrade_tx];
 
-    // Use run_block_no_panic to catch the error instead of panicking
-    let result = tester.execute_block_no_panic_with(transactions, None, None, None);
+    // Use execute_block_no_panic to catch the error instead of panicking
+    let result = tester.execute_block_no_panic(transactions);
 
     // The upgrade transaction should fail with an internal error (not validation error)
     assert!(result.is_err());
@@ -897,13 +886,12 @@ fn test_upgrade_tx_revert_internal_error() {
 
 #[test]
 fn test_upgrade_tx_succeeds() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     // Create a contract that always succeeds
     let contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does RETURN(0, 0)
     let bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    tester.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
+    let mut tester =
+        ZKsyncOSTester::new().with_evm_contract(B160::from_alloy(contract_address), &bytecode);
 
     // Create a proper upgrade transaction that calls the contract
     let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
@@ -915,8 +903,8 @@ fn test_upgrade_tx_succeeds() {
 
     let transactions = vec![upgrade_tx];
 
-    // Use run_block_no_panic to catch the error instead of panicking
-    let result = tester.execute_block_no_panic_with(transactions, None, None, None);
+    // Use execute_block_no_panic to catch the error instead of panicking
+    let result = tester.execute_block_no_panic(transactions);
     assert!(result.is_ok());
     let tx_output = result.as_ref().unwrap().tx_results[0].as_ref().unwrap();
     assert!(tx_output.is_success());
@@ -927,12 +915,12 @@ fn test_upgrade_tx_succeeds() {
 
 #[test]
 fn test_invalid_transaction_type_failure() {
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     // Create a simple success contract for the call
     let contract_address = address!("0000000000000000000000000000000000010003");
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    tester.set_evm_bytecode(B160::from_alloy(contract_address), &success_bytecode);
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(B160::from_alloy(contract_address), &success_bytecode)
+        .with_run_config(run_config().unwrap());
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -953,7 +941,7 @@ fn test_invalid_transaction_type_failure() {
         );
 
         let transactions = vec![invalid_tx];
-        let result = tester.execute_block_with(transactions, None, None, run_config());
+        let result = tester.execute_block(transactions);
         assert!(
             result.tx_results[0].is_err(),
             "Transaction with invalid type should fail"
@@ -963,11 +951,14 @@ fn test_invalid_transaction_type_failure() {
 
 #[test]
 fn test_modexp_intermediate_zero_block() {
-    let mut tester = ZKsyncOSTester::<false>::new();
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
     .unwrap();
+    let mut tester = ZKsyncOSTester::new().with_balance(
+        B160::from_alloy(wallet.address()),
+        U256::from(10u64.pow(18)),
+    );
 
     // Modexp precompile address
     let modexp_address = address!("0000000000000000000000000000000000000005");
@@ -1016,12 +1007,7 @@ fn test_modexp_intermediate_zero_block() {
 
     let transactions = vec![encoded_tx];
 
-    tester.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(10u64.pow(18)),
-    );
-
-    let result = tester.execute_block_with(transactions, None, None, None);
+    let result = tester.execute_block(transactions);
 
     // The transaction should succeed
     assert!(
@@ -1048,11 +1034,14 @@ fn test_modexp_intermediate_zero_block() {
 
 #[test]
 fn test_point_eval_call() {
-    let mut tester = ZKsyncOSTester::<false>::new();
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
     .unwrap();
+    let mut tester = ZKsyncOSTester::new().with_balance(
+        B160::from_alloy(wallet.address()),
+        U256::from(10u64.pow(18)),
+    );
 
     let point_eval_address = address!("000000000000000000000000000000000000000a");
 
@@ -1091,12 +1080,7 @@ fn test_point_eval_call() {
 
     let transactions = vec![encoded_tx];
 
-    tester.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(10u64.pow(18)),
-    );
-
-    let result = tester.execute_block_with(transactions, None, None, None);
+    let result = tester.execute_block(transactions);
 
     // The transaction should succeed
     assert!(result.tx_results[0].is_ok(), "Transaction should succeed");
@@ -1123,7 +1107,7 @@ fn test_selfdestruct_to_precompile_gas() {
     // Test that a selfdestruct with a precompile as target doesn't charge for
     // extra warm gas (regression)
 
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
@@ -1132,7 +1116,7 @@ fn test_selfdestruct_to_precompile_gas() {
     // SELFDESTRUCT
     let bytecode = hex::decode("730000000000000000000000000000000000000001ff").unwrap();
 
-    tester.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
+    tester = tester.with_evm_contract(B160::from_alloy(contract_address), &bytecode);
 
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -1154,7 +1138,8 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    let result = tester.execute_block_with(vec![tx_request], None, None, run_config());
+    tester = tester.with_run_config(run_config().unwrap());
+    let result = tester.execute_block(vec![tx_request]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
     let gas_used = res0.clone().unwrap().gas_used;
@@ -1163,7 +1148,7 @@ fn test_selfdestruct_to_precompile_gas() {
 
 #[test]
 fn test_reject_caller_with_code_behavior() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
 
     // Create a contract address with bytecode deployed
@@ -1171,7 +1156,7 @@ fn test_reject_caller_with_code_behavior() {
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // Deploy bytecode to the contract address to make it a "contract with code"
-    tester.set_evm_bytecode(
+    tester.set_evm_contract(
         B160::from_alloy(contract_address),
         &hex::decode("60006000f3").unwrap(), // Simple contract: PUSH1 0, PUSH1 0, RETURN
     );
@@ -1191,7 +1176,7 @@ fn test_reject_caller_with_code_behavior() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let result_simulation = tester.simulate_block_with(vec![from_contract_tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![from_contract_tx.clone()]);
 
     // In simulation mode, the transaction should succeed
     assert!(result_simulation.tx_results[0].is_ok(),);
@@ -1203,7 +1188,9 @@ fn test_reject_caller_with_code_behavior() {
     );
 
     // But in normal mode it should fail
-    let result_normal = tester.execute_block_with(vec![from_contract_tx], None, None, run_config());
+    let result_normal = tester
+        .with_run_config(run_config().unwrap())
+        .execute_block(vec![from_contract_tx]);
     assert!(matches!(
         result_normal.tx_results[0],
         Err(InvalidTransaction::RejectCallerWithCode)
@@ -1214,13 +1201,10 @@ fn test_reject_caller_with_code_behavior() {
 fn test_expensive_pubdata() {
     // Test if a transaction can be executed even if the pubdata price is such that
     // validation pubdata requires to use withheld resources.
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    // Set balance for the contract address
-    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1250,21 +1234,22 @@ fn test_expensive_pubdata() {
         eip1559_basefee: U256::from(1),
         ..Default::default()
     };
+    tester = tester
+        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     // Check tx succeeds
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
 
 #[test]
 fn test_check_pubdata_encoding_version() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    // Set balance for the contract address
-    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1290,8 +1275,12 @@ fn test_check_pubdata_encoding_version() {
         eip1559_basefee: U256::from(1),
         ..Default::default()
     };
+    tester = tester
+        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     // Check tx succeeds
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1300,13 +1289,10 @@ fn test_check_pubdata_encoding_version() {
 
 #[test]
 fn test_check_pubdata_has_timestamp() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    // Set balance for the contract address
-    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1334,8 +1320,12 @@ fn test_check_pubdata_has_timestamp() {
         timestamp,
         ..Default::default()
     };
+    tester = tester
+        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     // Check tx succeeds
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1351,7 +1341,6 @@ fn test_check_pubdata_has_timestamp() {
 
 #[test]
 fn test_simple_service_transaction() {
-    let mut tester = ZKsyncOSTester::<false>::new();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1364,21 +1353,21 @@ fn test_simple_service_transaction() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let mut tester = ZKsyncOSTester::new()
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
+    let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
 
 #[test]
 fn test_simple_service_transaction_whitelist() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     // Invalid target
     let target_address = [0u8; 20];
-
-    // Set balance for the contract address
-    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
         to: alloy::primitives::Address::from_slice(&target_address),
@@ -1390,15 +1379,18 @@ fn test_simple_service_transaction_whitelist() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
+    tester = tester
+        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     // Check tx succeeds
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_err(), "Tx should fail");
 }
 
 #[test]
 fn test_service_tx_gas_limit_exceeds_block() {
-    let mut tester = ZKsyncOSTester::<false>::new();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1412,20 +1404,21 @@ fn test_service_tx_gas_limit_exceeds_block() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, run_config());
+    let mut tester = ZKsyncOSTester::new()
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
+    let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok());
 }
 
 #[test]
 fn test_service_block_invariants() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
-    // Set balance for the contract address
-    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester = tester.with_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     // Check that a service block with several service txs works
     let tx1 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1448,9 +1441,11 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     // Check txs succeed
-    let result =
-        tester.execute_block_with(vec![tx1, tx2, tx3], Some(block_context), None, run_config());
+    let result = tester.execute_block(vec![tx1, tx2, tx3]);
     assert!(
         result.tx_results.iter().all(|res| res.is_ok()),
         "All txs should succeed"
@@ -1480,13 +1475,11 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     tester
-        .execute_block_no_panic_with(
-            vec![tx4.clone(), tx_non_service.clone()],
-            Some(block_context),
-            None,
-            run_config(),
-        )
+        .execute_block_no_panic(vec![tx4.clone(), tx_non_service.clone()])
         .expect_err("Service block with non service tx should fail");
 
     // Check that a non-service block with a service tx fails
@@ -1494,20 +1487,18 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::ZERO,
         ..Default::default()
     };
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
     tester
-        .execute_block_no_panic_with(
-            vec![tx_non_service, tx4],
-            Some(block_context),
-            None,
-            run_config(),
-        )
+        .execute_block_no_panic(vec![tx_non_service, tx4])
         .expect_err("Service block with non service tx should fail");
 }
 
 /// Regression test for: Skip nonce check on simulation
 #[test]
 fn test_simulation_skips_nonce_check() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
 
@@ -1528,7 +1519,7 @@ fn test_simulation_skips_nonce_check() {
     };
 
     // In simulation mode, the transaction should succeed (nonce check skipped)
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction should pass validation in simulation mode, got: {:?}",
@@ -1536,7 +1527,8 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    let result_normal = tester.execute_block_with(vec![tx], None, None, run_config());
+    tester = tester.with_run_config(run_config().unwrap());
+    let result_normal = tester.execute_block(vec![tx]);
     assert!(
         matches!(
             result_normal.tx_results[0],
@@ -1554,7 +1546,7 @@ fn test_simulation_skips_nonce_check() {
 /// - gasPrice == 0 && value == 0: ok
 #[test]
 fn test_simulation_balance_check() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
 
@@ -1571,7 +1563,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee and value should fail validation in simulation mode"
@@ -1590,7 +1582,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee should fail validation in simulation mode"
@@ -1609,7 +1601,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with value should fail validation in simulation mode"
@@ -1628,7 +1620,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction with no fee/value should pass validation in simulation mode"
@@ -1637,7 +1629,7 @@ fn test_simulation_balance_check() {
 
 #[test]
 fn test_simulation_4844_zero_blob_fee_allowed() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
 
@@ -1663,7 +1655,8 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
         ..Default::default()
     };
 
-    let result_simulation = tester.simulate_block_with(vec![encoded_tx], Some(block_context));
+    tester = tester.with_block_context(block_context);
+    let result_simulation = tester.simulate_block(vec![encoded_tx]);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "EIP-4844 tx should pass simulation when blob_fee > 0 and max_fee_per_blob_gas = 0, got: {:?}",
@@ -1674,7 +1667,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
 /// Check that gas and native used is the same in simulation and actual execution
 #[test]
 fn test_simulation_gas_and_native_used() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
 
@@ -1699,8 +1692,8 @@ fn test_simulation_gas_and_native_used() {
         ..Default::default()
     };
 
-    let result_simulation =
-        tester.simulate_block_with(vec![encoded_for_simulation], Some(block_context.clone()));
+    tester = tester.with_block_context(block_context.clone());
+    let result_simulation = tester.simulate_block(vec![encoded_for_simulation]);
     let tx_result_simulation = result_simulation.tx_results[0]
         .clone()
         .expect("Simulation must succeed");
@@ -1711,8 +1704,10 @@ fn test_simulation_gas_and_native_used() {
     };
     let encoded = ZKsyncTxEnvelope::from_eth_tx(tx, wallet);
 
-    let result_normal =
-        tester.execute_block_with(vec![encoded], Some(block_context), None, run_config());
+    tester = tester
+        .with_block_context(block_context)
+        .with_run_config(run_config().unwrap());
+    let result_normal = tester.execute_block(vec![encoded]);
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
         .expect("Normal execution must succeed");
@@ -1733,10 +1728,10 @@ fn test_simulation_gas_and_native_used() {
 /// underestimated gas usage.
 #[test]
 fn test_simulation_gas_used_regression() {
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
-    tester.set_balance(B160::from_alloy(wallet.address()), U256::MAX);
+    tester = tester.with_balance(B160::from_alloy(wallet.address()), U256::MAX);
 
     // First tx, 0 gas price.
     let tx = {
@@ -1757,8 +1752,8 @@ fn test_simulation_gas_used_regression() {
         pubdata_price: U256::from(10303657632u64 * 4),
         ..Default::default()
     };
-    let result_simulation =
-        tester.simulate_block_with(vec![tx.clone()], Some(block_context.clone()));
+    tester = tester.with_block_context(block_context.clone());
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     let first_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1777,7 +1772,8 @@ fn test_simulation_gas_used_regression() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let result_simulation = tester.simulate_block_with(vec![tx.clone()], Some(block_context));
+    tester = tester.with_block_context(block_context);
+    let result_simulation = tester.simulate_block(vec![tx.clone()]);
     let second_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1793,7 +1789,7 @@ fn test_simulation_gas_used_regression() {
 fn test_treasury_based_token_distribution_regression() {
     use rig::system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
 
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
 
     // Manually ensure treasury is funded for this test
     tester.mint_tokens_to_treasury();
@@ -1830,7 +1826,7 @@ fn test_treasury_based_token_distribution_regression() {
     let value_to_transfer = U256::from(1_000_000u64);
 
     // Credit L1 sender with enough balance for the value transfer
-    tester.set_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
+    tester = tester.with_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
 
     let l1_tx: ZKsyncTxEnvelope = {
         let tx = L1TxBuilder::new()
@@ -1848,7 +1844,8 @@ fn test_treasury_based_token_distribution_regression() {
         coinbase: B160::from_alloy(coinbase),
         ..Default::default()
     };
-    let output = tester.execute_block_with(vec![l1_tx], Some(block_context), None, None);
+    tester = tester.with_block_context(block_context);
+    let output = tester.execute_block(vec![l1_tx]);
 
     // Verify transaction succeeded
     assert!(
@@ -1928,11 +1925,10 @@ fn test_treasury_based_token_distribution_regression() {
 fn test_treasury_insufficient_balance_failure() {
     use rig::system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
 
-    let mut tester = ZKsyncOSTester::<false>::new();
-
     // Manually set very low treasury balance instead of using default
     let low_treasury_balance = U256::from(1000u64);
-    tester.set_balance(BASE_TOKEN_HOLDER_ADDRESS, low_treasury_balance);
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(BASE_TOKEN_HOLDER_ADDRESS, low_treasury_balance);
 
     // Create L1→L2 transaction that requires more tokens than treasury has
     let l1_sender = address!("1234000000000000000000000000000000000000");
@@ -1959,7 +1955,8 @@ fn test_treasury_insufficient_balance_failure() {
     };
 
     // This should fail due to insufficient treasury balance
-    let result = tester.execute_block_no_panic_with(vec![l1_tx], None, None, Some(config));
+    tester = tester.with_run_config(config);
+    let result = tester.execute_block_no_panic(vec![l1_tx]);
 
     // Verify transaction fails due to treasury insufficient balance
     assert!(
@@ -1981,15 +1978,9 @@ fn test_pubdata_native_calculation_overflow() {
     use alloy::consensus::TxEip1559;
     use rig::alloy::primitives::TxKind;
 
-    let mut tester = ZKsyncOSTester::<false>::new();
+    let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
-
-    // Set initial balance for the wallet
-    tester.set_balance(
-        B160::from_alloy(from),
-        U256::from_str("100000000000000000000010000").unwrap(),
-    );
 
     let to = address!("1234567890123456789012345678901234567890");
     /*
@@ -2005,8 +1996,6 @@ fn test_pubdata_native_calculation_overflow() {
     */
     // Spam some pubdata
     let bytecode = hex::decode("60806040525f5f90505b6014811015603f576c0fffffffffffffffffffffffff5f5f8381526020019081526020015f208190555080806001019150506009565b00fea2646970667358221220d8f4977e359f09d23e2979156755d7e177d43f8a1882a5a178eb98dd8bcb237264736f6c634300081f0033").unwrap();
-    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-
     // Create a transaction that will generate significant pubdata
     let tx = {
         let tx = TxEip1559 {
@@ -2032,8 +2021,14 @@ fn test_pubdata_native_calculation_overflow() {
         eip1559_basefee: U256::from(1),
         ..Default::default()
     };
-
-    let result = tester.execute_block_with(vec![tx], Some(block_context), None, None);
+    tester = tester
+        .with_balance(
+            B160::from_alloy(from),
+            U256::from_str("100000000000000000000010000").unwrap(),
+        )
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_block_context(block_context);
+    let result = tester.execute_block(vec![tx]);
 
     // Verify the specific error is OutOfNativeResources
     match &result.tx_results[0].as_ref().unwrap().execution_result {

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -12,7 +12,7 @@ use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{ZKsyncOSTester, alloy, common_target_address, default_run_config, signer_from_key};
+use rig::{alloy, common_target_address, default_run_config, signer_from_key, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -268,11 +268,8 @@ fn test_withdrawal() {
 
     let transactions = vec![withdrawal_tx, withdrawal_with_message_tx];
 
-    let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-
     let mut tester = ZKsyncOSTester::new()
         .with_system_contracts(true, true, false)
-        .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address())
         .with_run_config(run_config());
 

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -25,14 +25,26 @@ use zksync_web3_rs::signers::{LocalWallet, Signer};
 mod l1_tx_resilience;
 mod native_charging;
 
-fn run_config() -> Option<rig::chain::RunConfig> {
-    Some(rig::chain::RunConfig {
+const PRIMARY_TEST_PK: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+const SECONDARY_TEST_PK: &str = "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be";
+const TERTIARY_TEST_PK: &str = "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+
+fn signer_from_key(key: &str) -> PrivateKeySigner {
+    PrivateKeySigner::from_str(key).unwrap()
+}
+
+fn common_target_address() -> alloy::primitives::Address {
+    address!("4242000000000000000000000000000000000000")
+}
+
+fn run_config() -> RunConfig {
+    RunConfig {
         app: Some("for_tests".to_string()),
         only_forward: false,
         check_storage_diff_hashes: true,
         skip_minting_tokens_to_treasury: false,
         ..Default::default()
-    })
+    }
 }
 
 #[test]
@@ -41,19 +53,11 @@ fn run_base_system() {
     // Which seems to suggest that it is special.
     // Consider changing this one to be more "random".
 
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     // We used for test where from cannot have deployed code
-    let eoa_wallet = PrivateKeySigner::from_str(
-        "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be",
-    )
-    .unwrap();
+    let eoa_wallet = signer_from_key(SECONDARY_TEST_PK);
 
-    let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
 
     let mint_tx = {
@@ -99,7 +103,7 @@ fn run_base_system() {
         ZKsyncTxEnvelope::from_eth_tx(deployment_tx, wallet.clone())
     };
     let transfer_to_eoa_tx = {
-        let eoa_to = address!("4242000000000000000000000000000000000000");
+        let eoa_to = common_target_address();
         let transfer_to_eoa = TxEip1559 {
             chain_id: 37u64,
             nonce: 0,
@@ -132,7 +136,7 @@ fn run_base_system() {
     let l1_l2_transfer = {
         L1TxBuilder::new()
             .from(address!("1234000000000000000000000000000000000000"))
-            .to(address!("4242000000000000000000000000000000000000"))
+            .to(common_target_address())
             .value(alloy::primitives::U256::from(100))
             .gas_price(1000)
             .gas_limit(21_000)
@@ -166,7 +170,7 @@ fn run_base_system() {
 
     let tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_prefunded_account(B160::from_alloy(wallet.address()))
         .with_prefunded_account(B160::from_alloy(eoa_wallet.address()))
         .with_balance(
             B160::from_alloy(address!("1234000000000000000000000000000000000000")),
@@ -174,7 +178,7 @@ fn run_base_system() {
         );
 
     let output = tester
-        .with_run_config(run_config().unwrap())
+        .with_run_config(run_config())
         .execute_block(transactions);
 
     // Assert all txs succeeded
@@ -227,13 +231,7 @@ fn test_gas_price_zero_fee_one() {
 
 #[test]
 fn test_withdrawal() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-
-    let from = wallet_ethers.address();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     // L2 base token address
     let to = address!("000000000000000000000000000000000000800a");
@@ -285,8 +283,8 @@ fn test_withdrawal() {
     let mut tester = ZKsyncOSTester::new()
         .with_system_contracts(true, true, false)
         .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_be_bytes(from.0))
-        .with_run_config(run_config().unwrap());
+        .with_prefunded_account(B160::from_alloy(wallet.address()))
+        .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -312,19 +310,13 @@ fn test_withdrawal() {
 
 #[test]
 fn test_tx_with_access_list() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-
-    let from = wallet_ethers.address();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     let to = address!("0000000000000000000000000000000000010002");
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
-    let encoded_mint_tx = {
+    let mint_tx = {
         let access_list = AccessList::from(vec![AccessListItem {
             address: to,
             storage_keys: vec![b256!(
@@ -344,14 +336,14 @@ fn test_tx_with_access_list() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_mint_tx];
+    let transactions = vec![mint_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_be_bytes(from.0))
-        .with_run_config(run_config().unwrap());
+        .with_prefunded_account(B160::from_alloy(wallet.address()))
+        .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -363,23 +355,17 @@ fn test_tx_with_authorization_list() {
     use rig::alloy::eips::eip7702::*;
     use rig::alloy::signers::SignerSync;
 
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
 
-    let delegate = PrivateKeySigner::from_str(
-        "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be",
-    )
-    .unwrap();
+    let delegate = signer_from_key(SECONDARY_TEST_PK);
 
     let from = wallet_ethers.address();
     let to = delegate.address();
 
     let erc_20_contract = address!("0000000000000000000000000000000000010002");
 
-    let encoded_mint_tx = {
+    let mint_tx = {
         let authorization = Authorization {
             chain_id: U256::from(37u64),
             address: erc_20_contract,
@@ -409,9 +395,9 @@ fn test_tx_with_authorization_list() {
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(erc_20_contract), &bytecode)
         .with_prefunded_account(B160::from_be_bytes(from.0))
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
-    let output = tester.execute_block(vec![encoded_mint_tx]);
+    let output = tester.execute_block(vec![mint_tx]);
 
     tester.assert_all_txs_succeded(&output);
 }
@@ -419,10 +405,7 @@ fn test_tx_with_authorization_list() {
 // Test that slots made warm in a tx are cold in the next tx
 #[test]
 fn test_cold_in_new_tx() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
 
     let from = wallet_ethers.address();
@@ -431,7 +414,7 @@ fn test_cold_in_new_tx() {
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
-    let encoded_mint_tx = {
+    let mint_tx = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -445,7 +428,7 @@ fn test_cold_in_new_tx() {
     };
 
     // Gas is just enough to succeed.
-    let encoded_mint1_tx = {
+    let mint_tx_1 = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 1,
@@ -459,7 +442,7 @@ fn test_cold_in_new_tx() {
     };
 
     // Any lower gas amount should fail
-    let encoded_mint_tx2 = {
+    let mint_tx_2 = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 2,
@@ -472,14 +455,14 @@ fn test_cold_in_new_tx() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_mint_tx, encoded_mint1_tx, encoded_mint_tx2];
+    let transactions = vec![mint_tx, mint_tx_1, mint_tx_2];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
         .with_prefunded_account(B160::from_be_bytes(from.0))
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -490,20 +473,14 @@ fn test_cold_in_new_tx() {
 // Test that if we send 2 simple transfers from and to different addresses,
 // the length of the pubdata from both is the same.
 fn test_independent_txs_have_same_pubdata() {
-    let wallet1 = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet1 = signer_from_key(PRIMARY_TEST_PK);
 
-    let wallet2 = PrivateKeySigner::from_str(
-        "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet2 = signer_from_key(TERTIARY_TEST_PK);
 
     let to1 = address!("0000000000000000000000000000000000010002");
     let to2 = address!("0000000000000000000000000000000000010003");
 
-    let encoded_tx_1 = {
+    let tx_1 = {
         let tx = TxEip1559 {
             chain_id: 37u64,
             nonce: 0,
@@ -518,7 +495,7 @@ fn test_independent_txs_have_same_pubdata() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet1.clone())
     };
 
-    let encoded_tx_2 = {
+    let tx_2 = {
         let tx = TxEip1559 {
             chain_id: 37u64,
             nonce: 0,
@@ -533,7 +510,7 @@ fn test_independent_txs_have_same_pubdata() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet2.clone())
     };
 
-    let transactions = vec![encoded_tx_1, encoded_tx_2];
+    let transactions = vec![tx_1, tx_2];
 
     let mut tester = ZKsyncOSTester::new()
         .with_balance(
@@ -544,7 +521,7 @@ fn test_independent_txs_have_same_pubdata() {
             B160::from_alloy(wallet2.address()),
             U256::from(1_000_000_000_000_000_u64),
         )
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -560,10 +537,7 @@ fn test_independent_txs_have_same_pubdata() {
 
 #[test]
 fn test_invalid_tx_does_not_bump_tx_counter() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
     let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
@@ -573,7 +547,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     let l1_messenger_hook = address!("0000000000000000000000000000000000007001");
 
     // Invalid tx first
-    let encoded_mint1_tx = {
+    let mint_tx_1 = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -602,7 +576,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
         tx.into()
     };
 
-    let transactions = vec![encoded_mint1_tx, withdrawal_tx];
+    let transactions = vec![mint_tx_1, withdrawal_tx];
 
     let mut tester = ZKsyncOSTester::new()
         .with_balance(
@@ -636,17 +610,14 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
 
 #[test]
 fn test_invalid_tx_does_not_affect_native() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
     let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     // First we run a single tx to get the "normal" amount of native used
-    let encoded_mint_tx = {
+    let mint_tx = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -659,7 +630,7 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_mint_tx.clone()];
+    let transactions = vec![mint_tx.clone()];
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(to), &bytecode)
         .with_balance(
@@ -683,7 +654,7 @@ fn test_invalid_tx_does_not_affect_native() {
     // Same tx but with a huge gas limit, which makes it invalid
     // We run this one first and then the valid one, and check that
     // the valid one uses the same amount of native as in the reference case.
-    let encoded_mint1_tx = {
+    let mint_tx_1 = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -702,7 +673,7 @@ fn test_invalid_tx_does_not_affect_native() {
             B160::from_be_bytes(from.0),
             U256::from(1_000_000_000_000_000_u64),
         );
-    let transactions = vec![encoded_mint1_tx, encoded_mint_tx];
+    let transactions = vec![mint_tx_1, mint_tx];
     let output = tester.execute_block(transactions);
 
     // Assert tx succeeded
@@ -720,10 +691,7 @@ fn test_invalid_tx_does_not_affect_native() {
 // TODO: find better place for regression tests
 #[test]
 fn test_regression_returndata_empty_3541() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
     // Code for:
     // PUSH13 0x63EF0000006000526004601CF3
@@ -761,11 +729,11 @@ fn test_regression_returndata_empty_3541() {
             B160::from_be_bytes(from.0),
             U256::from(1_000_000_000_000_000_u64),
         )
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
-    let encoded_tx = {
+    let tx_envelope = {
         let mint_tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -778,7 +746,7 @@ fn test_regression_returndata_empty_3541() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_tx];
+    let transactions = vec![tx_envelope];
 
     let output = tester.execute_block(transactions);
 
@@ -790,10 +758,7 @@ fn test_regression_returndata_empty_3541() {
 /// Test that transactions with balance calculation overflow are properly rejected
 #[test]
 fn test_balance_overflow_protection() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     let from = alloy::primitives::Address::from_slice(&wallet.address().as_slice());
     let to = address!("0000000000000000000000000000000000010002");
@@ -802,7 +767,7 @@ fn test_balance_overflow_protection() {
             B160::from_alloy(from),
             U256::from(1_000_000_000_000_000_u64),
         )
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
     let overflow_fee_tx = {
@@ -920,7 +885,7 @@ fn test_invalid_transaction_type_failure() {
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(B160::from_alloy(contract_address), &success_bytecode)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -951,10 +916,7 @@ fn test_invalid_transaction_type_failure() {
 
 #[test]
 fn test_modexp_intermediate_zero_block() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let mut tester = ZKsyncOSTester::new().with_balance(
         B160::from_alloy(wallet.address()),
         U256::from(10u64.pow(18)),
@@ -991,7 +953,7 @@ fn test_modexp_intermediate_zero_block() {
     ))
     .unwrap();
 
-    let encoded_tx = {
+    let tx_envelope = {
         let mint_tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -1005,7 +967,7 @@ fn test_modexp_intermediate_zero_block() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_tx];
+    let transactions = vec![tx_envelope];
 
     let result = tester.execute_block(transactions);
 
@@ -1034,10 +996,7 @@ fn test_modexp_intermediate_zero_block() {
 
 #[test]
 fn test_point_eval_call() {
-    let wallet = PrivateKeySigner::from_str(
-        "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
-    )
-    .unwrap();
+    let wallet = signer_from_key(PRIMARY_TEST_PK);
     let mut tester = ZKsyncOSTester::new().with_balance(
         B160::from_alloy(wallet.address()),
         U256::from(10u64.pow(18)),
@@ -1064,7 +1023,7 @@ fn test_point_eval_call() {
         2, 255, 254, 91, 254, 255, 255, 255, 255, 0, 0, 0, 1,
     ];
 
-    let encoded_tx = {
+    let tx_envelope = {
         let mint_tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -1078,7 +1037,7 @@ fn test_point_eval_call() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let transactions = vec![encoded_tx];
+    let transactions = vec![tx_envelope];
 
     let result = tester.execute_block(transactions);
 
@@ -1138,7 +1097,7 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    tester = tester.with_run_config(run_config().unwrap());
+    tester = tester.with_run_config(run_config());
     let result = tester.execute_block(vec![tx_request]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1153,7 +1112,7 @@ fn test_reject_caller_with_code_behavior() {
 
     // Create a contract address with bytecode deployed
     let contract_address = wallet.address();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     // Deploy bytecode to the contract address to make it a "contract with code"
     tester.set_evm_contract(
@@ -1189,7 +1148,7 @@ fn test_reject_caller_with_code_behavior() {
 
     // But in normal mode it should fail
     let result_normal = tester
-        .with_run_config(run_config().unwrap())
+        .with_run_config(run_config())
         .execute_block(vec![from_contract_tx]);
     assert!(matches!(
         result_normal.tx_results[0],
@@ -1204,7 +1163,7 @@ fn test_expensive_pubdata() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     let tx = {
         let tx = TxEip1559 {
@@ -1237,7 +1196,7 @@ fn test_expensive_pubdata() {
     tester = tester
         .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1249,7 +1208,7 @@ fn test_check_pubdata_encoding_version() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     let tx = {
         let tx = TxEip1559 {
@@ -1278,7 +1237,7 @@ fn test_check_pubdata_encoding_version() {
     tester = tester
         .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1292,7 +1251,7 @@ fn test_check_pubdata_has_timestamp() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     let tx = {
         let tx = TxEip1559 {
@@ -1323,7 +1282,7 @@ fn test_check_pubdata_has_timestamp() {
     tester = tester
         .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1355,7 +1314,7 @@ fn test_simple_service_transaction() {
     };
     let mut tester = ZKsyncOSTester::new()
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1382,7 +1341,7 @@ fn test_simple_service_transaction_whitelist() {
     tester = tester
         .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1406,7 +1365,7 @@ fn test_service_tx_gas_limit_exceeds_block() {
     };
     let mut tester = ZKsyncOSTester::new()
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok());
 }
@@ -1443,7 +1402,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     // Check txs succeed
     let result = tester.execute_block(vec![tx1, tx2, tx3]);
     assert!(
@@ -1464,7 +1423,7 @@ fn test_service_block_invariants() {
             max_fee_per_gas: 134217728,
             max_priority_fee_per_gas: 134217728,
             gas_limit: 75_000,
-            to: TxKind::Call(address!("4242000000000000000000000000000000000000")),
+            to: TxKind::Call(common_target_address()),
             value: Default::default(),
             input: Default::default(),
             access_list: Default::default(),
@@ -1477,7 +1436,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     tester
         .execute_block_no_panic(vec![tx4.clone(), tx_non_service.clone()])
         .expect_err("Service block with non service tx should fail");
@@ -1489,7 +1448,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     tester
         .execute_block_no_panic(vec![tx_non_service, tx4])
         .expect_err("Service block with non service tx should fail");
@@ -1500,7 +1459,7 @@ fn test_service_block_invariants() {
 fn test_simulation_skips_nonce_check() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     // Create a transaction with nonce 100, but the account's nonce is 0
     let tx = {
@@ -1527,7 +1486,7 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    tester = tester.with_run_config(run_config().unwrap());
+    tester = tester.with_run_config(run_config());
     let result_normal = tester.execute_block(vec![tx]);
     assert!(
         matches!(
@@ -1548,7 +1507,7 @@ fn test_simulation_skips_nonce_check() {
 fn test_simulation_balance_check() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     // - gasPrice > 0 && value > 0: fail
     let tx = {
@@ -1631,7 +1590,7 @@ fn test_simulation_balance_check() {
 fn test_simulation_4844_zero_blob_fee_allowed() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     let tx = TxEip4844 {
         chain_id: 37u64,
@@ -1648,7 +1607,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
         )],
         max_fee_per_blob_gas: 0,
     };
-    let encoded_tx = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone());
+    let tx_envelope = ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone());
 
     let block_context = BlockContext {
         blob_fee: U256::from(1),
@@ -1656,7 +1615,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
     };
 
     tester = tester.with_block_context(block_context);
-    let result_simulation = tester.simulate_block(vec![encoded_tx]);
+    let result_simulation = tester.simulate_block(vec![tx_envelope]);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "EIP-4844 tx should pass simulation when blob_fee > 0 and max_fee_per_blob_gas = 0, got: {:?}",
@@ -1669,7 +1628,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
 fn test_simulation_gas_and_native_used() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.prefunded_random_signer();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
     let tx = TxEip1559 {
         chain_id: 37u64,
@@ -1683,7 +1642,7 @@ fn test_simulation_gas_and_native_used() {
         access_list: Default::default(),
     };
 
-    let encoded_for_simulation = ZKsyncTxEnvelope::from_eth_tx(tx.clone(), wallet.clone());
+    let tx_for_simulation = ZKsyncTxEnvelope::from_eth_tx(tx.clone(), wallet.clone());
 
     // We use a very low native per gas ratio to force the transaction to require extra gas
     let block_context = BlockContext {
@@ -1693,7 +1652,7 @@ fn test_simulation_gas_and_native_used() {
     };
 
     tester = tester.with_block_context(block_context.clone());
-    let result_simulation = tester.simulate_block(vec![encoded_for_simulation]);
+    let result_simulation = tester.simulate_block(vec![tx_for_simulation]);
     let tx_result_simulation = result_simulation.tx_results[0]
         .clone()
         .expect("Simulation must succeed");
@@ -1706,7 +1665,7 @@ fn test_simulation_gas_and_native_used() {
 
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config().unwrap());
+        .with_run_config(run_config());
     let result_normal = tester.execute_block(vec![encoded]);
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
@@ -1730,7 +1689,7 @@ fn test_simulation_gas_and_native_used() {
 fn test_simulation_gas_used_regression() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
     tester = tester.with_balance(B160::from_alloy(wallet.address()), U256::MAX);
 
     // First tx, 0 gas price.
@@ -1801,24 +1760,16 @@ fn test_treasury_based_token_distribution_regression() {
     let refund_recipient = address!("0000000000000000000000000000000000000000"); // refund recipient (zero address)
 
     // Record initial treasury balance
-    let treasury_initial_balance = tester
-        .get_account_properties(&BASE_TOKEN_HOLDER_ADDRESS)
-        .balance;
+    let treasury_initial_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS);
 
     // Record initial operator balance
-    let operator_initial_balance = tester
-        .get_account_properties(&B160::from_alloy(coinbase))
-        .balance;
+    let operator_initial_balance = tester.get_balance(&B160::from_alloy(coinbase));
 
     // Record initial recipient balance
-    let recipient_initial_balance = tester
-        .get_account_properties(&B160::from_alloy(l1_recipient))
-        .balance;
+    let recipient_initial_balance = tester.get_balance(&B160::from_alloy(l1_recipient));
 
     // Record initial refund recipient balance
-    let refund_recipient_initial_balance = tester
-        .get_account_properties(&B160::from_alloy(refund_recipient))
-        .balance;
+    let refund_recipient_initial_balance = tester.get_balance(&B160::from_alloy(refund_recipient));
 
     // Create L1→L2 transaction with value transfer and fees
     let gas_price = 1000u64;
@@ -1828,17 +1779,14 @@ fn test_treasury_based_token_distribution_regression() {
     // Credit L1 sender with enough balance for the value transfer
     tester = tester.with_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
 
-    let l1_tx: ZKsyncTxEnvelope = {
-        let tx = L1TxBuilder::new()
-            .from(l1_sender)
-            .to(l1_recipient)
-            .gas_price(gas_price.into())
-            .gas_limit(gas_limit.into())
-            .value(value_to_transfer)
-            .build();
-
-        tx.into()
-    };
+    let l1_tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(l1_sender)
+        .to(l1_recipient)
+        .gas_price(gas_price.into())
+        .gas_limit(gas_limit.into())
+        .value(value_to_transfer)
+        .build()
+        .into();
 
     let block_context = BlockContext {
         coinbase: B160::from_alloy(coinbase),
@@ -1865,21 +1813,13 @@ fn test_treasury_based_token_distribution_regression() {
     let fee_paid_to_operator = U256::from(gas_used) * U256::from(gas_price);
 
     // Get final balances
-    let treasury_final_balance = tester
-        .get_account_properties(&BASE_TOKEN_HOLDER_ADDRESS)
-        .balance;
+    let treasury_final_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS);
 
-    let operator_final_balance = tester
-        .get_account_properties(&B160::from_alloy(coinbase))
-        .balance;
+    let operator_final_balance = tester.get_balance(&B160::from_alloy(coinbase));
 
-    let recipient_final_balance = tester
-        .get_account_properties(&B160::from_alloy(l1_recipient))
-        .balance;
+    let recipient_final_balance = tester.get_balance(&B160::from_alloy(l1_recipient));
 
-    let refund_recipient_final_balance = tester
-        .get_account_properties(&B160::from_alloy(refund_recipient))
-        .balance;
+    let refund_recipient_final_balance = tester.get_balance(&B160::from_alloy(refund_recipient));
 
     // Calculate total amount that should go to operator (fee + refund)
     // Refund recipient is 0 in this test
@@ -1938,21 +1878,17 @@ fn test_treasury_insufficient_balance_failure() {
     let gas_limit = 100_000u64;
     let value_to_transfer = U256::from(500_000u64); // More than treasury can cover
 
-    let l1_tx: ZKsyncTxEnvelope = {
-        let tx = L1TxBuilder::new()
-            .from(l1_sender)
-            .to(l1_recipient)
-            .gas_price(gas_price.into())
-            .gas_limit(gas_limit.into())
-            .value(value_to_transfer)
-            .build();
-        tx.into()
-    };
+    let l1_tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(l1_sender)
+        .to(l1_recipient)
+        .gas_price(gas_price.into())
+        .gas_limit(gas_limit.into())
+        .value(value_to_transfer)
+        .build()
+        .into();
 
-    let config = RunConfig {
-        skip_minting_tokens_to_treasury: true,
-        ..Default::default()
-    };
+    let mut config = run_config();
+    config.skip_minting_tokens_to_treasury = true; // Ensure we rely on treasury balance, not minting
 
     // This should fail due to insufficient treasury balance
     tester = tester.with_run_config(config);
@@ -2027,7 +1963,8 @@ fn test_pubdata_native_calculation_overflow() {
             U256::from_str("100000000000000000000010000").unwrap(),
         )
         .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_block_context(block_context);
+        .with_block_context(block_context)
+        .with_run_config(run_config());
     let result = tester.execute_block(vec![tx]);
 
     // Verify the specific error is OutOfNativeResources

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -12,7 +12,7 @@ use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, common_target_address, signer_from_key, ZKsyncOSTester};
+use rig::{alloy, common_target_address, signer_from_key, TestingFramework};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
@@ -147,7 +147,7 @@ fn run_base_system() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address())
         .with_prefunded_account(eoa_wallet.address())
@@ -170,13 +170,13 @@ fn run_base_system() {
 
 #[test]
 fn test_block_of_erc20() {
-    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
+    let mut tester = TestingFramework::new_with_randomized_tree();
     tester.run_block_of_erc20(10, None);
 }
 
 #[test]
 fn test_gas_price_zero_fee_zero() {
-    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
+    let mut tester = TestingFramework::new_with_randomized_tree();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
@@ -198,7 +198,7 @@ fn test_gas_price_zero_fee_zero() {
 
 #[test]
 fn test_gas_price_zero_fee_one() {
-    let mut tester = ZKsyncOSTester::new_with_randomized_tree();
+    let mut tester = TestingFramework::new_with_randomized_tree();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
@@ -255,7 +255,7 @@ fn test_withdrawal() {
 
     let transactions = vec![withdrawal_tx, withdrawal_with_message_tx];
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_system_contracts(true, true, false)
         .with_prefunded_account(wallet.address());
 
@@ -313,7 +313,7 @@ fn test_tx_with_access_list() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address());
 
@@ -362,7 +362,7 @@ fn test_tx_with_authorization_list() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(erc_20_contract, &bytecode)
         .with_prefunded_account(wallet.address());
 
@@ -425,7 +425,7 @@ fn test_cold_in_new_tx() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address());
 
@@ -483,7 +483,7 @@ fn test_independent_txs_have_same_pubdata() {
 
     let transactions = vec![tx_1, tx_2];
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_balance(wallet1.address(), U256::from(1_000_000_000_000_000_u64))
         .with_balance(wallet2.address(), U256::from(1_000_000_000_000_000_u64));
 
@@ -540,7 +540,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
 
     let transactions = vec![mint_tx_1, withdrawal_tx];
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_balance(l1_messenger_contract, U256::from(1_000_000_000_000_000_u64))
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
@@ -585,7 +585,7 @@ fn test_invalid_tx_does_not_affect_native() {
     };
 
     let transactions = vec![mint_tx.clone()];
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
@@ -618,7 +618,7 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
     let transactions = vec![mint_tx_1, mint_tx];
@@ -668,7 +668,7 @@ fn test_regression_returndata_empty_3541() {
 
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(BYTECODE).unwrap();
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
@@ -702,8 +702,8 @@ fn test_balance_overflow_protection() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     let to = address!("0000000000000000000000000000000000010002");
-    let mut tester =
-        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+    let mut tester = TestingFramework::new()
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
     let overflow_fee_tx = {
@@ -756,7 +756,7 @@ fn test_upgrade_tx_revert_internal_error() {
     // Simple contract bytecode that just does REVERT(0, 0)
     let revert_bytecode = hex::decode("60006000fd").unwrap(); // PUSH1 0, PUSH1 0, REVERT
     let mut tester =
-        ZKsyncOSTester::new().with_evm_contract(revert_contract_address, &revert_bytecode);
+        TestingFramework::new().with_evm_contract(revert_contract_address, &revert_bytecode);
 
     // Create a proper upgrade transaction that calls the reverting contract
 
@@ -791,7 +791,7 @@ fn test_upgrade_tx_succeeds() {
     let contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does RETURN(0, 0)
     let bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    let mut tester = ZKsyncOSTester::new().with_evm_contract(contract_address, &bytecode);
+    let mut tester = TestingFramework::new().with_evm_contract(contract_address, &bytecode);
 
     // Create a proper upgrade transaction that calls the contract
     let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
@@ -818,7 +818,7 @@ fn test_invalid_transaction_type_failure() {
     // Create a simple success contract for the call
     let contract_address = address!("0000000000000000000000000000000000010003");
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    let mut tester = ZKsyncOSTester::new().with_evm_contract(contract_address, &success_bytecode);
+    let mut tester = TestingFramework::new().with_evm_contract(contract_address, &success_bytecode);
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -851,7 +851,7 @@ fn test_invalid_transaction_type_failure() {
 fn test_modexp_intermediate_zero_block() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
     let mut tester =
-        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
+        TestingFramework::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 
     // Modexp precompile address
     let modexp_address = address!("0000000000000000000000000000000000000005");
@@ -929,7 +929,7 @@ fn test_modexp_intermediate_zero_block() {
 fn test_point_eval_call() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
     let mut tester =
-        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
+        TestingFramework::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 
     let point_eval_address = address!("000000000000000000000000000000000000000a");
 
@@ -995,7 +995,7 @@ fn test_selfdestruct_to_precompile_gas() {
     // Test that a selfdestruct with a precompile as target doesn't charge for
     // extra warm gas (regression)
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.prefunded_random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
@@ -1035,7 +1035,7 @@ fn test_selfdestruct_to_precompile_gas() {
 
 #[test]
 fn test_reject_caller_with_code_behavior() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.prefunded_random_signer();
 
     // Create a contract address with bytecode deployed
@@ -1086,7 +1086,7 @@ fn test_reject_caller_with_code_behavior() {
 fn test_expensive_pubdata() {
     // Test if a transaction can be executed even if the pubdata price is such that
     // validation pubdata requires to use withheld resources.
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
 
@@ -1129,7 +1129,7 @@ fn test_expensive_pubdata() {
 
 #[test]
 fn test_check_pubdata_encoding_version() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
 
@@ -1170,7 +1170,7 @@ fn test_check_pubdata_encoding_version() {
 
 #[test]
 fn test_check_pubdata_has_timestamp() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
 
@@ -1232,7 +1232,7 @@ fn test_simple_service_transaction() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let mut tester = ZKsyncOSTester::new().with_block_context(block_context);
+    let mut tester = TestingFramework::new().with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1240,7 +1240,7 @@ fn test_simple_service_transaction() {
 
 #[test]
 fn test_simple_service_transaction_whitelist() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     // Invalid target
     let target_address = [0u8; 20];
@@ -1279,14 +1279,14 @@ fn test_service_tx_gas_limit_exceeds_block() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let mut tester = ZKsyncOSTester::new().with_block_context(block_context);
+    let mut tester = TestingFramework::new().with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok());
 }
 
 #[test]
 fn test_service_block_invariants() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
@@ -1364,7 +1364,7 @@ fn test_service_block_invariants() {
 /// Regression test for: Skip nonce check on simulation
 #[test]
 fn test_simulation_skips_nonce_check() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = common_target_address();
 
@@ -1411,7 +1411,7 @@ fn test_simulation_skips_nonce_check() {
 /// - gasPrice == 0 && value == 0: ok
 #[test]
 fn test_simulation_balance_check() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
 
@@ -1494,7 +1494,7 @@ fn test_simulation_balance_check() {
 
 #[test]
 fn test_simulation_4844_zero_blob_fee_allowed() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = common_target_address();
 
@@ -1532,7 +1532,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
 /// Check that gas and native used is the same in simulation and actual execution
 #[test]
 fn test_simulation_gas_and_native_used() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.prefunded_random_signer();
     let target_address = common_target_address();
 
@@ -1591,7 +1591,7 @@ fn test_simulation_gas_and_native_used() {
 /// underestimated gas usage.
 #[test]
 fn test_simulation_gas_used_regression() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
     tester = tester.with_balance(wallet.address(), U256::MAX);
@@ -1652,7 +1652,7 @@ fn test_simulation_gas_used_regression() {
 fn test_treasury_based_token_distribution_regression() {
     use rig::system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
 
     // Manually ensure treasury is funded for this test
     tester.mint_tokens_to_treasury();
@@ -1771,7 +1771,7 @@ fn test_treasury_insufficient_balance_failure() {
 
     // Manually set very low treasury balance instead of using default
     let low_treasury_balance = U256::from(1000u64);
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_balance(BASE_TOKEN_HOLDER_ADDRESS.into_alloy(), low_treasury_balance);
 
     // Create L1→L2 transaction that requires more tokens than treasury has
@@ -1818,7 +1818,7 @@ fn test_pubdata_native_calculation_overflow() {
     use alloy::consensus::TxEip1559;
     use rig::alloy::primitives::TxKind;
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let to = address!("1234567890123456789012345678901234567890");

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -8,12 +8,11 @@ use rig::alloy::consensus::TxEip7702;
 use rig::alloy::primitives::{address, b256};
 use rig::alloy::rpc::types::{AccessList, AccessListItem, TransactionRequest};
 use rig::basic_bootloader::bootloader::block_flow::zk::PUBDATA_ENCODING_VERSION;
-use rig::chain::RunConfig;
 use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, common_target_address, signer_from_key, ZKsyncOSTester};
+use rig::{ZKsyncOSTester, alloy, common_target_address, default_run_config, signer_from_key};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
@@ -26,16 +25,6 @@ mod native_charging;
 const PRIMARY_TEST_PK: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
 const SECONDARY_TEST_PK: &str = "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be";
 const TERTIARY_TEST_PK: &str = "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
-
-fn run_config() -> RunConfig {
-    RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        skip_minting_tokens_to_treasury: false,
-        ..Default::default()
-    }
-}
 
 #[test]
 fn run_base_system() {
@@ -168,7 +157,7 @@ fn run_base_system() {
         );
 
     let output = tester
-        .with_run_config(run_config())
+        .with_run_config(default_run_config())
         .execute_block(transactions);
 
     // Assert all txs succeeded
@@ -271,7 +260,7 @@ fn test_withdrawal() {
     let mut tester = ZKsyncOSTester::new()
         .with_system_contracts(true, true, false)
         .with_prefunded_account(wallet.address())
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -330,7 +319,7 @@ fn test_tx_with_access_list() {
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address())
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -380,7 +369,7 @@ fn test_tx_with_authorization_list() {
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(erc_20_contract, &bytecode)
         .with_prefunded_account(wallet.address())
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let output = tester.execute_block(vec![mint_tx]);
 
@@ -444,7 +433,7 @@ fn test_cold_in_new_tx() {
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address())
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -503,7 +492,7 @@ fn test_independent_txs_have_same_pubdata() {
     let mut tester = ZKsyncOSTester::new()
         .with_balance(wallet1.address(), U256::from(1_000_000_000_000_000_u64))
         .with_balance(wallet2.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let output = tester.execute_block(transactions);
 
@@ -689,7 +678,7 @@ fn test_regression_returndata_empty_3541() {
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
@@ -723,7 +712,7 @@ fn test_balance_overflow_protection() {
     let to = address!("0000000000000000000000000000000000010002");
     let mut tester = ZKsyncOSTester::new()
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
     let overflow_fee_tx = {
@@ -840,7 +829,7 @@ fn test_invalid_transaction_type_failure() {
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(contract_address, &success_bytecode)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -1048,7 +1037,7 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    tester = tester.with_run_config(run_config());
+    tester = tester.with_run_config(default_run_config());
     let result = tester.execute_block(vec![tx_request]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1099,7 +1088,7 @@ fn test_reject_caller_with_code_behavior() {
 
     // But in normal mode it should fail
     let result_normal = tester
-        .with_run_config(run_config())
+        .with_run_config(default_run_config())
         .execute_block(vec![from_contract_tx]);
     assert!(matches!(
         result_normal.tx_results[0],
@@ -1146,7 +1135,7 @@ fn test_expensive_pubdata() {
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1186,7 +1175,7 @@ fn test_check_pubdata_encoding_version() {
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1230,7 +1219,7 @@ fn test_check_pubdata_has_timestamp() {
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1262,7 +1251,7 @@ fn test_simple_service_transaction() {
     };
     let mut tester = ZKsyncOSTester::new()
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1288,7 +1277,7 @@ fn test_simple_service_transaction_whitelist() {
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1312,7 +1301,7 @@ fn test_service_tx_gas_limit_exceeds_block() {
     };
     let mut tester = ZKsyncOSTester::new()
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok());
 }
@@ -1348,7 +1337,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     // Check txs succeed
     let result = tester.execute_block(vec![tx1, tx2, tx3]);
     assert!(
@@ -1382,7 +1371,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     tester
         .execute_block_no_panic(vec![tx4.clone(), tx_non_service.clone()])
         .expect_err("Service block with non service tx should fail");
@@ -1394,7 +1383,7 @@ fn test_service_block_invariants() {
     };
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     tester
         .execute_block_no_panic(vec![tx_non_service, tx4])
         .expect_err("Service block with non service tx should fail");
@@ -1432,7 +1421,7 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    tester = tester.with_run_config(run_config());
+    tester = tester.with_run_config(default_run_config());
     let result_normal = tester.execute_block(vec![tx]);
     assert!(
         matches!(
@@ -1611,7 +1600,7 @@ fn test_simulation_gas_and_native_used() {
 
     tester = tester
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     let result_normal = tester.execute_block(vec![encoded]);
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
@@ -1833,7 +1822,7 @@ fn test_treasury_insufficient_balance_failure() {
         .build()
         .into();
 
-    let mut config = run_config();
+    let mut config = default_run_config();
     config.skip_minting_tokens_to_treasury = true; // Ensure we rely on treasury balance, not minting
 
     // This should fail due to insufficient treasury balance
@@ -1909,7 +1898,7 @@ fn test_pubdata_native_calculation_overflow() {
         )
         .with_evm_contract(to, &bytecode)
         .with_block_context(block_context)
-        .with_run_config(run_config());
+        .with_run_config(default_run_config());
     let result = tester.execute_block(vec![tx]);
 
     // Verify the specific error is OutOfNativeResources

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -12,7 +12,7 @@ use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, common_target_address, default_run_config, signer_from_key, ZKsyncOSTester};
+use rig::{alloy, common_target_address, signer_from_key, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
@@ -147,7 +147,7 @@ fn run_base_system() {
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let tester = ZKsyncOSTester::new()
+    let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
         .with_prefunded_account(wallet.address())
         .with_prefunded_account(eoa_wallet.address())
@@ -156,9 +156,7 @@ fn run_base_system() {
             U256::from(100),
         );
 
-    let output = tester
-        .with_run_config(default_run_config())
-        .execute_block(transactions);
+    let output = tester.execute_block(transactions);
 
     // Assert all txs succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -259,8 +257,7 @@ fn test_withdrawal() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_system_contracts(true, true, false)
-        .with_prefunded_account(wallet.address())
-        .with_run_config(default_run_config());
+        .with_prefunded_account(wallet.address());
 
     let output = tester.execute_block(transactions);
 
@@ -318,8 +315,7 @@ fn test_tx_with_access_list() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
-        .with_prefunded_account(wallet.address())
-        .with_run_config(default_run_config());
+        .with_prefunded_account(wallet.address());
 
     let output = tester.execute_block(transactions);
 
@@ -368,8 +364,7 @@ fn test_tx_with_authorization_list() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(erc_20_contract, &bytecode)
-        .with_prefunded_account(wallet.address())
-        .with_run_config(default_run_config());
+        .with_prefunded_account(wallet.address());
 
     let output = tester.execute_block(vec![mint_tx]);
 
@@ -432,8 +427,7 @@ fn test_cold_in_new_tx() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
-        .with_prefunded_account(wallet.address())
-        .with_run_config(default_run_config());
+        .with_prefunded_account(wallet.address());
 
     let output = tester.execute_block(transactions);
 
@@ -491,8 +485,7 @@ fn test_independent_txs_have_same_pubdata() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_balance(wallet1.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_balance(wallet2.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(default_run_config());
+        .with_balance(wallet2.address(), U256::from(1_000_000_000_000_000_u64));
 
     let output = tester.execute_block(transactions);
 
@@ -677,8 +670,7 @@ fn test_regression_returndata_empty_3541() {
     let bytecode = hex::decode(BYTECODE).unwrap();
     let mut tester = ZKsyncOSTester::new()
         .with_evm_contract(to, &bytecode)
-        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(default_run_config());
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
     // costs are hard to reason about.
@@ -710,9 +702,8 @@ fn test_balance_overflow_protection() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
 
     let to = address!("0000000000000000000000000000000000010002");
-    let mut tester = ZKsyncOSTester::new()
-        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
-        .with_run_config(default_run_config());
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
     let overflow_fee_tx = {
@@ -827,9 +818,7 @@ fn test_invalid_transaction_type_failure() {
     // Create a simple success contract for the call
     let contract_address = address!("0000000000000000000000000000000000010003");
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(contract_address, &success_bytecode)
-        .with_run_config(default_run_config());
+    let mut tester = ZKsyncOSTester::new().with_evm_contract(contract_address, &success_bytecode);
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -1037,7 +1026,6 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    tester = tester.with_run_config(default_run_config());
     let result = tester.execute_block(vec![tx_request]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1087,9 +1075,7 @@ fn test_reject_caller_with_code_behavior() {
     );
 
     // But in normal mode it should fail
-    let result_normal = tester
-        .with_run_config(default_run_config())
-        .execute_block(vec![from_contract_tx]);
+    let result_normal = tester.execute_block(vec![from_contract_tx]);
     assert!(matches!(
         result_normal.tx_results[0],
         Err(InvalidTransaction::RejectCallerWithCode)
@@ -1134,8 +1120,7 @@ fn test_expensive_pubdata() {
     };
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+        .with_block_context(block_context);
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1174,8 +1159,7 @@ fn test_check_pubdata_encoding_version() {
     };
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+        .with_block_context(block_context);
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1218,8 +1202,7 @@ fn test_check_pubdata_has_timestamp() {
     };
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+        .with_block_context(block_context);
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1249,9 +1232,7 @@ fn test_simple_service_transaction() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let mut tester = ZKsyncOSTester::new()
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    let mut tester = ZKsyncOSTester::new().with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
@@ -1276,8 +1257,7 @@ fn test_simple_service_transaction_whitelist() {
     };
     tester = tester
         .with_balance(wallet.address(), U256::from(u64::MAX))
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+        .with_block_context(block_context);
     // Check tx succeeds
     let result = tester.execute_block(vec![tx]);
     let res0 = result.tx_results.first().expect("Must have a tx result");
@@ -1299,9 +1279,7 @@ fn test_service_tx_gas_limit_exceeds_block() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let mut tester = ZKsyncOSTester::new()
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    let mut tester = ZKsyncOSTester::new().with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
     assert!(result.tx_results[0].is_ok());
 }
@@ -1335,9 +1313,7 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    tester = tester.with_block_context(block_context);
     // Check txs succeed
     let result = tester.execute_block(vec![tx1, tx2, tx3]);
     assert!(
@@ -1369,9 +1345,7 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    tester = tester.with_block_context(block_context);
     tester
         .execute_block_no_panic(vec![tx4.clone(), tx_non_service.clone()])
         .expect_err("Service block with non service tx should fail");
@@ -1381,9 +1355,7 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::ZERO,
         ..Default::default()
     };
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    tester = tester.with_block_context(block_context);
     tester
         .execute_block_no_panic(vec![tx_non_service, tx4])
         .expect_err("Service block with non service tx should fail");
@@ -1421,7 +1393,6 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    tester = tester.with_run_config(default_run_config());
     let result_normal = tester.execute_block(vec![tx]);
     assert!(
         matches!(
@@ -1598,9 +1569,7 @@ fn test_simulation_gas_and_native_used() {
     };
     let encoded = ZKsyncTxEnvelope::from_eth_tx(tx, wallet);
 
-    tester = tester
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+    tester = tester.with_block_context(block_context);
     let result_normal = tester.execute_block(vec![encoded]);
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
@@ -1822,7 +1791,7 @@ fn test_treasury_insufficient_balance_failure() {
         .build()
         .into();
 
-    let mut config = default_run_config();
+    let mut config: rig::chain::RunConfig = Default::default();
     config.skip_minting_tokens_to_treasury = true; // Ensure we rely on treasury balance, not minting
 
     // This should fail due to insufficient treasury balance
@@ -1897,8 +1866,7 @@ fn test_pubdata_native_calculation_overflow() {
             U256::from_str("100000000000000000000010000").unwrap(),
         )
         .with_evm_contract(to, &bytecode)
-        .with_block_context(block_context)
-        .with_run_config(default_run_config());
+        .with_block_context(block_context);
     let result = tester.execute_block(vec![tx]);
 
     // Verify the specific error is OutOfNativeResources

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg(test)]
 use alloy::consensus::{TxEip1559, TxEip2930, TxEip4844, TxLegacy};
 use alloy::primitives::TxKind;
-use alloy::signers::local::PrivateKeySigner;
 use rig::alloy::consensus::TxEip7702;
 use rig::alloy::primitives::{address, b256};
 use rig::alloy::rpc::types::{AccessList, AccessListItem, TransactionRequest};
@@ -14,7 +13,7 @@ use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, ZKsyncOSTester};
+use rig::{alloy, common_target_address, signer_from_key, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
@@ -27,14 +26,6 @@ mod native_charging;
 const PRIMARY_TEST_PK: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
 const SECONDARY_TEST_PK: &str = "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be";
 const TERTIARY_TEST_PK: &str = "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
-
-fn signer_from_key(key: &str) -> PrivateKeySigner {
-    PrivateKeySigner::from_str(key).unwrap()
-}
-
-fn common_target_address() -> alloy::primitives::Address {
-    address!("4242000000000000000000000000000000000000")
-}
 
 fn run_config() -> RunConfig {
     RunConfig {

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -287,7 +287,7 @@ fn test_withdrawal() {
 
     let output = tester.execute_block(transactions);
 
-    tester.assert_all_txs_succeded(&output);
+    tester.assert_all_txs_succeeded(&output);
 
     // Check preimage of withdrawal
     let mut expected_preimage =
@@ -346,7 +346,7 @@ fn test_tx_with_access_list() {
 
     let output = tester.execute_block(transactions);
 
-    tester.assert_all_txs_succeded(&output);
+    tester.assert_all_txs_succeeded(&output);
 }
 
 #[test]
@@ -396,7 +396,7 @@ fn test_tx_with_authorization_list() {
 
     let output = tester.execute_block(vec![mint_tx]);
 
-    tester.assert_all_txs_succeded(&output);
+    tester.assert_all_txs_succeeded(&output);
 }
 
 // Test that slots made warm in a tx are cold in the next tx
@@ -460,7 +460,13 @@ fn test_cold_in_new_tx() {
 
     let output = tester.execute_block(transactions);
 
-    tester.assert_all_txs_succeded(&output);
+    // Assert all txs succeeded
+    let result0 = output.tx_results.first().unwrap().clone();
+    let result1 = output.tx_results.get(1).unwrap().clone();
+    let result2 = output.tx_results.get(2).unwrap().clone();
+    assert!(result0.is_ok_and(|o| o.is_success()));
+    assert!(result1.is_ok_and(|o| o.is_success()));
+    assert!(result2.is_ok_and(|o| !o.is_success()));
 }
 
 #[test]
@@ -514,7 +520,7 @@ fn test_independent_txs_have_same_pubdata() {
     let output = tester.execute_block(transactions);
 
     // Assert all txs succeeded and compare pubdata len
-    tester.assert_all_txs_succeded(&output);
+    tester.assert_all_txs_succeeded(&output);
 
     let result1 = output.tx_results.first().unwrap().clone();
     let result2 = output.tx_results.get(1).unwrap().clone();
@@ -616,7 +622,7 @@ fn test_invalid_tx_does_not_affect_native() {
     let output = tester.execute_block(transactions);
 
     // Assert tx succeeded
-    tester.assert_all_txs_succeded(&output);
+    tester.assert_all_txs_succeeded(&output);
 
     let native_used_reference = output
         .tx_results

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -13,9 +13,8 @@ use rig::chain::RunConfig;
 use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
-use rig::testing_utils::install_system_contracts;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, zksync_web3_rs, Chain};
+use rig::{alloy, zksync_web3_rs, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
@@ -39,7 +38,6 @@ fn run_config() -> Option<rig::chain::RunConfig> {
 
 #[test]
 fn run_base_system() {
-    let mut chain = Chain::empty(None);
     // FIXME: this address looks very similar to bridgehub/shared bridge on gateway.
     // Which seems to suggest that it is special.
     // Consider changing this one to be more "random".
@@ -59,7 +57,7 @@ fn run_base_system() {
     let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
 
-    let encoded_mint_tx = {
+    let mint_tx = {
         let mint_tx = TxLegacy {
             chain_id: 37u64.into(),
             nonce: 0,
@@ -69,10 +67,10 @@ fn run_base_system() {
             value: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let encoded_transfer_tx = {
+    let transfer_tx = {
         let transfer_tx = TxEip1559 {
             chain_id: 37u64,
             nonce: 1,
@@ -84,11 +82,11 @@ fn run_base_system() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone())
     };
 
     // `to` == null
-    let encoded_deployment_tx = {
+    let deployment_tx = {
         let deployment_tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 2,
@@ -99,9 +97,9 @@ fn run_base_system() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_DEPLOYMENT_BYTECODE).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(deployment_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(deployment_tx, wallet.clone())
     };
-    let encoded_transfer_to_eoa_tx = {
+    let transfer_to_eoa_tx = {
         let eoa_to = address!("4242000000000000000000000000000000000000");
         let transfer_to_eoa = TxEip1559 {
             chain_id: 37u64,
@@ -114,10 +112,10 @@ fn run_base_system() {
             access_list: Default::default(),
             input: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(transfer_to_eoa, eoa_wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(transfer_to_eoa, eoa_wallet.clone())
     };
 
-    let encoded_mint2_tx = {
+    let mint2_tx = {
         let mint_tx = TxEip1559 {
             chain_id: 37u64,
             nonce: 3,
@@ -129,60 +127,60 @@ fn run_base_system() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_MINT_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone())
     };
 
-    let encoded_l1_l2_transfer = {
-        let transfer = L1TxBuilder::new()
+    let l1_l2_transfer = {
+        L1TxBuilder::new()
             .from(address!("1234000000000000000000000000000000000000"))
             .to(address!("4242000000000000000000000000000000000000"))
             .value(alloy::primitives::U256::from(100))
             .gas_price(1000)
             .gas_limit(21_000)
-            .build();
-        transfer.encode()
+            .build()
+            .into()
     };
 
-    let encoded_l1_l2_erc_transfer = {
-        let tx = L1TxBuilder::new()
+    let l1_l2_erc_transfer = {
+        L1TxBuilder::new()
             .from(wallet.address())
             .to(to)
             .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into())
             .gas_price(1000)
             .gas_limit(40_000)
             .nonce(3)
-            .build();
-        tx.encode()
+            .build()
+            .into()
     };
 
     let transactions = vec![
-        encoded_mint_tx,
-        encoded_transfer_tx,
-        encoded_deployment_tx,
-        encoded_transfer_to_eoa_tx,
-        encoded_mint2_tx,
-        encoded_l1_l2_transfer,
-        encoded_l1_l2_erc_transfer,
+        mint_tx,
+        transfer_tx,
+        deployment_tx,
+        transfer_to_eoa_tx,
+        mint2_tx,
+        l1_l2_transfer,
+        l1_l2_erc_transfer,
     ];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain
-        .set_balance(
+    let tester = ZKsyncOSTester::<false>::new()
+        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_balance(
             B160::from_be_bytes(from.0),
             U256::from(1_000_000_000_000_000_u64),
         )
-        .set_balance(
+        .with_balance(
             B160::from_alloy(eoa_wallet.address()),
             U256::from(1_000_000_000_000_000_u64),
-        ) // Set the balance for L1 -> L2 tx msg.value transfer
-        .set_balance(
-            B160::from_be_bytes(address!("1234000000000000000000000000000000000000").into()),
-            alloy::primitives::U256::from(100),
+        )
+        .with_balance(
+            B160::from_alloy(address!("1234000000000000000000000000000000000000")),
+            U256::from(100),
         );
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.with_run_config(run_config().unwrap()).execute_block(transactions);
 
     // Assert all txs succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -196,18 +194,18 @@ fn run_base_system() {
 
 #[test]
 fn test_block_of_erc20() {
-    let mut chain = Chain::empty_randomized(None);
-    run_block_of_erc20(&mut chain, 10, None);
+    let mut tester = ZKsyncOSTester::<true>::new();
+    tester.run_block_of_erc20(10, None);
 }
 
 #[test]
 fn test_gas_price_zero_fee_zero() {
-    let mut chain = Chain::empty_randomized(None);
+    let mut tester = ZKsyncOSTester::<true>::new();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
     };
-    let output = run_block_of_erc20_with_fee(&mut chain, 10, Some(block_context), 0);
+    let output = tester.run_block_of_erc20_with_fee(10, Some(block_context), 0);
     let res_0 = output
         .tx_results
         .first()
@@ -224,18 +222,18 @@ fn test_gas_price_zero_fee_zero() {
 
 #[test]
 fn test_gas_price_zero_fee_one() {
-    let mut chain = Chain::empty_randomized(None);
+    let mut tester = ZKsyncOSTester::<true>::new();
     let block_context = BlockContext {
         eip1559_basefee: U256::ZERO,
         ..BlockContext::default()
     };
-    run_block_of_erc20_with_fee(&mut chain, 10, Some(block_context), 1);
+    tester.run_block_of_erc20_with_fee(10, Some(block_context), 1);
 }
 
 #[test]
 fn test_withdrawal() {
-    let mut chain = Chain::empty(None);
-    install_system_contracts(&mut chain, true, false, false);
+    let mut tester = ZKsyncOSTester::<false>::new();
+    tester.install_system_contracts(true, false, false);
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -291,16 +289,16 @@ fn test_withdrawal() {
     let transactions = vec![withdrawal_tx, withdrawal_with_message_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    install_system_contracts(&mut chain, false, true, false);
+    tester.install_system_contracts(false, true, false);
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.run_block(transactions, None, None, run_config());
 
     // Assert all txs succeeded
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -331,7 +329,7 @@ fn test_withdrawal() {
 
 #[test]
 fn test_tx_with_access_list() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -368,14 +366,14 @@ fn test_tx_with_access_list() {
     let transactions = vec![encoded_mint_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.run_block(transactions, None, None, run_config());
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -386,7 +384,7 @@ fn test_tx_with_access_list() {
 fn test_tx_with_authorization_list() {
     use rig::alloy::eips::eip7702::*;
     use rig::alloy::signers::SignerSync;
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -432,9 +430,9 @@ fn test_tx_with_authorization_list() {
     let transactions = vec![encoded_mint_tx];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(erc_20_contract), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(erc_20_contract), &bytecode);
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
@@ -445,7 +443,7 @@ fn test_tx_with_authorization_list() {
         check_storage_diff_hashes: true,
         ..Default::default()
     };
-    let output = chain.run_block(transactions, None, None, Some(run_config));
+    let output = tester.run_block(transactions, None, None, Some(run_config));
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -455,7 +453,7 @@ fn test_tx_with_authorization_list() {
 // Test that slots made warm in a tx are cold in the next tx
 #[test]
 fn test_cold_in_new_tx() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -513,14 +511,14 @@ fn test_cold_in_new_tx() {
     let transactions = vec![encoded_mint_tx, encoded_mint1_tx, encoded_mint_tx2];
 
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.run_block(transactions, None, None, run_config());
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -535,7 +533,7 @@ fn test_cold_in_new_tx() {
 // Test that if we send 2 simple transfers from and to different addresses,
 // the length of the pubdata from both is the same.
 fn test_independent_txs_have_same_pubdata() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet1 = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -581,7 +579,7 @@ fn test_independent_txs_have_same_pubdata() {
 
     let transactions = vec![encoded_tx_1, encoded_tx_2];
 
-    chain
+    tester
         .set_balance(
             B160::from_alloy(wallet1.address()),
             U256::from(1_000_000_000_000_000_u64),
@@ -591,7 +589,7 @@ fn test_independent_txs_have_same_pubdata() {
             U256::from(1_000_000_000_000_000_u64),
         );
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.run_block(transactions, None, None, run_config());
 
     // Assert all txs succeeded and compare pubdata len
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
@@ -619,7 +617,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Invalid tx first
     let encoded_mint1_tx = {
@@ -638,7 +636,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
         let l1_messenger_contract = address!("0000000000000000000000000000000000008008");
         let l1_messenger_hook = address!("0000000000000000000000000000000000007001");
 
-        chain.set_balance(
+        tester.set_balance(
             B160::from_alloy(l1_messenger_contract),
             U256::from(1_000_000_000_000_000_u64),
         );
@@ -660,13 +658,13 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     };
 
     let transactions = vec![encoded_mint1_tx, withdrawal_tx];
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    chain.set_balance(
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.run_block(transactions, None, None, None);
 
     // Assert tx succeeded/failed
     let result0 = output.tx_results.first().unwrap().clone();
@@ -711,14 +709,14 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
     };
 
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let transactions = vec![encoded_mint_tx.clone()];
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    chain.set_balance(
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.run_block(transactions, None, None, None);
 
     // Assert tx succeeded
     let result = output.tx_results.first().unwrap().clone();
@@ -742,14 +740,14 @@ fn test_invalid_tx_does_not_affect_native() {
         ZKsyncTxEnvelope::from_eth_tx(mint_tx, wallet.clone()).encode()
     };
 
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let transactions = vec![encoded_mint1_tx, encoded_mint_tx];
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
-    chain.set_balance(
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
-    let output = chain.run_block(transactions, None, None, None);
+    let output = tester.run_block(transactions, None, None, None);
 
     // Assert tx succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -766,7 +764,7 @@ fn test_invalid_tx_does_not_affect_native() {
 // TODO: find better place for regression tests
 #[test]
 fn test_regression_returndata_empty_3541() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -821,14 +819,14 @@ fn test_regression_returndata_empty_3541() {
     let transactions = vec![encoded_tx];
 
     let bytecode = hex::decode(BYTECODE).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_be_bytes(from.0),
         U256::from(1_000_000_000_000_000_u64),
     );
 
-    let output = chain.run_block(transactions, None, None, run_config());
+    let output = tester.run_block(transactions, None, None, run_config());
 
     // Assert all txs succeeded
     let result0 = output.tx_results.first().unwrap().clone();
@@ -838,7 +836,7 @@ fn test_regression_returndata_empty_3541() {
 /// Test that transactions with balance calculation overflow are properly rejected
 #[test]
 fn test_balance_overflow_protection() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
@@ -849,7 +847,7 @@ fn test_balance_overflow_protection() {
     let to = address!("0000000000000000000000000000000000010002");
 
     // Set a reasonable balance that would be sufficient for normal transactions
-    chain.set_balance(
+    tester.set_balance(
         B160::from_alloy(from),
         U256::from(1_000_000_000_000_000_u64),
     );
@@ -884,7 +882,7 @@ fn test_balance_overflow_protection() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
 
-    let output = chain.run_block(
+    let output = tester.run_block(
         vec![overflow_fee_tx, overflow_total_tx],
         None,
         None,
@@ -905,13 +903,13 @@ fn test_balance_overflow_protection() {
 /// instead of a validation error.
 #[test]
 fn test_upgrade_tx_revert_internal_error() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Create a contract that always reverts
     let revert_contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does REVERT(0, 0)
     let revert_bytecode = hex::decode("60006000fd").unwrap(); // PUSH1 0, PUSH1 0, REVERT
-    chain.set_evm_bytecode(B160::from_alloy(revert_contract_address), &revert_bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(revert_contract_address), &revert_bytecode);
 
     // Create a proper upgrade transaction that calls the reverting contract
 
@@ -925,7 +923,7 @@ fn test_upgrade_tx_revert_internal_error() {
     let transactions = vec![upgrade_tx.encode()];
 
     // Use run_block_no_panic to catch the error instead of panicking
-    let result = chain.run_block_no_panic(transactions, None, None, None);
+    let result = tester.run_block_no_panic(transactions, None, None, None);
 
     // The upgrade transaction should fail with an internal error (not validation error)
     assert!(result.is_err());
@@ -942,13 +940,13 @@ fn test_upgrade_tx_revert_internal_error() {
 
 #[test]
 fn test_upgrade_tx_succeeds() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Create a contract that always succeeds
     let contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does RETURN(0, 0)
     let bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    chain.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
 
     // Create a proper upgrade transaction that calls the contract
     let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
@@ -961,7 +959,7 @@ fn test_upgrade_tx_succeeds() {
     let transactions = vec![upgrade_tx.encode()];
 
     // Use run_block_no_panic to catch the error instead of panicking
-    let result = chain.run_block_no_panic(transactions, None, None, None);
+    let result = tester.run_block_no_panic(transactions, None, None, None);
     assert!(result.is_ok());
     let tx_output = result.as_ref().unwrap().tx_results[0].as_ref().unwrap();
     assert!(tx_output.is_success());
@@ -972,12 +970,12 @@ fn test_upgrade_tx_succeeds() {
 
 #[test]
 fn test_invalid_transaction_type_failure() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Create a simple success contract for the call
     let contract_address = address!("0000000000000000000000000000000000010003");
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    chain.set_evm_bytecode(B160::from_alloy(contract_address), &success_bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(contract_address), &success_bytecode);
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
 
@@ -998,7 +996,7 @@ fn test_invalid_transaction_type_failure() {
         );
 
         let transactions = vec![invalid_tx.encode()];
-        let result = chain.run_block(transactions, None, None, run_config());
+        let result = tester.run_block(transactions, None, None, run_config());
         assert!(
             result.tx_results[0].is_err(),
             "Transaction with invalid type should fail"
@@ -1008,7 +1006,7 @@ fn test_invalid_transaction_type_failure() {
 
 #[test]
 fn test_modexp_intermediate_zero_block() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -1061,12 +1059,12 @@ fn test_modexp_intermediate_zero_block() {
 
     let transactions = vec![encoded_tx];
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_alloy(wallet.address()),
         U256::from(10u64.pow(18)),
     );
 
-    let result = chain.run_block(transactions, None, None, None);
+    let result = tester.run_block(transactions, None, None, None);
 
     // The transaction should succeed
     assert!(
@@ -1093,7 +1091,7 @@ fn test_modexp_intermediate_zero_block() {
 
 #[test]
 fn test_point_eval_call() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let wallet = PrivateKeySigner::from_str(
         "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7",
     )
@@ -1136,12 +1134,12 @@ fn test_point_eval_call() {
 
     let transactions = vec![encoded_tx];
 
-    chain.set_balance(
+    tester.set_balance(
         B160::from_alloy(wallet.address()),
         U256::from(10u64.pow(18)),
     );
 
-    let result = chain.run_block(transactions, None, None, None);
+    let result = tester.run_block(transactions, None, None, None);
 
     // The transaction should succeed
     assert!(result.tx_results[0].is_ok(), "Transaction should succeed");
@@ -1168,8 +1166,8 @@ fn test_selfdestruct_to_precompile_gas() {
     // Test that a selfdestruct with a precompile as target doesn't charge for
     // extra warm gas (regression)
 
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.prefunded_random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
 
@@ -1177,11 +1175,7 @@ fn test_selfdestruct_to_precompile_gas() {
     // SELFDESTRUCT
     let bytecode = hex::decode("730000000000000000000000000000000000000001ff").unwrap();
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(contract_address), &bytecode);
 
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -1203,7 +1197,7 @@ fn test_selfdestruct_to_precompile_gas() {
         ZKsyncTxEnvelope::from_eth_tx_from_req(tx_request, wallet)
     };
 
-    let result = chain.run_block(vec![tx_request.encode()], None, None, run_config());
+    let result = tester.run_block(vec![tx_request.encode()], None, None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
     let gas_used = res0.clone().unwrap().gas_used;
@@ -1212,25 +1206,20 @@ fn test_selfdestruct_to_precompile_gas() {
 
 #[test]
 fn test_reject_caller_with_code_behavior() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.prefunded_random_signer();
 
     // Create a contract address with bytecode deployed
     let contract_address = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // Deploy bytecode to the contract address to make it a "contract with code"
-    chain.set_evm_bytecode(
+    tester.set_evm_bytecode(
         B160::from_alloy(contract_address),
         &hex::decode("60006000f3").unwrap(), // Simple contract: PUSH1 0, PUSH1 0, RETURN
     );
 
     // Set balance for the contract address
-    chain.set_balance(
-        B160::from_alloy(contract_address),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-
     let from_contract_tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
@@ -1245,7 +1234,7 @@ fn test_reject_caller_with_code_behavior() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
 
-    let result_simulation = chain.simulate_block(vec![from_contract_tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![from_contract_tx.clone()], None);
 
     // In simulation mode, the transaction should succeed
     assert!(result_simulation.tx_results[0].is_ok(),);
@@ -1257,7 +1246,7 @@ fn test_reject_caller_with_code_behavior() {
     );
 
     // But in normal mode it should fail
-    let result_normal = chain.run_block(vec![from_contract_tx], None, None, run_config());
+    let result_normal = tester.run_block(vec![from_contract_tx], None, None, run_config());
     assert!(matches!(
         result_normal.tx_results[0],
         Err(InvalidTransaction::RejectCallerWithCode)
@@ -1268,13 +1257,13 @@ fn test_reject_caller_with_code_behavior() {
 fn test_expensive_pubdata() {
     // Test if a transaction can be executed even if the pubdata price is such that
     // validation pubdata requires to use withheld resources.
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // Set balance for the contract address
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1305,20 +1294,20 @@ fn test_expensive_pubdata() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
 
 #[test]
 fn test_check_pubdata_encoding_version() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // Set balance for the contract address
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1345,7 +1334,7 @@ fn test_check_pubdata_encoding_version() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1354,13 +1343,13 @@ fn test_check_pubdata_encoding_version() {
 
 #[test]
 fn test_check_pubdata_has_timestamp() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // Set balance for the contract address
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = {
         let tx = TxEip1559 {
@@ -1389,7 +1378,7 @@ fn test_check_pubdata_has_timestamp() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 
@@ -1405,7 +1394,7 @@ fn test_check_pubdata_has_timestamp() {
 
 #[test]
 fn test_simple_service_transaction() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1419,21 +1408,21 @@ fn test_simple_service_transaction() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_ok(), "Tx should succeed");
 }
 
 #[test]
 fn test_simple_service_transaction_whitelist() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
     // Invalid target
     let target_address = [0u8; 20];
 
     // Set balance for the contract address
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
         to: alloy::primitives::Address::from_slice(&target_address),
@@ -1447,14 +1436,14 @@ fn test_simple_service_transaction_whitelist() {
         ..Default::default()
     };
     // Check tx succeeds
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     let res0 = result.tx_results.first().expect("Must have a tx result");
     assert!(res0.as_ref().is_err(), "Tx should fail");
 }
 
 #[test]
 fn test_service_tx_gas_limit_exceeds_block() {
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
     let tx = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1470,19 +1459,19 @@ fn test_service_tx_gas_limit_exceeds_block() {
         ..Default::default()
     };
 
-    let result = chain.run_block(vec![tx], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx], Some(block_context), None, run_config());
     assert!(result.tx_results[0].is_ok());
 }
 
 #[test]
 fn test_service_block_invariants() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
     // Set balance for the contract address
-    chain.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester.set_balance(B160::from_alloy(from), U256::from(u64::MAX));
 
     // Check that a service block with several service txs works
     let tx1 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1509,7 +1498,7 @@ fn test_service_block_invariants() {
         ..Default::default()
     };
     // Check txs succeed
-    let result = chain.run_block(vec![tx1, tx2, tx3], Some(block_context), None, run_config());
+    let result = tester.run_block(vec![tx1, tx2, tx3], Some(block_context), None, run_config());
     assert!(
         result.tx_results.iter().all(|res| res.is_ok()),
         "All txs should succeed"
@@ -1535,7 +1524,7 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::from(1000),
         ..Default::default()
     };
-    chain
+    tester
         .run_block_no_panic(
             vec![tx4.clone(), tx_non_service.clone()],
             Some(block_context),
@@ -1549,7 +1538,7 @@ fn test_service_block_invariants() {
         eip1559_basefee: U256::ZERO,
         ..Default::default()
     };
-    chain
+    tester
         .run_block_no_panic(
             vec![tx_non_service, tx4],
             Some(block_context),
@@ -1562,16 +1551,9 @@ fn test_service_block_invariants() {
 /// Regression test for: Skip nonce check on simulation
 #[test]
 fn test_simulation_skips_nonce_check() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
-    let from = wallet.address();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    // Set balance so the tx can pay for gas
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
 
     // Create a transaction with nonce 100, but the account's nonce is 0
     let tx = {
@@ -1590,7 +1572,7 @@ fn test_simulation_skips_nonce_check() {
     };
 
     // In simulation mode, the transaction should succeed (nonce check skipped)
-    let result_simulation = chain.simulate_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction should pass validation in simulation mode, got: {:?}",
@@ -1598,7 +1580,7 @@ fn test_simulation_skips_nonce_check() {
     );
 
     // In normal execution mode, the transaction should fail with NonceTooHigh
-    let result_normal = chain.run_block(vec![tx], None, None, run_config());
+    let result_normal = tester.run_block(vec![tx], None, None, run_config());
     assert!(
         matches!(
             result_normal.tx_results[0],
@@ -1616,8 +1598,8 @@ fn test_simulation_skips_nonce_check() {
 /// - gasPrice == 0 && value == 0: ok
 #[test]
 fn test_simulation_balance_check() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
 
     // - gasPrice > 0 && value > 0: fail
@@ -1633,7 +1615,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
-    let result_simulation = chain.simulate_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee and value should fail validation in simulation mode"
@@ -1652,7 +1634,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
-    let result_simulation = chain.simulate_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with fee should fail validation in simulation mode"
@@ -1671,7 +1653,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
-    let result_simulation = chain.simulate_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_err(),
         "Transaction with value should fail validation in simulation mode"
@@ -1690,7 +1672,7 @@ fn test_simulation_balance_check() {
         };
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
-    let result_simulation = chain.simulate_block(vec![tx.clone()], None);
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], None);
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "Transaction with no fee/value should pass validation in simulation mode"
@@ -1699,15 +1681,9 @@ fn test_simulation_balance_check() {
 
 #[test]
 fn test_simulation_4844_zero_blob_fee_allowed() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
-    let from = wallet.address();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    chain.set_balance(
-        B160::from_be_bytes(from.into_array()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
 
     let tx = TxEip4844 {
         chain_id: 37u64,
@@ -1731,7 +1707,7 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
         ..Default::default()
     };
 
-    let result_simulation = chain.simulate_block(vec![encoded_tx], Some(block_context));
+    let result_simulation = tester.simulate_encoded_block(vec![encoded_tx], Some(block_context));
     assert!(
         result_simulation.tx_results[0].is_ok(),
         "EIP-4844 tx should pass simulation when blob_fee > 0 and max_fee_per_blob_gas = 0, got: {:?}",
@@ -1742,14 +1718,9 @@ fn test_simulation_4844_zero_blob_fee_allowed() {
 /// Check that gas and native used is the same in simulation and actual execution
 #[test]
 fn test_simulation_gas_and_native_used() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.prefunded_random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
-
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
 
     let tx = TxEip1559 {
         chain_id: 37u64,
@@ -1773,7 +1744,7 @@ fn test_simulation_gas_and_native_used() {
     };
 
     let result_simulation =
-        chain.simulate_block(vec![encoded_for_simulation], Some(block_context.clone()));
+        tester.simulate_encoded_block(vec![encoded_for_simulation], Some(block_context.clone()));
     let tx_result_simulation = result_simulation.tx_results[0]
         .clone()
         .expect("Simulation must succeed");
@@ -1784,7 +1755,7 @@ fn test_simulation_gas_and_native_used() {
     };
     let encoded = ZKsyncTxEnvelope::from_eth_tx(tx, wallet).encode();
 
-    let result_normal = chain.run_block(vec![encoded], Some(block_context), None, run_config());
+    let result_normal = tester.run_block(vec![encoded], Some(block_context), None, run_config());
     let tx_result_normal = result_normal.tx_results[0]
         .clone()
         .expect("Normal execution must succeed");
@@ -1805,10 +1776,10 @@ fn test_simulation_gas_and_native_used() {
 /// underestimated gas usage.
 #[test]
 fn test_simulation_gas_used_regression() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let target_address = address!("4242000000000000000000000000000000000000");
-    chain.set_balance(B160::from_alloy(wallet.address()), U256::MAX);
+    tester.set_balance(B160::from_alloy(wallet.address()), U256::MAX);
 
     // First tx, 0 gas price.
     let tx = {
@@ -1829,7 +1800,8 @@ fn test_simulation_gas_used_regression() {
         pubdata_price: U256::from(10303657632u64 * 4),
         ..Default::default()
     };
-    let result_simulation = chain.simulate_block(vec![tx.clone()], Some(block_context.clone()));
+    let result_simulation =
+        tester.simulate_encoded_block(vec![tx.clone()], Some(block_context.clone()));
     let first_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1848,7 +1820,7 @@ fn test_simulation_gas_used_regression() {
         ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
     };
 
-    let result_simulation = chain.simulate_block(vec![tx.clone()], Some(block_context));
+    let result_simulation = tester.simulate_encoded_block(vec![tx.clone()], Some(block_context));
     let second_tx = result_simulation.tx_results[0]
         .clone()
         .expect("Must succeed");
@@ -1864,10 +1836,10 @@ fn test_simulation_gas_used_regression() {
 fn test_treasury_based_token_distribution_regression() {
     use rig::system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
 
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Manually ensure treasury is funded for this test
-    chain.mint_tokens_to_treasury();
+    tester.mint_tokens_to_treasury();
 
     // Create L1 transaction sender
     let l1_sender = address!("1234000000000000000000000000000000000000");
@@ -1876,22 +1848,22 @@ fn test_treasury_based_token_distribution_regression() {
     let refund_recipient = address!("0000000000000000000000000000000000000000"); // refund recipient (zero address)
 
     // Record initial treasury balance
-    let treasury_initial_balance = chain
+    let treasury_initial_balance = tester
         .get_account_properties(&BASE_TOKEN_HOLDER_ADDRESS)
         .balance;
 
     // Record initial operator balance
-    let operator_initial_balance = chain
+    let operator_initial_balance = tester
         .get_account_properties(&B160::from_alloy(coinbase))
         .balance;
 
     // Record initial recipient balance
-    let recipient_initial_balance = chain
+    let recipient_initial_balance = tester
         .get_account_properties(&B160::from_alloy(l1_recipient))
         .balance;
 
     // Record initial refund recipient balance
-    let refund_recipient_initial_balance = chain
+    let refund_recipient_initial_balance = tester
         .get_account_properties(&B160::from_alloy(refund_recipient))
         .balance;
 
@@ -1901,7 +1873,7 @@ fn test_treasury_based_token_distribution_regression() {
     let value_to_transfer = U256::from(1_000_000u64);
 
     // Credit L1 sender with enough balance for the value transfer
-    chain.set_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
+    tester.set_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
 
     let l1_tx = {
         let tx = L1TxBuilder::new()
@@ -1919,7 +1891,7 @@ fn test_treasury_based_token_distribution_regression() {
         coinbase: B160::from_alloy(coinbase),
         ..Default::default()
     };
-    let output = chain.run_block(vec![l1_tx], Some(block_context), None, None);
+    let output = tester.run_block(vec![l1_tx], Some(block_context), None, None);
 
     // Verify transaction succeeded
     assert!(
@@ -1939,19 +1911,19 @@ fn test_treasury_based_token_distribution_regression() {
     let fee_paid_to_operator = U256::from(gas_used) * U256::from(gas_price);
 
     // Get final balances
-    let treasury_final_balance = chain
+    let treasury_final_balance = tester
         .get_account_properties(&BASE_TOKEN_HOLDER_ADDRESS)
         .balance;
 
-    let operator_final_balance = chain
+    let operator_final_balance = tester
         .get_account_properties(&B160::from_alloy(coinbase))
         .balance;
 
-    let recipient_final_balance = chain
+    let recipient_final_balance = tester
         .get_account_properties(&B160::from_alloy(l1_recipient))
         .balance;
 
-    let refund_recipient_final_balance = chain
+    let refund_recipient_final_balance = tester
         .get_account_properties(&B160::from_alloy(refund_recipient))
         .balance;
 
@@ -1999,11 +1971,11 @@ fn test_treasury_based_token_distribution_regression() {
 fn test_treasury_insufficient_balance_failure() {
     use rig::system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
 
-    let mut chain = Chain::empty(None);
+    let mut tester = ZKsyncOSTester::<false>::new();
 
     // Manually set very low treasury balance instead of using default
     let low_treasury_balance = U256::from(1000u64);
-    chain.set_balance(BASE_TOKEN_HOLDER_ADDRESS, low_treasury_balance);
+    tester.set_balance(BASE_TOKEN_HOLDER_ADDRESS, low_treasury_balance);
 
     // Create L1→L2 transaction that requires more tokens than treasury has
     let l1_sender = address!("1234000000000000000000000000000000000000");
@@ -2030,7 +2002,7 @@ fn test_treasury_insufficient_balance_failure() {
     };
 
     // This should fail due to insufficient treasury balance
-    let result = chain.run_block_no_panic(vec![l1_tx], None, None, Some(config));
+    let result = tester.run_block_no_panic(vec![l1_tx], None, None, Some(config));
 
     // Verify transaction fails due to treasury insufficient balance
     assert!(
@@ -2052,12 +2024,12 @@ fn test_pubdata_native_calculation_overflow() {
     use alloy::consensus::TxEip1559;
     use rig::alloy::primitives::TxKind;
 
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::<false>::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
 
     // Set initial balance for the wallet
-    chain.set_balance(
+    tester.set_balance(
         B160::from_alloy(from),
         U256::from_str("100000000000000000000010000").unwrap(),
     );
@@ -2076,7 +2048,7 @@ fn test_pubdata_native_calculation_overflow() {
     */
     // Spam some pubdata
     let bytecode = hex::decode("60806040525f5f90505b6014811015603f576c0fffffffffffffffffffffffff5f5f8381526020019081526020015f208190555080806001019150506009565b00fea2646970667358221220d8f4977e359f09d23e2979156755d7e177d43f8a1882a5a178eb98dd8bcb237264736f6c634300081f0033").unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(to), &bytecode);
+    tester.set_evm_bytecode(B160::from_alloy(to), &bytecode);
 
     // Create a transaction that will generate significant pubdata
     let tx = {
@@ -2104,7 +2076,7 @@ fn test_pubdata_native_calculation_overflow() {
         ..Default::default()
     };
 
-    let result = chain.run_block(vec![tx], Some(block_context), None, None);
+    let result = tester.run_block(vec![tx], Some(block_context), None, None);
 
     // Verify the specific error is OutOfNativeResources
     match &result.tx_results[0].as_ref().unwrap().execution_result {

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -12,7 +12,7 @@ use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, common_target_address, signer_from_key, TestingFramework};
+use rig::{alloy, common_target_address, testing_signer, TestingFramework};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
@@ -22,20 +22,16 @@ use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 mod l1_tx_resilience;
 mod native_charging;
 
-const PRIMARY_TEST_PK: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
-const SECONDARY_TEST_PK: &str = "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be";
-const TERTIARY_TEST_PK: &str = "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
-
 #[test]
 fn run_base_system() {
     // FIXME: this address looks very similar to bridgehub/shared bridge on gateway.
     // Which seems to suggest that it is special.
     // Consider changing this one to be more "random".
 
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
     // We used for test where from cannot have deployed code
-    let eoa_wallet = signer_from_key(SECONDARY_TEST_PK);
+    let eoa_wallet = testing_signer(1);
 
     let to = address!("0000000000000000000000000000000000010002");
 
@@ -208,7 +204,7 @@ fn test_gas_price_zero_fee_one() {
 
 #[test]
 fn test_withdrawal() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
     // L2 base token address
     let to = address!("000000000000000000000000000000000000800a");
@@ -283,7 +279,7 @@ fn test_withdrawal() {
 
 #[test]
 fn test_tx_with_access_list() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
     let to = address!("0000000000000000000000000000000000010002");
 
@@ -327,9 +323,9 @@ fn test_tx_with_authorization_list() {
     use rig::alloy::eips::eip7702::*;
     use rig::alloy::signers::SignerSync;
 
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
-    let delegate = signer_from_key(SECONDARY_TEST_PK);
+    let delegate = testing_signer(1);
 
     let to = delegate.address();
 
@@ -374,7 +370,7 @@ fn test_tx_with_authorization_list() {
 // Test that slots made warm in a tx are cold in the next tx
 #[test]
 fn test_cold_in_new_tx() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
     let to = address!("0000000000000000000000000000000000010002");
 
@@ -444,9 +440,9 @@ fn test_cold_in_new_tx() {
 // Test that if we send 2 simple transfers from and to different addresses,
 // the length of the pubdata from both is the same.
 fn test_independent_txs_have_same_pubdata() {
-    let wallet1 = signer_from_key(PRIMARY_TEST_PK);
+    let wallet1 = testing_signer(0);
 
-    let wallet2 = signer_from_key(TERTIARY_TEST_PK);
+    let wallet2 = testing_signer(2);
 
     let to1 = address!("0000000000000000000000000000000000010002");
     let to2 = address!("0000000000000000000000000000000000010003");
@@ -501,7 +497,7 @@ fn test_independent_txs_have_same_pubdata() {
 
 #[test]
 fn test_invalid_tx_does_not_bump_tx_counter() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
@@ -566,7 +562,7 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
 
 #[test]
 fn test_invalid_tx_does_not_affect_native() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
@@ -639,7 +635,7 @@ fn test_invalid_tx_does_not_affect_native() {
 // TODO: find better place for regression tests
 #[test]
 fn test_regression_returndata_empty_3541() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
     // Code for:
     // PUSH13 0x63EF0000006000526004601CF3
     // PUSH1  0x00
@@ -699,7 +695,7 @@ fn test_regression_returndata_empty_3541() {
 /// Test that transactions with balance calculation overflow are properly rejected
 #[test]
 fn test_balance_overflow_protection() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
 
     let to = address!("0000000000000000000000000000000000010002");
     let mut tester = TestingFramework::new()
@@ -849,7 +845,7 @@ fn test_invalid_transaction_type_failure() {
 
 #[test]
 fn test_modexp_intermediate_zero_block() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
     let mut tester =
         TestingFramework::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 
@@ -927,7 +923,7 @@ fn test_modexp_intermediate_zero_block() {
 
 #[test]
 fn test_point_eval_call() {
-    let wallet = signer_from_key(PRIMARY_TEST_PK);
+    let wallet = testing_signer(0);
     let mut tester =
         TestingFramework::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -10,17 +10,16 @@ use rig::alloy::primitives::{address, b256};
 use rig::alloy::rpc::types::{AccessList, AccessListItem, TransactionRequest};
 use rig::basic_bootloader::bootloader::block_flow::zk::PUBDATA_ENCODING_VERSION;
 use rig::chain::RunConfig;
-use rig::forward_system::run::convert_alloy::FromAlloy;
+use rig::forward_system::run::convert_alloy::{FromAlloy, IntoAlloy};
 use rig::ruint::aliases::{B160, U256};
 use rig::system_hooks::addresses_constants::L2_INTEROP_ROOT_STORAGE_ADDRESS;
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::{alloy, zksync_web3_rs, ZKsyncOSTester};
+use rig::{alloy, ZKsyncOSTester};
 use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
 use zksync_os_tests_common::zksync_tx::upgrade_tx::ZKsyncUpgradeTx;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use zksync_web3_rs::signers::{LocalWallet, Signer};
 
 mod l1_tx_resilience;
 mod native_charging;
@@ -169,11 +168,11 @@ fn run_base_system() {
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_alloy(wallet.address()))
-        .with_prefunded_account(B160::from_alloy(eoa_wallet.address()))
+        .with_evm_contract(to, &bytecode)
+        .with_prefunded_account(wallet.address())
+        .with_prefunded_account(eoa_wallet.address())
         .with_balance(
-            B160::from_alloy(address!("1234000000000000000000000000000000000000")),
+            address!("1234000000000000000000000000000000000000"),
             U256::from(100),
         );
 
@@ -282,8 +281,8 @@ fn test_withdrawal() {
 
     let mut tester = ZKsyncOSTester::new()
         .with_system_contracts(true, true, false)
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_alloy(wallet.address()))
+        .with_evm_contract(to, &bytecode)
+        .with_prefunded_account(wallet.address())
         .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
@@ -341,8 +340,8 @@ fn test_tx_with_access_list() {
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_alloy(wallet.address()))
+        .with_evm_contract(to, &bytecode)
+        .with_prefunded_account(wallet.address())
         .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
@@ -356,11 +355,9 @@ fn test_tx_with_authorization_list() {
     use rig::alloy::signers::SignerSync;
 
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
 
     let delegate = signer_from_key(SECONDARY_TEST_PK);
 
-    let from = wallet_ethers.address();
     let to = delegate.address();
 
     let erc_20_contract = address!("0000000000000000000000000000000000010002");
@@ -393,8 +390,8 @@ fn test_tx_with_authorization_list() {
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(erc_20_contract), &bytecode)
-        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_evm_contract(erc_20_contract, &bytecode)
+        .with_prefunded_account(wallet.address())
         .with_run_config(run_config());
 
     let output = tester.execute_block(vec![mint_tx]);
@@ -406,9 +403,6 @@ fn test_tx_with_authorization_list() {
 #[test]
 fn test_cold_in_new_tx() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-
-    let from = wallet_ethers.address();
 
     let to = address!("0000000000000000000000000000000000010002");
 
@@ -460,8 +454,8 @@ fn test_cold_in_new_tx() {
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_prefunded_account(B160::from_be_bytes(from.0))
+        .with_evm_contract(to, &bytecode)
+        .with_prefunded_account(wallet.address())
         .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
@@ -513,14 +507,8 @@ fn test_independent_txs_have_same_pubdata() {
     let transactions = vec![tx_1, tx_2];
 
     let mut tester = ZKsyncOSTester::new()
-        .with_balance(
-            B160::from_alloy(wallet1.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        )
-        .with_balance(
-            B160::from_alloy(wallet2.address()),
-            U256::from(1_000_000_000_000_000_u64),
-        )
+        .with_balance(wallet1.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_balance(wallet2.address(), U256::from(1_000_000_000_000_000_u64))
         .with_run_config(run_config());
 
     let output = tester.execute_block(transactions);
@@ -538,8 +526,6 @@ fn test_independent_txs_have_same_pubdata() {
 #[test]
 fn test_invalid_tx_does_not_bump_tx_counter() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-    let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
@@ -579,15 +565,9 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
     let transactions = vec![mint_tx_1, withdrawal_tx];
 
     let mut tester = ZKsyncOSTester::new()
-        .with_balance(
-            B160::from_alloy(l1_messenger_contract),
-            U256::from(1_000_000_000_000_000_u64),
-        )
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_balance(
-            B160::from_be_bytes(from.0),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+        .with_balance(l1_messenger_contract, U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(to, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
     let output = tester.execute_block(transactions);
 
     // Assert tx succeeded/failed
@@ -611,8 +591,6 @@ fn test_invalid_tx_does_not_bump_tx_counter() {
 #[test]
 fn test_invalid_tx_does_not_affect_native() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-    let from = wallet_ethers.address();
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(ERC_20_BYTECODE).unwrap();
 
@@ -632,11 +610,8 @@ fn test_invalid_tx_does_not_affect_native() {
 
     let transactions = vec![mint_tx.clone()];
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_balance(
-            B160::from_be_bytes(from.0),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+        .with_evm_contract(to, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     let output = tester.execute_block(transactions);
 
@@ -668,11 +643,8 @@ fn test_invalid_tx_does_not_affect_native() {
     };
 
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_balance(
-            B160::from_be_bytes(from.0),
-            U256::from(1_000_000_000_000_000_u64),
-        );
+        .with_evm_contract(to, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
     let transactions = vec![mint_tx_1, mint_tx];
     let output = tester.execute_block(transactions);
 
@@ -692,7 +664,6 @@ fn test_invalid_tx_does_not_affect_native() {
 #[test]
 fn test_regression_returndata_empty_3541() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
     // Code for:
     // PUSH13 0x63EF0000006000526004601CF3
     // PUSH1  0x00
@@ -719,16 +690,11 @@ fn test_regression_returndata_empty_3541() {
     const BYTECODE: &str =
         "6c63ef0000006000526004601cf3600052600d60136000f03d15600858015760006000fd5b60006000f3";
 
-    let from = wallet_ethers.address();
-
     let to = address!("0000000000000000000000000000000000010002");
     let bytecode = hex::decode(BYTECODE).unwrap();
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
-        .with_balance(
-            B160::from_be_bytes(from.0),
-            U256::from(1_000_000_000_000_000_u64),
-        )
+        .with_evm_contract(to, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
         .with_run_config(run_config());
 
     // We do an initial mint to populate storage slots, otherwise SSTORE
@@ -760,13 +726,9 @@ fn test_regression_returndata_empty_3541() {
 fn test_balance_overflow_protection() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
 
-    let from = alloy::primitives::Address::from_slice(&wallet.address().as_slice());
     let to = address!("0000000000000000000000000000000000010002");
     let mut tester = ZKsyncOSTester::new()
-        .with_balance(
-            B160::from_alloy(from),
-            U256::from(1_000_000_000_000_000_u64),
-        )
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
         .with_run_config(run_config());
 
     // Test 1: Transaction with max_fee_per_gas * gas_limit overflow
@@ -819,8 +781,8 @@ fn test_upgrade_tx_revert_internal_error() {
     let revert_contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does REVERT(0, 0)
     let revert_bytecode = hex::decode("60006000fd").unwrap(); // PUSH1 0, PUSH1 0, REVERT
-    let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(revert_contract_address), &revert_bytecode);
+    let mut tester =
+        ZKsyncOSTester::new().with_evm_contract(revert_contract_address, &revert_bytecode);
 
     // Create a proper upgrade transaction that calls the reverting contract
 
@@ -855,8 +817,7 @@ fn test_upgrade_tx_succeeds() {
     let contract_address = address!("0000000000000000000000000000000000010003");
     // Simple contract bytecode that just does RETURN(0, 0)
     let bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
-    let mut tester =
-        ZKsyncOSTester::new().with_evm_contract(B160::from_alloy(contract_address), &bytecode);
+    let mut tester = ZKsyncOSTester::new().with_evm_contract(contract_address, &bytecode);
 
     // Create a proper upgrade transaction that calls the contract
     let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
@@ -884,7 +845,7 @@ fn test_invalid_transaction_type_failure() {
     let contract_address = address!("0000000000000000000000000000000000010003");
     let success_bytecode = hex::decode("60006000f3").unwrap(); // PUSH1 0, PUSH1 0, RETURN
     let mut tester = ZKsyncOSTester::new()
-        .with_evm_contract(B160::from_alloy(contract_address), &success_bytecode)
+        .with_evm_contract(contract_address, &success_bytecode)
         .with_run_config(run_config());
 
     let transaction_types = vec![0x55, 0x80, 0xFF]; // Some invalid types;
@@ -917,10 +878,8 @@ fn test_invalid_transaction_type_failure() {
 #[test]
 fn test_modexp_intermediate_zero_block() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let mut tester = ZKsyncOSTester::new().with_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(10u64.pow(18)),
-    );
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 
     // Modexp precompile address
     let modexp_address = address!("0000000000000000000000000000000000000005");
@@ -997,10 +956,8 @@ fn test_modexp_intermediate_zero_block() {
 #[test]
 fn test_point_eval_call() {
     let wallet = signer_from_key(PRIMARY_TEST_PK);
-    let mut tester = ZKsyncOSTester::new().with_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(10u64.pow(18)),
-    );
+    let mut tester =
+        ZKsyncOSTester::new().with_balance(wallet.address(), U256::from(10u64.pow(18)));
 
     let point_eval_address = address!("000000000000000000000000000000000000000a");
 
@@ -1075,7 +1032,7 @@ fn test_selfdestruct_to_precompile_gas() {
     // SELFDESTRUCT
     let bytecode = hex::decode("730000000000000000000000000000000000000001ff").unwrap();
 
-    tester = tester.with_evm_contract(B160::from_alloy(contract_address), &bytecode);
+    tester = tester.with_evm_contract(contract_address, &bytecode);
 
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -1116,7 +1073,7 @@ fn test_reject_caller_with_code_behavior() {
 
     // Deploy bytecode to the contract address to make it a "contract with code"
     tester.set_evm_contract(
-        B160::from_alloy(contract_address),
+        contract_address,
         &hex::decode("60006000f3").unwrap(), // Simple contract: PUSH1 0, PUSH1 0, RETURN
     );
 
@@ -1162,7 +1119,6 @@ fn test_expensive_pubdata() {
     // validation pubdata requires to use withheld resources.
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
     let target_address = common_target_address();
 
     let tx = {
@@ -1194,7 +1150,7 @@ fn test_expensive_pubdata() {
         ..Default::default()
     };
     tester = tester
-        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
         .with_run_config(run_config());
     // Check tx succeeds
@@ -1207,7 +1163,6 @@ fn test_expensive_pubdata() {
 fn test_check_pubdata_encoding_version() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
     let target_address = common_target_address();
 
     let tx = {
@@ -1235,7 +1190,7 @@ fn test_check_pubdata_encoding_version() {
         ..Default::default()
     };
     tester = tester
-        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
         .with_run_config(run_config());
     // Check tx succeeds
@@ -1250,7 +1205,6 @@ fn test_check_pubdata_encoding_version() {
 fn test_check_pubdata_has_timestamp() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
     let target_address = common_target_address();
 
     let tx = {
@@ -1280,7 +1234,7 @@ fn test_check_pubdata_has_timestamp() {
         ..Default::default()
     };
     tester = tester
-        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
         .with_run_config(run_config());
     // Check tx succeeds
@@ -1324,7 +1278,6 @@ fn test_simple_service_transaction() {
 fn test_simple_service_transaction_whitelist() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
     // Invalid target
     let target_address = [0u8; 20];
 
@@ -1339,7 +1292,7 @@ fn test_simple_service_transaction_whitelist() {
         ..Default::default()
     };
     tester = tester
-        .with_balance(B160::from_alloy(from), U256::from(u64::MAX))
+        .with_balance(wallet.address(), U256::from(u64::MAX))
         .with_block_context(block_context)
         .with_run_config(run_config());
     // Check tx succeeds
@@ -1374,10 +1327,9 @@ fn test_service_tx_gas_limit_exceeds_block() {
 fn test_service_block_invariants() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
     let target_address = L2_INTEROP_ROOT_STORAGE_ADDRESS.to_be_bytes::<20>();
 
-    tester = tester.with_balance(B160::from_alloy(from), U256::from(u64::MAX));
+    tester = tester.with_balance(wallet.address(), U256::from(u64::MAX));
 
     // Check that a service block with several service txs works
     let tx1 = ZKsyncTxEnvelope::from(ZKsyncServiceTx {
@@ -1690,7 +1642,7 @@ fn test_simulation_gas_used_regression() {
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
     let target_address = common_target_address();
-    tester = tester.with_balance(B160::from_alloy(wallet.address()), U256::MAX);
+    tester = tester.with_balance(wallet.address(), U256::MAX);
 
     // First tx, 0 gas price.
     let tx = {
@@ -1760,16 +1712,16 @@ fn test_treasury_based_token_distribution_regression() {
     let refund_recipient = address!("0000000000000000000000000000000000000000"); // refund recipient (zero address)
 
     // Record initial treasury balance
-    let treasury_initial_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS);
+    let treasury_initial_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS.into_alloy());
 
     // Record initial operator balance
-    let operator_initial_balance = tester.get_balance(&B160::from_alloy(coinbase));
+    let operator_initial_balance = tester.get_balance(&coinbase);
 
     // Record initial recipient balance
-    let recipient_initial_balance = tester.get_balance(&B160::from_alloy(l1_recipient));
+    let recipient_initial_balance = tester.get_balance(&l1_recipient);
 
     // Record initial refund recipient balance
-    let refund_recipient_initial_balance = tester.get_balance(&B160::from_alloy(refund_recipient));
+    let refund_recipient_initial_balance = tester.get_balance(&refund_recipient);
 
     // Create L1→L2 transaction with value transfer and fees
     let gas_price = 1000u64;
@@ -1777,7 +1729,7 @@ fn test_treasury_based_token_distribution_regression() {
     let value_to_transfer = U256::from(1_000_000u64);
 
     // Credit L1 sender with enough balance for the value transfer
-    tester = tester.with_balance(B160::from_be_bytes(l1_sender.0 .0), value_to_transfer);
+    tester = tester.with_balance(l1_sender, value_to_transfer);
 
     let l1_tx: ZKsyncTxEnvelope = L1TxBuilder::new()
         .from(l1_sender)
@@ -1813,13 +1765,13 @@ fn test_treasury_based_token_distribution_regression() {
     let fee_paid_to_operator = U256::from(gas_used) * U256::from(gas_price);
 
     // Get final balances
-    let treasury_final_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS);
+    let treasury_final_balance = tester.get_balance(&BASE_TOKEN_HOLDER_ADDRESS.into_alloy());
 
-    let operator_final_balance = tester.get_balance(&B160::from_alloy(coinbase));
+    let operator_final_balance = tester.get_balance(&coinbase);
 
-    let recipient_final_balance = tester.get_balance(&B160::from_alloy(l1_recipient));
+    let recipient_final_balance = tester.get_balance(&l1_recipient);
 
-    let refund_recipient_final_balance = tester.get_balance(&B160::from_alloy(refund_recipient));
+    let refund_recipient_final_balance = tester.get_balance(&refund_recipient);
 
     // Calculate total amount that should go to operator (fee + refund)
     // Refund recipient is 0 in this test
@@ -1867,8 +1819,8 @@ fn test_treasury_insufficient_balance_failure() {
 
     // Manually set very low treasury balance instead of using default
     let low_treasury_balance = U256::from(1000u64);
-    let mut tester =
-        ZKsyncOSTester::new().with_balance(BASE_TOKEN_HOLDER_ADDRESS, low_treasury_balance);
+    let mut tester = ZKsyncOSTester::new()
+        .with_balance(BASE_TOKEN_HOLDER_ADDRESS.into_alloy(), low_treasury_balance);
 
     // Create L1→L2 transaction that requires more tokens than treasury has
     let l1_sender = address!("1234000000000000000000000000000000000000");
@@ -1916,7 +1868,6 @@ fn test_pubdata_native_calculation_overflow() {
 
     let mut tester = ZKsyncOSTester::new();
     let wallet = tester.random_signer();
-    let from = wallet.address();
 
     let to = address!("1234567890123456789012345678901234567890");
     /*
@@ -1959,10 +1910,10 @@ fn test_pubdata_native_calculation_overflow() {
     };
     tester = tester
         .with_balance(
-            B160::from_alloy(from),
+            wallet.address(),
             U256::from_str("100000000000000000000010000").unwrap(),
         )
-        .with_evm_contract(B160::from_alloy(to), &bytecode)
+        .with_evm_contract(to, &bytecode)
         .with_block_context(block_context)
         .with_run_config(run_config());
     let result = tester.execute_block(vec![tx]);

--- a/tests/instances/transactions/src/native_charging.rs
+++ b/tests/instances/transactions/src/native_charging.rs
@@ -1,17 +1,13 @@
 use crate::TxEip1559;
 use crate::ERC_20_TRANSFER_CALLDATA;
-use alloy::primitives::TxKind;
-use alloy::signers::local::PrivateKeySigner;
-use rig::alloy::primitives::address;
-use rig::forward_system::run::convert_alloy::FromAlloy;
-use rig::ruint::aliases::{B160, U256};
+use rig::alloy;
+use rig::alloy::primitives::{address, TxKind};
+use rig::ruint::aliases::{B256, U256};
 use rig::utils::L1TxBuilder;
-use rig::zksync_os_interface::traits::EncodedTx;
-use rig::{alloy, zksync_web3_rs, BlockContext, Chain};
-use std::str::FromStr;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::{BlockContext, ZKsyncOSTester};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-use zksync_web3_rs::signers::{LocalWallet, Signer};
+
+use super::signer_from_key;
 
 const WALLET: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
 const TO: alloy::primitives::Address = address!("0000000000000000000000000000000000010002");
@@ -20,42 +16,37 @@ const AVG_RATIO: u64 = 150;
 const LOW_RATIO: u64 = 1;
 const HIGH_RATIO: u64 = 1_000_000;
 
-fn run_tx(tx: EncodedTx, basefee: u64, native_price: u64, should_succeed: bool, simulation: bool) {
-    let mut chain = Chain::empty(None);
-
-    let transactions = vec![tx];
-
+fn run_tx(
+    tx: ZKsyncTxEnvelope,
+    basefee: u64,
+    native_price: u64,
+    should_succeed: bool,
+    simulation: bool,
+) {
     let bytecode = hex::decode(crate::ERC_20_BYTECODE).unwrap();
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
-    chain.set_evm_bytecode(B160::from_alloy(TO), &bytecode);
-    let wallet_ethers = LocalWallet::from_bytes(wallet.to_bytes().as_slice()).unwrap();
-    let from = wallet_ethers.address();
-
-    chain.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-
-    chain.set_balance(
-        B160::from_be_bytes(from.0),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let wallet = signer_from_key(WALLET);
     let key = crate::compute_erc20_balance_slot(wallet.address());
-    let value = rig::ruint::aliases::B256::from(U256::from(1_000_000_000_000_000_u64));
-    chain.set_storage_slot(B160::from_alloy(TO), key, value);
+    let value = B256::from(U256::from(1_000_000_000_000_000_u64));
 
     let block_context = BlockContext {
         native_price: U256::from(native_price),
         eip1559_basefee: U256::from(basefee),
         ..Default::default()
     };
+
+    let mut tester = ZKsyncOSTester::new()
+        .with_evm_contract(TO, &bytecode)
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_storage_slot(TO, key, value)
+        .with_block_context(block_context);
+
     let output = if simulation {
-        chain.simulate_block(transactions, Some(block_context))
+        tester.simulate_block(vec![tx])
     } else {
-        chain.run_block(transactions, Some(block_context), None, None)
+        tester.execute_block(vec![tx])
     };
 
-    // Assert all txs succeeded
+    // Assert all txs succeeded/failed as expected.
     assert!(output.tx_results.iter().cloned().enumerate().all(|(i, r)| {
         let success = r.clone().is_ok_and(|o| o.is_success());
         if !success {
@@ -68,67 +59,61 @@ fn run_tx(tx: EncodedTx, basefee: u64, native_price: u64, should_succeed: bool, 
 // Test with a low cycles/gas ratio, should fail
 #[test]
 fn test_l1_tx_low_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * LOW_RATIO;
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(wallet.address())
-            .to(TO)
-            .gas_price(gas_price.into())
-            .gas_limit(70_000)
-            .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
-            .build();
-        tx.encode()
-    };
+    let tx = L1TxBuilder::new()
+        .from(wallet.address())
+        .to(TO)
+        .gas_price(gas_price.into())
+        .gas_limit(70_000)
+        .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
+        .build()
+        .into();
     run_tx(tx, gas_price, native_price, false, false)
 }
 
 // Test with a avg cycles/gas ratio, should succeed
 #[test]
 fn test_l1_tx_avg_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * AVG_RATIO;
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(wallet.address())
-            .to(TO)
-            .gas_price(gas_price.into())
-            .gas_limit(70_000)
-            .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
-            .build();
-        tx.encode()
-    };
+    let tx = L1TxBuilder::new()
+        .from(wallet.address())
+        .to(TO)
+        .gas_price(gas_price.into())
+        .gas_limit(70_000)
+        .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
+        .build()
+        .into();
     run_tx(tx, gas_price, native_price, true, false)
 }
 
 // Test with a high cycles/gas ratio, should succeed
 #[test]
 fn test_l1_tx_high_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * HIGH_RATIO;
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(wallet.address())
-            .to(TO)
-            .gas_price(gas_price.into())
-            .gas_limit(70_000)
-            .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
-            .build();
-        tx.encode()
-    };
+    let tx = L1TxBuilder::new()
+        .from(wallet.address())
+        .to(TO)
+        .gas_price(gas_price.into())
+        .gas_limit(70_000)
+        .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
+        .build()
+        .into();
     run_tx(tx, gas_price, native_price, true, false)
 }
 
 // Test with a low cycles/gas ratio, should fail
 #[test]
 fn test_l2_tx_low_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 100;
     let gas_price = 100 * LOW_RATIO;
     let tx = {
@@ -143,7 +128,7 @@ fn test_l2_tx_low_ratio() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
     };
     run_tx(tx, gas_price, native_price, false, false)
 }
@@ -151,7 +136,7 @@ fn test_l2_tx_low_ratio() {
 // Test with a avg cycles/gas ratio, should succeed
 #[test]
 fn test_l2_tx_avg_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 100;
     let gas_price = native_price * AVG_RATIO;
     let tx = {
@@ -166,7 +151,7 @@ fn test_l2_tx_avg_ratio() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
     };
     run_tx(tx, gas_price, native_price, true, false)
 }
@@ -174,7 +159,7 @@ fn test_l2_tx_avg_ratio() {
 // Test with a high cycles/gas ratio, should succeed
 #[test]
 fn test_l2_tx_high_ratio() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 100;
     let gas_price = native_price * HIGH_RATIO;
     let tx = {
@@ -189,7 +174,7 @@ fn test_l2_tx_high_ratio() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
     };
     run_tx(tx, gas_price, native_price, true, false)
 }
@@ -198,7 +183,7 @@ fn test_l2_tx_high_ratio() {
 // Also call as simulation to skip validation step.
 #[test]
 fn test_0_gas_limit() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 10;
     let gas_price = native_price * AVG_RATIO;
     let tx = {
@@ -213,21 +198,19 @@ fn test_0_gas_limit() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     run_tx(tx.clone(), gas_price, native_price, false, false);
     run_tx(tx, gas_price, native_price, false, true);
 
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(wallet.address())
-            .to(TO)
-            .gas_price(gas_price.into())
-            .gas_limit(0)
-            .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
-            .build();
-        tx.encode()
-    };
+    let tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(wallet.address())
+        .to(TO)
+        .gas_price(gas_price.into())
+        .gas_limit(0)
+        .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
+        .build()
+        .into();
     run_tx(tx.clone(), gas_price, native_price, false, false);
     run_tx(tx, gas_price, native_price, false, true);
 }
@@ -236,7 +219,7 @@ fn test_0_gas_limit() {
 // Also call as simulation to skip validation step.
 #[test]
 fn test_0_gas_price() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 10;
     let gas_price = 0;
     let tx = {
@@ -251,28 +234,26 @@ fn test_0_gas_price() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     run_tx(tx.clone(), gas_price, native_price, true, false);
     run_tx(tx, gas_price, native_price, true, true);
 
-    let tx = {
-        let tx = L1TxBuilder::new()
-            .from(wallet.address())
-            .to(TO)
-            .gas_price(gas_price.into())
-            .gas_limit(70_000)
-            .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
-            .build();
-        tx.encode()
-    };
+    let tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(wallet.address())
+        .to(TO)
+        .gas_price(gas_price.into())
+        .gas_limit(70_000)
+        .input(hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap())
+        .build()
+        .into();
     run_tx(tx.clone(), gas_price, native_price, true, false)
 }
 
 // Test delta gas, pass lower ratio
 #[test]
 fn test_delta_gas() {
-    let wallet = PrivateKeySigner::from_str(WALLET).unwrap();
+    let wallet = signer_from_key(WALLET);
     let native_price = 100;
     // Low enough that tx will fail without priority fee
     let ratio = 20;
@@ -290,7 +271,7 @@ fn test_delta_gas() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     // Should fail
     run_tx(tx, gas_price, native_price, false, false);
@@ -307,7 +288,7 @@ fn test_delta_gas() {
             access_list: Default::default(),
             input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
     // Should succeed
     run_tx(tx, gas_price, native_price, true, false)

--- a/tests/instances/transactions/src/native_charging.rs
+++ b/tests/instances/transactions/src/native_charging.rs
@@ -3,13 +3,11 @@ use crate::ERC_20_TRANSFER_CALLDATA;
 use rig::alloy;
 use rig::alloy::primitives::{address, TxKind};
 use rig::ruint::aliases::{B256, U256};
+use rig::testing_signer;
 use rig::utils::L1TxBuilder;
 use rig::{BlockContext, TestingFramework};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
-use super::signer_from_key;
-
-const WALLET: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
 const TO: alloy::primitives::Address = address!("0000000000000000000000000000000000010002");
 
 const AVG_RATIO: u64 = 150;
@@ -24,7 +22,7 @@ fn run_tx(
     simulation: bool,
 ) {
     let bytecode = hex::decode(crate::ERC_20_BYTECODE).unwrap();
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let key = crate::compute_erc20_balance_slot(wallet.address());
     let value = B256::from(U256::from(1_000_000_000_000_000_u64));
 
@@ -59,7 +57,7 @@ fn run_tx(
 // Test with a low cycles/gas ratio, should fail
 #[test]
 fn test_l1_tx_low_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * LOW_RATIO;
@@ -77,7 +75,7 @@ fn test_l1_tx_low_ratio() {
 // Test with a avg cycles/gas ratio, should succeed
 #[test]
 fn test_l1_tx_avg_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * AVG_RATIO;
@@ -95,7 +93,7 @@ fn test_l1_tx_avg_ratio() {
 // Test with a high cycles/gas ratio, should succeed
 #[test]
 fn test_l1_tx_high_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     // L1 Txs have a hard-coded native price of 10
     let native_price = 10;
     let gas_price = native_price * HIGH_RATIO;
@@ -113,7 +111,7 @@ fn test_l1_tx_high_ratio() {
 // Test with a low cycles/gas ratio, should fail
 #[test]
 fn test_l2_tx_low_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 100;
     let gas_price = 100 * LOW_RATIO;
     let tx = {
@@ -136,7 +134,7 @@ fn test_l2_tx_low_ratio() {
 // Test with a avg cycles/gas ratio, should succeed
 #[test]
 fn test_l2_tx_avg_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 100;
     let gas_price = native_price * AVG_RATIO;
     let tx = {
@@ -159,7 +157,7 @@ fn test_l2_tx_avg_ratio() {
 // Test with a high cycles/gas ratio, should succeed
 #[test]
 fn test_l2_tx_high_ratio() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 100;
     let gas_price = native_price * HIGH_RATIO;
     let tx = {
@@ -183,7 +181,7 @@ fn test_l2_tx_high_ratio() {
 // Also call as simulation to skip validation step.
 #[test]
 fn test_0_gas_limit() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 10;
     let gas_price = native_price * AVG_RATIO;
     let tx = {
@@ -219,7 +217,7 @@ fn test_0_gas_limit() {
 // Also call as simulation to skip validation step.
 #[test]
 fn test_0_gas_price() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 10;
     let gas_price = 0;
     let tx = {
@@ -253,7 +251,7 @@ fn test_0_gas_price() {
 // Test delta gas, pass lower ratio
 #[test]
 fn test_delta_gas() {
-    let wallet = signer_from_key(WALLET);
+    let wallet = testing_signer(0);
     let native_price = 100;
     // Low enough that tx will fail without priority fee
     let ratio = 20;

--- a/tests/instances/transactions/src/native_charging.rs
+++ b/tests/instances/transactions/src/native_charging.rs
@@ -4,7 +4,7 @@ use rig::alloy;
 use rig::alloy::primitives::{address, TxKind};
 use rig::ruint::aliases::{B256, U256};
 use rig::utils::L1TxBuilder;
-use rig::{BlockContext, ZKsyncOSTester};
+use rig::{BlockContext, TestingFramework};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 use super::signer_from_key;
@@ -34,7 +34,7 @@ fn run_tx(
         ..Default::default()
     };
 
-    let mut tester = ZKsyncOSTester::new()
+    let mut tester = TestingFramework::new()
         .with_evm_contract(TO, &bytecode)
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
         .with_storage_slot(TO, key, value)

--- a/tests/instances/unit/src/coinbase_regression.rs
+++ b/tests/instances/unit/src/coinbase_regression.rs
@@ -9,13 +9,13 @@
 use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{TxKind, U256};
 use rig::ruint::aliases::B160;
-use rig::{common_target_address, BlockContext, ZKsyncOSTester};
+use rig::{common_target_address, BlockContext, TestingFramework};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[test]
 #[should_panic]
 fn test_invalid_coinbase() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
     let target_address = common_target_address();

--- a/tests/instances/unit/src/coinbase_regression.rs
+++ b/tests/instances/unit/src/coinbase_regression.rs
@@ -7,25 +7,20 @@
 //!
 
 use rig::alloy::consensus::TxEip2930;
-use rig::alloy::primitives::{address, TxKind, U256};
-use rig::forward_system::run::convert_alloy::FromAlloy;
+use rig::alloy::primitives::{TxKind, U256};
 use rig::ruint::aliases::B160;
-use rig::{BlockContext, Chain};
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::{common_target_address, BlockContext, ZKsyncOSTester};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[test]
 #[should_panic]
 fn test_invalid_coinbase() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
-    let target_address = address!("4242000000000000000000000000000000000000");
+    let target_address = common_target_address();
 
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester.with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     let tx = {
         let tx = TxEip2930 {
@@ -38,11 +33,11 @@ fn test_invalid_coinbase() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Create invalid coinbase with 24 bytes set
-    let mut coinbase = rig::ruint::aliases::B160::ZERO;
+    let mut coinbase = B160::ZERO;
     unsafe {
         for limb in coinbase.as_limbs_mut() {
             *limb = u64::MAX;
@@ -55,5 +50,6 @@ fn test_invalid_coinbase() {
         ..Default::default()
     };
 
-    let _result = chain.run_block(vec![tx], Some(block_context), None, None);
+    tester.set_block_context(Some(block_context));
+    let _result = tester.execute_block(vec![tx]);
 }

--- a/tests/instances/unit/src/initial_slot_regression.rs
+++ b/tests/instances/unit/src/initial_slot_regression.rs
@@ -34,7 +34,7 @@ use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
 use rig::zk_ee::types_config::EthereumIOTypesConfig;
 use rig::zk_ee::utils::Bytes32;
 use rig::zksync_os_interface::traits::TxListSource;
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// Malicious storage responder that returns non-zero initial values for new storage slots
@@ -211,7 +211,7 @@ impl TestingOracleFactory<false> for InvalidInitialValueOracleFactory {
 #[test]
 #[should_panic(expected = "Initial value of empty slot must be trivial")]
 fn test_initial_slot_value_assertion() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");

--- a/tests/instances/unit/src/initial_slot_regression.rs
+++ b/tests/instances/unit/src/initial_slot_regression.rs
@@ -34,8 +34,7 @@ use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
 use rig::zk_ee::types_config::EthereumIOTypesConfig;
 use rig::zk_ee::utils::Bytes32;
 use rig::zksync_os_interface::traits::TxListSource;
-use rig::Chain;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::ZKsyncOSTester;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// Malicious storage responder that returns non-zero initial values for new storage slots
@@ -124,10 +123,8 @@ impl InvalidInitialValueOracleFactory {
     fn new(targets: Vec<(B160, Bytes32)>) -> Self {
         Self { targets }
     }
-}
 
-impl TestingOracleFactory<false> for InvalidInitialValueOracleFactory {
-    fn create_oracle<M: MemorySource>(
+    fn build_oracle<M: MemorySource + 'static>(
         &self,
         block_metadata: BlockMetadataFromOracle,
         state_tree: InMemoryTree<false>,
@@ -135,7 +132,6 @@ impl TestingOracleFactory<false> for InvalidInitialValueOracleFactory {
         tx_source: TxListSource,
         proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
         da_commitment_scheme: Option<DACommitmentScheme>,
-        _add_uart: bool,
     ) -> ZkEENonDeterminismSource<M> {
         // Create a malicious oracle manually instead of using the default factory
         let block_metadata_responder = BlockMetadataResponder { block_metadata };
@@ -169,11 +165,54 @@ impl TestingOracleFactory<false> for InvalidInitialValueOracleFactory {
     }
 }
 
+impl TestingOracleFactory<false> for InvalidInitialValueOracleFactory {
+    fn create_forward_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        _add_uart: bool,
+    ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+        self.build_oracle(
+            block_metadata,
+            state_tree,
+            preimage_source,
+            tx_source,
+            proof_data,
+            da_commitment_scheme,
+        )
+    }
+
+    fn create_proof_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        _add_uart: bool,
+    ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+    {
+        self.build_oracle(
+            block_metadata,
+            state_tree,
+            preimage_source,
+            tx_source,
+            proof_data,
+            da_commitment_scheme,
+        )
+    }
+}
+
 #[test]
 #[should_panic(expected = "Initial value of empty slot must be trivial")]
 fn test_initial_slot_value_assertion() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
 
@@ -181,19 +220,13 @@ fn test_initial_slot_value_assertion() {
     // function store(uint256 value) { data = value; }
     let simple_storage_bytecode = hex::decode("6080604052348015600e575f5ffd5b50600436106026575f3560e01c80636057361d14602a575b5f5ffd5b60406004803603810190603c9190607d565b6042565b005b805f8190555050565b5f5ffd5b5f819050919050565b605f81604f565b81146068575f5ffd5b50565b5f813590506077816058565b92915050565b5f60208284031215608f57608e604b565b5b5f609a84828501606b565b9150509291505056fea26469706673582212209a9900f35fcdc7903c2ece72cf1b055b4dda7395c3555e100df93ef7977e707064736f6c634300081e0033").unwrap();
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(contract_address), &simple_storage_bytecode);
-
     // Create a transaction that calls store(42) which writes to storage slot 0
     // Function selector for store(uint256): 6057361d
     let calldata =
         hex::decode("6057361d000000000000000000000000000000000000000000000000000000000000002a")
             .unwrap();
 
-    let encoded_tx = {
+    let tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -204,7 +237,7 @@ fn test_initial_slot_value_assertion() {
             input: calldata.into(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Use the malicious oracle factory that should trigger the assertion
@@ -213,8 +246,12 @@ fn test_initial_slot_value_assertion() {
         Bytes32::zero(),
     )]);
 
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(contract_address, &simple_storage_bytecode)
+        .with_oracle_factory(malicious_factory);
+
     // This should panic with "initial value of empty slot must be trivial"
     // when the oracle returns invalid initial values for empty storage slots
-    let _result =
-        chain.run_block_with_oracle_factory(vec![encoded_tx], None, None, None, &malicious_factory);
+    let _result = tester.execute_block(vec![tx]);
 }

--- a/tests/instances/unit/src/initial_slot_regression.rs
+++ b/tests/instances/unit/src/initial_slot_regression.rs
@@ -249,7 +249,7 @@ fn test_initial_slot_value_assertion() {
     tester = tester
         .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
         .with_evm_contract(contract_address, &simple_storage_bytecode)
-        .with_oracle_factory(malicious_factory);
+        .with_custom_oracle_factory(malicious_factory);
 
     // This should panic with "initial value of empty slot must be trivial"
     // when the oracle returns invalid initial values for empty storage slots

--- a/tests/instances/unit/src/tracer/evm_opcodes_logger.rs
+++ b/tests/instances/unit/src/tracer/evm_opcodes_logger.rs
@@ -7,13 +7,10 @@
 
 use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{address, Address, TxKind, U256};
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
 use rig::forward_system::system::tracers::evm_opcodes_logger::EvmOpcodesLogger;
-use rig::ruint::aliases::B160;
 use rig::zk_ee::system::validator::{NopTxValidator, TxValidator};
-use rig::Chain;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::ZKsyncOSTester;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 fn run_chain_with_tracer(
@@ -33,19 +30,16 @@ fn run_chain_with_tracer_and_validator<V>(
 ) where
     V: TxValidator<ForwardRunningSystem>,
 {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     for (address, bytecode) in contracts {
-        chain.set_evm_bytecode(B160::from_alloy(address), &bytecode);
+        tester.set_evm_contract(address, &bytecode);
     }
 
-    let encoded_tx = {
+    let tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -56,14 +50,10 @@ fn run_chain_with_tracer_and_validator<V>(
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let result =
-        chain.run_block_with_extra_stats(vec![encoded_tx], None, None, None, tracer, validator);
-
-    assert!(result.is_ok(), "Block execution should succeed");
-    let (block_output, _, _) = result.unwrap();
+    let block_output = tester.execute_block_with_tracing(vec![tx], tracer, validator);
     assert!(
         block_output.tx_results[0].is_ok(),
         "Transaction should succeed. Result: {:?}",

--- a/tests/instances/unit/src/tracer/evm_opcodes_logger.rs
+++ b/tests/instances/unit/src/tracer/evm_opcodes_logger.rs
@@ -10,7 +10,7 @@ use rig::alloy::primitives::{address, Address, TxKind, U256};
 use rig::forward_system::system::system_types::ForwardRunningSystem;
 use rig::forward_system::system::tracers::evm_opcodes_logger::EvmOpcodesLogger;
 use rig::zk_ee::system::validator::{NopTxValidator, TxValidator};
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 fn run_chain_with_tracer(
@@ -30,7 +30,7 @@ fn run_chain_with_tracer_and_validator<V>(
 ) where
     V: TxValidator<ForwardRunningSystem>,
 {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));

--- a/tests/instances/unit/src/tracer/mod.rs
+++ b/tests/instances/unit/src/tracer/mod.rs
@@ -7,12 +7,9 @@ pub mod tracer_storage_hooks;
 
 use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{Address, TxKind, U256};
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::system::tracers::call_tracer::CallTracer;
-use rig::ruint::aliases::B160;
 use rig::zk_ee::system::validator::NopTxValidator;
-use rig::{BlockContext, Chain};
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::{BlockContext, ZKsyncOSTester};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 pub(crate) fn run_chain_with_tracer(
@@ -21,20 +18,16 @@ pub(crate) fn run_chain_with_tracer(
     tracer: &mut CallTracer,
     block_context: Option<BlockContext>,
 ) {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
-
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
+    tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 
     for (address, bytecode) in contracts {
-        chain.set_evm_bytecode(B160::from_alloy(address), &bytecode);
+        tester.set_evm_contract(address, &bytecode);
     }
 
     // Create transaction to call the contract
-    let encoded_tx = {
+    let tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -45,15 +38,9 @@ pub(crate) fn run_chain_with_tracer(
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
-    let _ = chain.run_block_with_extra_stats(
-        vec![encoded_tx],
-        block_context,
-        None,
-        None,
-        tracer,
-        &mut NopTxValidator::default(),
-    );
+    tester.set_block_context(block_context);
+    let _ = tester.execute_block_with_tracing(vec![tx], tracer, &mut NopTxValidator::default());
 }

--- a/tests/instances/unit/src/tracer/mod.rs
+++ b/tests/instances/unit/src/tracer/mod.rs
@@ -9,7 +9,7 @@ use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{Address, TxKind, U256};
 use rig::forward_system::system::tracers::call_tracer::CallTracer;
 use rig::zk_ee::system::validator::NopTxValidator;
-use rig::{BlockContext, ZKsyncOSTester};
+use rig::{BlockContext, TestingFramework};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 pub(crate) fn run_chain_with_tracer(
@@ -18,7 +18,7 @@ pub(crate) fn run_chain_with_tracer(
     tracer: &mut CallTracer,
     block_context: Option<BlockContext>,
 ) {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
 

--- a/tests/instances/unit/src/tracer/tracer_event_hook.rs
+++ b/tests/instances/unit/src/tracer/tracer_event_hook.rs
@@ -8,8 +8,8 @@
 
 use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{address, TxKind, U256};
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
+use rig::ruint;
 use rig::ruint::aliases::B160;
 use rig::zk_ee::system::tracer::evm_tracer::NopEvmTracer;
 use rig::zk_ee::system::validator::NopTxValidator;
@@ -21,8 +21,7 @@ use rig::zk_ee::{
     },
     utils::Bytes32,
 };
-use rig::{ruint, Chain};
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::ZKsyncOSTester;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// A struct to track tracer calls for event operations
@@ -115,8 +114,8 @@ impl Tracer<ForwardRunningSystem> for EventOperationTracer {
 
 #[test]
 fn test_event_hook() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
 
@@ -127,17 +126,12 @@ fn test_event_hook() {
     // STOP
     let test_contract_bytecode = hex::decode("604260005260206000A060206000611234a100").unwrap();
 
-    chain.set_balance(
-        ruint::aliases::B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(
-        ruint::aliases::B160::from_alloy(contract_address),
-        &test_contract_bytecode,
-    );
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(contract_address, &test_contract_bytecode);
 
     // Create transaction to call the contract
-    let encoded_tx = {
+    let tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -148,22 +142,13 @@ fn test_event_hook() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     let mut tracer = EventOperationTracer::new();
 
-    let result = chain.run_block_with_extra_stats(
-        vec![encoded_tx],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut NopTxValidator::default(),
-    );
-
-    assert!(result.is_ok(), "Block execution should succeed");
-    let (block_output, _, _) = result.unwrap();
+    let block_output =
+        tester.execute_block_with_tracing(vec![tx], &mut tracer, &mut NopTxValidator::default());
     assert!(
         block_output.tx_results[0].is_ok(),
         "Transaction should succeed with correct tracer calls. Result: {:?}",
@@ -177,7 +162,7 @@ fn test_event_hook() {
         "Should have captured exactly 2 events"
     );
 
-    let contract_address = ruint::aliases::B160::from_alloy(contract_address);
+    let contract_address = ruint::aliases::B160::from_be_bytes(contract_address.into_array());
     assert_eq!(
         tracer.calls.events[0],
         (

--- a/tests/instances/unit/src/tracer/tracer_event_hook.rs
+++ b/tests/instances/unit/src/tracer/tracer_event_hook.rs
@@ -21,7 +21,7 @@ use rig::zk_ee::{
     },
     utils::Bytes32,
 };
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// A struct to track tracer calls for event operations
@@ -114,7 +114,7 @@ impl Tracer<ForwardRunningSystem> for EventOperationTracer {
 
 #[test]
 fn test_event_hook() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");

--- a/tests/instances/unit/src/tracer/tracer_storage_hooks.rs
+++ b/tests/instances/unit/src/tracer/tracer_storage_hooks.rs
@@ -5,7 +5,6 @@
 
 use rig::alloy::consensus::TxEip2930;
 use rig::alloy::primitives::{address, TxKind, U256};
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
 use rig::ruint::aliases::B160;
 use rig::zk_ee::system::tracer::evm_tracer::NopEvmTracer;
@@ -18,8 +17,7 @@ use rig::zk_ee::{
     },
     utils::Bytes32,
 };
-use rig::Chain;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::ZKsyncOSTester;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// A struct to track tracer calls for storage operations
@@ -122,8 +120,8 @@ impl Tracer<ForwardRunningSystem> for StorageOperationTracer {
 
 #[test]
 fn test_storage_hooks() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");
 
@@ -134,14 +132,12 @@ fn test_storage_hooks() {
     // PUSH1 0, TLOAD, POP        (tload from slot 0 - should call on_storage_read)
     let test_contract_bytecode = hex::decode("602a60005560005450602a60005D60005C50").unwrap();
 
-    chain.set_balance(
-        B160::from_alloy(wallet.address()),
-        U256::from(1_000_000_000_000_000_u64),
-    );
-    chain.set_evm_bytecode(B160::from_alloy(contract_address), &test_contract_bytecode);
+    tester = tester
+        .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+        .with_evm_contract(contract_address, &test_contract_bytecode);
 
     // Create transaction to call the contract
-    let encoded_tx = {
+    let tx = {
         let tx = TxEip2930 {
             chain_id: 37u64,
             nonce: 0,
@@ -152,22 +148,13 @@ fn test_storage_hooks() {
             input: Default::default(),
             access_list: Default::default(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     let mut tracer = StorageOperationTracer::new();
 
-    let result = chain.run_block_with_extra_stats(
-        vec![encoded_tx],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut NopTxValidator::default(),
-    );
-
-    assert!(result.is_ok(), "Block execution should succeed");
-    let (block_output, _, _) = result.unwrap();
+    let block_output =
+        tester.execute_block_with_tracing(vec![tx], &mut tracer, &mut NopTxValidator::default());
     assert!(
         block_output.tx_results[0].is_ok(),
         "Transaction should succeed with correct tracer calls. Result: {:?}",
@@ -175,11 +162,12 @@ fn test_storage_hooks() {
     );
 
     assert_eq!(tracer.calls.storage_reads.len(), 2);
+    let expected_contract = B160::from_be_bytes(contract_address.into_array());
     assert_eq!(
         tracer.calls.storage_reads[0],
         (
             false,
-            B160::from_alloy(contract_address),
+            expected_contract,
             Bytes32::zero(),
             Bytes32::from_hex("000000000000000000000000000000000000000000000000000000000000002a")
         )
@@ -188,7 +176,7 @@ fn test_storage_hooks() {
         tracer.calls.storage_reads[1],
         (
             true,
-            B160::from_alloy(contract_address),
+            expected_contract,
             Bytes32::zero(),
             Bytes32::from_hex("000000000000000000000000000000000000000000000000000000000000002a")
         )
@@ -199,7 +187,7 @@ fn test_storage_hooks() {
         tracer.calls.storage_writes[0],
         (
             false,
-            B160::from_alloy(contract_address),
+            expected_contract,
             Bytes32::zero(),
             Bytes32::from_hex("000000000000000000000000000000000000000000000000000000000000002a")
         )
@@ -208,7 +196,7 @@ fn test_storage_hooks() {
         tracer.calls.storage_writes[1],
         (
             true,
-            B160::from_alloy(contract_address),
+            expected_contract,
             Bytes32::zero(),
             Bytes32::from_hex("000000000000000000000000000000000000000000000000000000000000002a")
         )

--- a/tests/instances/unit/src/tracer/tracer_storage_hooks.rs
+++ b/tests/instances/unit/src/tracer/tracer_storage_hooks.rs
@@ -17,7 +17,7 @@ use rig::zk_ee::{
     },
     utils::Bytes32,
 };
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 /// A struct to track tracer calls for storage operations
@@ -120,7 +120,7 @@ impl Tracer<ForwardRunningSystem> for StorageOperationTracer {
 
 #[test]
 fn test_storage_hooks() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
 
     let contract_address = address!("1000000000000000000000000000000000000001");

--- a/tests/instances/unit/src/validator/tx_validator_filtering.rs
+++ b/tests/instances/unit/src/validator/tx_validator_filtering.rs
@@ -14,7 +14,7 @@ use rig::utils::L1TxBuilder;
 use rig::zk_ee::system::tracer::NopTracer;
 use rig::zk_ee::system::validator::{TxValidationError, TxValidator};
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::ZKsyncOSTester;
+use rig::TestingFramework;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[derive(Default)]
@@ -72,7 +72,7 @@ fn included_tx_number_in_block<T>(
 
 #[test]
 fn test_tx_validator_filters_out_tx_without_bumping_counter() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
 
@@ -147,7 +147,7 @@ fn test_tx_validator_filters_out_tx_without_bumping_counter() {
 fn test_no_custom_validator_does_not_restrict_tx_flow() {
     use rig::zk_ee::system::validator::NopTxValidator;
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
 
@@ -203,7 +203,7 @@ fn test_no_custom_validator_does_not_restrict_tx_flow() {
 
 #[test]
 fn test_l1_transactions_are_not_filtered_by_validator() {
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
 
@@ -272,7 +272,7 @@ fn test_tx_validator_filters_out_tx_on_begin_tx() {
     //! If a transaction is filtered by validator.begin_tx(),
     //! it should be rejected before execution and should not affect nonce counts.
 
-    let mut tester = ZKsyncOSTester::new();
+    let mut tester = TestingFramework::new();
     let wallet = tester.random_signer();
     let from = wallet.address();
 

--- a/tests/instances/unit/src/validator/tx_validator_filtering.rs
+++ b/tests/instances/unit/src/validator/tx_validator_filtering.rs
@@ -7,6 +7,7 @@
 
 use rig::alloy::consensus::TxLegacy;
 use rig::alloy::primitives::{address, TxKind};
+use rig::chain::RunConfig;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
 use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
@@ -100,6 +101,9 @@ fn test_tx_validator_filters_out_tx_without_bumping_counter() {
 
     let mut tracer = NopTracer::default();
     let mut validator = LoggingTxValidator::new(true, false);
+
+    // Disable RISC-V run because TxValidator is ignored during RISC-V execution
+    tester.set_run_config(Some(RunConfig::without_riscv_run()));
 
     let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 
@@ -299,6 +303,9 @@ fn test_tx_validator_filters_out_tx_on_begin_tx() {
     let mut tracer = NopTracer::default();
     // Validator that filters on begin_tx only (first tx)
     let mut validator = LoggingTxValidator::new(true, false);
+
+    // Disable RISC-V run because TxValidator is ignored during RISC-V execution
+    tester.set_run_config(Some(RunConfig::without_riscv_run()));
 
     let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 

--- a/tests/instances/unit/src/validator/tx_validator_filtering.rs
+++ b/tests/instances/unit/src/validator/tx_validator_filtering.rs
@@ -7,15 +7,13 @@
 
 use rig::alloy::consensus::TxLegacy;
 use rig::alloy::primitives::{address, TxKind};
-use rig::forward_system::run::convert_alloy::FromAlloy;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
-use rig::ruint::aliases::{B160, U256};
+use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
 use rig::zk_ee::system::tracer::NopTracer;
 use rig::zk_ee::system::validator::{TxValidationError, TxValidator};
 use rig::zksync_os_interface::error::InvalidTransaction;
-use rig::Chain;
-use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use rig::ZKsyncOSTester;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 #[derive(Default)]
@@ -73,14 +71,11 @@ fn included_tx_number_in_block<T>(
 
 #[test]
 fn test_tx_validator_filters_out_tx_without_bumping_counter() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
 
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester.with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     let withdrawal_to = address!("000000000000000000000000000000000000800a");
     let withdrawal_calldata =
@@ -97,7 +92,7 @@ fn test_tx_validator_filters_out_tx_without_bumping_counter() {
             value: U256::from(value),
             input: withdrawal_calldata.clone().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     let tx0 = mk_withdrawal(0, 10);
@@ -106,17 +101,7 @@ fn test_tx_validator_filters_out_tx_without_bumping_counter() {
     let mut tracer = NopTracer::default();
     let mut validator = LoggingTxValidator::new(true, false);
 
-    let result = chain.run_block_with_extra_stats(
-        vec![tx0, tx1],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut validator,
-    );
-
-    assert!(result.is_ok());
-    let (out, _, _) = result.unwrap();
+    let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 
     println!(
         "[TxValidator] totals: begin_calls={}, finish_calls={}",
@@ -158,14 +143,11 @@ fn test_tx_validator_filters_out_tx_without_bumping_counter() {
 fn test_no_custom_validator_does_not_restrict_tx_flow() {
     use rig::zk_ee::system::validator::NopTxValidator;
 
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
 
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester.with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     // Keep same tx shape; don't depend on L2->L1 logs.
     let withdrawal_to = address!("000000000000000000000000000000000000800a");
@@ -183,7 +165,7 @@ fn test_no_custom_validator_does_not_restrict_tx_flow() {
             value: U256::from(value),
             input: withdrawal_calldata.clone().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Normal nonces (0 then 1), because nothing is filtered.
@@ -193,17 +175,7 @@ fn test_no_custom_validator_does_not_restrict_tx_flow() {
     let mut tracer = NopTracer::default();
     let mut validator = NopTxValidator::default();
 
-    let result = chain.run_block_with_extra_stats(
-        vec![tx0, tx1],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut validator,
-    );
-
-    assert!(result.is_ok());
-    let (out, _, _) = result.unwrap();
+    let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 
     // 1) Both tx must succeed
     assert!(
@@ -227,8 +199,8 @@ fn test_no_custom_validator_does_not_restrict_tx_flow() {
 
 #[test]
 fn test_l1_transactions_are_not_filtered_by_validator() {
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
 
     let withdrawal_to = address!("000000000000000000000000000000000000800a");
@@ -236,10 +208,10 @@ fn test_l1_transactions_are_not_filtered_by_validator() {
         hex::decode("51cff8d9000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
             .unwrap();
 
-    chain.set_balance(B160::from_be_bytes(from.0 .0), U256::from(10_000_000));
+    tester = tester.with_balance(from, U256::from(10_000_000));
 
     let mk_l1_tx = |nonce: u64, value: u64| {
-        let tx = L1TxBuilder::new()
+        L1TxBuilder::new()
             .from(from)
             .to(withdrawal_to)
             .gas_price(1000u128.into())
@@ -247,8 +219,8 @@ fn test_l1_transactions_are_not_filtered_by_validator() {
             .value(U256::from(value))
             .input(withdrawal_calldata.clone().into())
             .nonce(nonce.into())
-            .build();
-        tx.encode()
+            .build()
+            .into()
     };
 
     let tx0 = mk_l1_tx(0, 10);
@@ -257,17 +229,7 @@ fn test_l1_transactions_are_not_filtered_by_validator() {
     let mut tracer = NopTracer::default();
     let mut validator = LoggingTxValidator::new(true, false);
 
-    let result = chain.run_block_with_extra_stats(
-        vec![tx0, tx1],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut validator,
-    );
-
-    assert!(result.is_ok());
-    let (out, _, _) = result.unwrap();
+    let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 
     println!(
         "[TxValidator] totals: begin_calls={}, finish_calls={}",
@@ -306,14 +268,11 @@ fn test_tx_validator_filters_out_tx_on_begin_tx() {
     //! If a transaction is filtered by validator.begin_tx(),
     //! it should be rejected before execution and should not affect nonce counts.
 
-    let mut chain = Chain::empty(None);
-    let wallet = chain.random_signer();
+    let mut tester = ZKsyncOSTester::new();
+    let wallet = tester.random_signer();
     let from = wallet.address();
 
-    chain.set_balance(
-        B160::from_alloy(from),
-        U256::from(1_000_000_000_000_000_u64),
-    );
+    tester = tester.with_balance(from, U256::from(1_000_000_000_000_000_u64));
 
     let withdrawal_to = address!("000000000000000000000000000000000000800a");
     let withdrawal_calldata =
@@ -330,7 +289,7 @@ fn test_tx_validator_filters_out_tx_on_begin_tx() {
             value: U256::from(value),
             input: withdrawal_calldata.clone().into(),
         };
-        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone()).encode()
+        ZKsyncTxEnvelope::from_eth_tx(tx, wallet.clone())
     };
 
     // Both txs with nonce 0 (first will be filtered, second should succeed with same nonce)
@@ -341,17 +300,7 @@ fn test_tx_validator_filters_out_tx_on_begin_tx() {
     // Validator that filters on begin_tx only (first tx)
     let mut validator = LoggingTxValidator::new(true, false);
 
-    let result = chain.run_block_with_extra_stats(
-        vec![tx0, tx1],
-        None,
-        None,
-        None,
-        &mut tracer,
-        &mut validator,
-    );
-
-    assert!(result.is_ok());
-    let (out, _, _) = result.unwrap();
+    let out = tester.execute_block_with_tracing(vec![tx0, tx1], &mut tracer, &mut validator);
 
     println!(
         "[TxValidator] totals: begin_calls={}, finish_calls={}",

--- a/tests/rig/Cargo.toml
+++ b/tests/rig/Cargo.toml
@@ -30,18 +30,14 @@ gpu_prover = { workspace = true, optional = true }
 
 zksync_os_tests_common = { path = "../common" }
 
-futures = "0.3.30"
 hex = "*"
 ruint = { workspace = true, default-features = false }
-tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 env_logger = "0.11.6"
-log = "0.4.22" # tokio with `rt-multi-thread` feature needed to build ethers 2.0.0
+log = "0.4.22"
 alloy = { version = "1", features = ["full", "eip712", "consensus"]}
 alloy-rlp = { version = "0.3.12" }
 alloy-sol-types = "1"
 alloy-rpc-types-debug = { version = "*", default-features = false }
-zksync-web3-rs = { git = "https://github.com/lambdaclass/zksync-web3-rs.git" }
-bincode = "1.3"
 once_cell = "1.20.3"
 
 [features]

--- a/tests/rig/Cargo.toml
+++ b/tests/rig/Cargo.toml
@@ -30,7 +30,6 @@ gpu_prover = { workspace = true, optional = true }
 
 zksync_os_tests_common = { path = "../common" }
 
-hex = "*"
 ruint = { workspace = true, default-features = false }
 env_logger = "0.11.6"
 log = "0.4.22"

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -221,10 +221,11 @@ impl RunConfig {
     }
 
     pub fn with_riscv_run() -> Self {
-        let mut config = Self::default();
-        config.do_riscv_run = true;
-        config.check_storage_diff_hashes = true; // Enable storage diff hash checks when RISC-V run is enabled
-        config
+        Self {
+            do_riscv_run: true,
+            check_storage_diff_hashes: true, // Enable storage diff hash checks when doing RISC-V run
+            ..Default::default()
+        }
     }
 
     pub fn disable_riscv_run(&mut self) {

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -141,7 +141,7 @@ impl Default for BlockContext {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RunConfig {
     // Config for the profiler
     pub profiler_config: Option<ProfilerConfig>,
@@ -228,6 +228,10 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
 
     pub fn set_block_hashes(&mut self, block_hashes: [U256; 256]) {
         self.block_hashes = block_hashes
+    }
+
+    pub fn set_chain_id(&mut self, chain_id: u64) {
+        self.chain_id = chain_id;
     }
 
     /// TODO: duplicated from API, unify.

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -207,6 +207,19 @@ impl Default for RunConfig {
     }
 }
 
+impl RunConfig {
+    pub fn without_riscv_run() -> Self {
+        let mut config = Self::default();
+        config.disable_riscv_run();
+        config
+    }
+
+    pub fn disable_riscv_run(&mut self) {
+        self.do_riscv_run = false;
+        self.check_storage_diff_hashes = false; // Disable storage diff hash checks when RISC-V run is disabled
+    }
+}
+
 impl Chain<false> {
     ///
     /// Create empty state

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -174,7 +174,7 @@ impl Default for BlockContext {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct RunConfig {
     // Config for the profiler
     pub profiler_config: Option<ProfilerConfig>,
@@ -182,13 +182,29 @@ pub struct RunConfig {
     pub witness_output_file: Option<PathBuf>,
     // Name of risc-v binary to use
     pub app: Option<String>,
-    // Only run in forward mode, skip proving run
-    pub only_forward: bool,
+    // Run RISC-V simulation
+    pub do_riscv_run: bool,
     // Whether to check that storage diff hashes from forward and proof runs match
     // Only to be used when state-diffs-pi feature is enabled in the binary and
-    // only_forward is false
+    // do_riscv_run is true
     pub check_storage_diff_hashes: bool,
     pub skip_minting_tokens_to_treasury: bool,
+}
+
+impl Default for RunConfig {
+    fn default() -> Self {
+        let do_riscv_run =
+            std::env::var("ZKSYNC_PROVING_RUN").is_ok() || std::env::var("CI").is_ok();
+
+        RunConfig {
+            app: Some("for_tests".to_string()),
+            do_riscv_run,
+            check_storage_diff_hashes: do_riscv_run, // Enable storage diff hash checks when doing RISC-V run
+            skip_minting_tokens_to_treasury: false,
+            profiler_config: None,
+            witness_output_file: None,
+        }
+    }
 }
 
 impl Chain<false> {
@@ -494,7 +510,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
             profiler_config,
             witness_output_file,
             app,
-            only_forward,
+            do_riscv_run,
             check_storage_diff_hashes,
             skip_minting_tokens_to_treasury,
         } = run_config;
@@ -627,7 +643,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
                 .insert(hash.0.into(), preimage.clone());
         }
 
-        let proof_input = if !only_forward {
+        let proof_input = if do_riscv_run {
             if let Some(path) = witness_output_file {
                 let result = Self::run_block_generate_witness::<false>(oracle, &app);
                 let mut file = File::create(&path).expect("should create file");

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -195,7 +195,7 @@ pub struct RunConfig {
 impl Default for RunConfig {
     fn default() -> Self {
         let do_riscv_run = Self::should_do_riscv_run(
-            std::env::var_os("ZKSYNC_PROVING_RUN").is_some(),
+            std::env::var_os("ZKSYNC_RISC_V_RUN").is_some(),
             std::env::var_os("CI").is_some(),
         );
 

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -193,8 +193,10 @@ pub struct RunConfig {
 
 impl Default for RunConfig {
     fn default() -> Self {
-        let do_riscv_run =
-            std::env::var("ZKSYNC_PROVING_RUN").is_ok() || std::env::var("CI").is_ok();
+        let do_riscv_run = Self::should_do_riscv_run(
+            std::env::var_os("ZKSYNC_PROVING_RUN").is_some(),
+            std::env::var_os("CI").is_some(),
+        );
 
         RunConfig {
             app: Some("for_tests".to_string()),
@@ -208,6 +210,10 @@ impl Default for RunConfig {
 }
 
 impl RunConfig {
+    fn should_do_riscv_run(zksync_proving_run_set: bool, ci_set: bool) -> bool {
+        zksync_proving_run_set || ci_set
+    }
+
     pub fn without_riscv_run() -> Self {
         let mut config = Self::default();
         config.disable_riscv_run();
@@ -1224,4 +1230,29 @@ fn run_prover(csr_reads: &[u32]) {
     );
 
     info!("block proved successfully");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RunConfig;
+
+    #[test]
+    fn run_config_should_do_riscv_run_matches_env_signals() {
+        assert!(RunConfig::should_do_riscv_run(true, false));
+        assert!(RunConfig::should_do_riscv_run(false, true));
+        assert!(RunConfig::should_do_riscv_run(true, true));
+        assert!(!RunConfig::should_do_riscv_run(false, false));
+    }
+
+    #[test]
+    fn run_config_without_riscv_run_disables_hash_checks() {
+        let mut config = RunConfig {
+            do_riscv_run: true,
+            check_storage_diff_hashes: true,
+            ..RunConfig::default()
+        };
+        config.disable_riscv_run();
+        assert!(!config.do_riscv_run);
+        assert!(!config.check_storage_diff_hashes);
+    }
 }

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -220,6 +220,13 @@ impl RunConfig {
         config
     }
 
+    pub fn with_riscv_run() -> Self {
+        let mut config = Self::default();
+        config.do_riscv_run = true;
+        config.check_storage_diff_hashes = true; // Enable storage diff hash checks when RISC-V run is enabled
+        config
+    }
+
     pub fn disable_riscv_run(&mut self) {
         self.do_riscv_run = false;
         self.check_storage_diff_hashes = false; // Disable storage diff hash checks when RISC-V run is disabled

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -1,5 +1,6 @@
 use crate::{colors, init_logger};
 use alloy::consensus::Header;
+use alloy::hex;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_rlp::{Decodable, Encodable};
 use basic_bootloader::bootloader::block_flow::ethereum::PectraForkHeader;

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -33,7 +33,7 @@ use forward_system::system::system_types::ForwardRunningSystem;
 use log::warn;
 use log::{debug, info, trace};
 use oracle_provider::MemorySource;
-use oracle_provider::{ReadWitnessSource, ZkEENonDeterminismSource};
+use oracle_provider::{DummyMemorySource, ReadWitnessSource, ZkEENonDeterminismSource};
 use risc_v_simulator::abstractions::memory::VectorMemoryImpl;
 use risc_v_simulator::sim::{DiagnosticsConfig, ProfilerConfig};
 use ruint::aliases::{B160, B256, U256};
@@ -58,7 +58,7 @@ use zksync_os_interface::types::StorageWrite;
 /// Trait for creating oracles with custom configuration
 pub trait TestingOracleFactory<const RANDOMIZED_TREE: bool> {
     #[allow(clippy::too_many_arguments)]
-    fn create_oracle<M: MemorySource + 'static>(
+    fn create_forward_oracle(
         &self,
         block_metadata: BlockMetadataFromOracle,
         state_tree: InMemoryTree<RANDOMIZED_TREE>,
@@ -67,7 +67,19 @@ pub trait TestingOracleFactory<const RANDOMIZED_TREE: bool> {
         proof_data: Option<ProofData<FlatStorageCommitment<TREE_HEIGHT>>>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         add_uart: bool,
-    ) -> ZkEENonDeterminismSource<M>;
+    ) -> ZkEENonDeterminismSource<DummyMemorySource>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_proof_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        state_tree: InMemoryTree<RANDOMIZED_TREE>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        proof_data: Option<ProofData<FlatStorageCommitment<TREE_HEIGHT>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_uart: bool,
+    ) -> ZkEENonDeterminismSource<VectorMemoryImpl>;
 }
 
 /// Default oracle factory that uses the existing make_oracle_for_proofs_and_dumps function
@@ -76,7 +88,7 @@ pub struct DefaultOracleFactory<const RANDOMIZED_TREE: bool>;
 impl<const RANDOMIZED_TREE: bool> TestingOracleFactory<RANDOMIZED_TREE>
     for DefaultOracleFactory<RANDOMIZED_TREE>
 {
-    fn create_oracle<M: MemorySource + 'static>(
+    fn create_forward_oracle(
         &self,
         block_metadata: BlockMetadataFromOracle,
         state_tree: InMemoryTree<RANDOMIZED_TREE>,
@@ -85,7 +97,28 @@ impl<const RANDOMIZED_TREE: bool> TestingOracleFactory<RANDOMIZED_TREE>
         proof_data: Option<ProofData<FlatStorageCommitment<TREE_HEIGHT>>>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         add_uart: bool,
-    ) -> ZkEENonDeterminismSource<M> {
+    ) -> ZkEENonDeterminismSource<DummyMemorySource> {
+        forward_system::run::make_oracle_for_proofs_and_dumps(
+            block_metadata,
+            state_tree,
+            preimage_source,
+            tx_source,
+            proof_data,
+            da_commitment_scheme,
+            add_uart,
+        )
+    }
+
+    fn create_proof_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        state_tree: InMemoryTree<RANDOMIZED_TREE>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        proof_data: Option<ProofData<FlatStorageCommitment<TREE_HEIGHT>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_uart: bool,
+    ) -> ZkEENonDeterminismSource<VectorMemoryImpl> {
         forward_system::run::make_oracle_for_proofs_and_dumps(
             block_metadata,
             state_tree,
@@ -358,13 +391,13 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
     ///
     /// You can also pass a run config.
     ///
-    pub fn run_block_with_oracle_factory<OF: TestingOracleFactory<RANDOMIZED_TREE>>(
+    pub fn run_block_with_oracle_factory(
         &mut self,
         transactions: Vec<EncodedTx>,
         block_context: Option<BlockContext>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         run_config: Option<RunConfig>,
-        oracle_factory: &OF,
+        oracle_factory: &dyn TestingOracleFactory<RANDOMIZED_TREE>,
     ) -> BlockOutput {
         self.run_block_with_extra_stats_with_oracle_factory(
             transactions,
@@ -424,9 +457,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
 
     #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
-    pub fn run_block_with_extra_stats_with_oracle_factory<
-        OF: TestingOracleFactory<RANDOMIZED_TREE>,
-    >(
+    pub fn run_block_with_extra_stats_with_oracle_factory(
         &mut self,
         transactions: Vec<EncodedTx>,
         block_context: Option<BlockContext>,
@@ -434,7 +465,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
         run_config: Option<RunConfig>,
         tracer: &mut impl Tracer<ForwardRunningSystem>,
         validator: &mut impl TxValidator<ForwardRunningSystem>,
-        oracle_factory: &OF,
+        oracle_factory: &dyn TestingOracleFactory<RANDOMIZED_TREE>,
     ) -> Result<(BlockOutput, BlockExtraStats, Vec<u32>), BootloaderSubsystemError> {
         self.run_inner(
             transactions,
@@ -449,13 +480,13 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
 
     #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
-    fn run_inner<OF: TestingOracleFactory<RANDOMIZED_TREE>>(
+    fn run_inner(
         &mut self,
         transactions: Vec<EncodedTx>,
         block_context: Option<BlockContext>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         run_config: RunConfig,
-        oracle_factory: &OF,
+        oracle_factory: &dyn TestingOracleFactory<RANDOMIZED_TREE>,
         tracer: &mut impl Tracer<ForwardRunningSystem>,
         validator: &mut impl TxValidator<ForwardRunningSystem>,
     ) -> Result<(BlockOutput, BlockExtraStats, Vec<u32>), BootloaderSubsystemError> {
@@ -501,7 +532,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
 
         let da_commitment_scheme =
             da_commitment_scheme.unwrap_or(DACommitmentScheme::BlobsAndPubdataKeccak256);
-        let oracle = oracle_factory.create_oracle(
+        let oracle = oracle_factory.create_proof_oracle(
             block_metadata,
             self.state_tree.clone(),
             self.preimage_source.clone(),
@@ -511,7 +542,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
             true,
         );
 
-        let forward_oracle = oracle_factory.create_oracle(
+        let forward_oracle = oracle_factory.create_forward_oracle(
             block_metadata,
             self.state_tree.clone(),
             self.preimage_source.clone(),
@@ -523,7 +554,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
 
         #[cfg(feature = "simulate_witness_gen")]
         let source_for_witness_bench = {
-            oracle_factory.create_oracle(
+            oracle_factory.create_proof_oracle(
                 block_metadata,
                 self.state_tree.clone(),
                 self.preimage_source.clone(),

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -103,7 +103,7 @@ pub struct LastExecutedBlockInfo {
     pub proof_input: Vec<u32>,
 }
 
-pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
+pub struct TestingFramework<const RANDOMIZED_TREE: bool = false> {
     chain: Chain<RANDOMIZED_TREE>,
     block_context: Option<BlockContext>,
     da_commitment_scheme: Option<DACommitmentScheme>,
@@ -112,7 +112,7 @@ pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
     oracle_factory: Option<Box<dyn TestingOracleFactory<RANDOMIZED_TREE>>>,
 }
 
-impl ZKsyncOSTester<true> {
+impl TestingFramework<true> {
     pub fn new_with_randomized_tree() -> Self {
         init_logger();
 
@@ -127,13 +127,13 @@ impl ZKsyncOSTester<true> {
     }
 }
 
-impl Default for ZKsyncOSTester<false> {
+impl Default for TestingFramework<false> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ZKsyncOSTester<false> {
+impl TestingFramework<false> {
     pub fn new() -> Self {
         init_logger();
 
@@ -148,7 +148,7 @@ impl ZKsyncOSTester<false> {
     }
 }
 
-impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
+impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain.set_chain_id(chain_id);
         self

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -404,6 +404,11 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         block_output
     }
 
+    /// Simulate a block in forward mode only.
+    ///
+    /// This method applies only the explicit/attached block context and intentionally
+    /// ignores proving-related configuration such as `run_config`, DA commitment scheme,
+    /// and custom oracle factories.
     pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -15,6 +15,7 @@ use alloy::signers::local::PrivateKeySigner;
 pub use alloy_rlp;
 pub use alloy_sol_types;
 pub use basic_bootloader;
+use basic_bootloader::bootloader::errors::BootloaderSubsystemError;
 pub use basic_system;
 pub use callable_oracles;
 pub use chain::BlockContext;
@@ -105,6 +106,12 @@ impl ZKsyncOSTester<true> {
             da_commitment_scheme: None,
             run_config: None,
         }
+    }
+}
+
+impl Default for ZKsyncOSTester<false> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -283,7 +290,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self.chain.run_block(
             encoded_txs,
             self.block_context.clone(),
-            self.da_commitment_scheme.clone(),
+            self.da_commitment_scheme,
             self.run_config.clone(),
         )
     }
@@ -300,7 +307,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     pub fn execute_block_no_panic<T: IntoEncodedTx>(
         &mut self,
         transactions: Vec<T>,
-    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
+    ) -> Result<BlockOutput, BootloaderSubsystemError> {
         let encoded_txs = transactions
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
@@ -308,12 +315,12 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self.chain.run_block_no_panic(
             encoded_txs,
             self.block_context.clone(),
-            self.da_commitment_scheme.clone(),
+            self.da_commitment_scheme,
             self.run_config.clone(),
         )
     }
 
-    pub fn assert_all_txs_succeded(&self, block_output: &BlockOutput) {
+    pub fn assert_all_txs_succeeded(&self, block_output: &BlockOutput) {
         assert!(block_output
             .tx_results
             .iter()

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -120,7 +120,7 @@ impl ZKsyncOSTester<true> {
             chain: Chain::empty_randomized(None),
             block_context: None,
             da_commitment_scheme: None,
-            run_config: None,
+            run_config: Some(Default::default()),
             last_executed_block_info: None,
             oracle_factory: None,
         }
@@ -141,7 +141,7 @@ impl ZKsyncOSTester<false> {
             chain: Chain::empty(None),
             block_context: None,
             da_commitment_scheme: None,
-            run_config: None,
+            run_config: Some(Default::default()),
             last_executed_block_info: None,
             oracle_factory: None,
         }
@@ -470,14 +470,4 @@ pub fn signer_from_key(key: &str) -> PrivateKeySigner {
 
 pub fn common_target_address() -> alloy::primitives::Address {
     address!("4242000000000000000000000000000000000000")
-}
-
-pub fn default_run_config() -> RunConfig {
-    RunConfig {
-        app: Some("for_tests".to_string()),
-        only_forward: false,
-        check_storage_diff_hashes: true,
-        skip_minting_tokens_to_treasury: false,
-        ..Default::default()
-    }
 }

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -90,10 +90,10 @@ mod colors {
 }
 
 pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
-    pub chain: Chain<RANDOMIZED_TREE>,
-    pub block_context: Option<BlockContext>,
-    pub da_commitment_scheme: Option<DACommitmentScheme>,
-    pub run_config: Option<RunConfig>,
+    chain: Chain<RANDOMIZED_TREE>,
+    block_context: Option<BlockContext>,
+    da_commitment_scheme: Option<DACommitmentScheme>,
+    run_config: Option<RunConfig>,
 }
 
 impl ZKsyncOSTester<true> {
@@ -209,6 +209,16 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
+    pub fn with_storage_slot(
+        mut self,
+        address: alloy::primitives::Address,
+        key: ruint::aliases::U256,
+        value: ruint::aliases::B256,
+    ) -> Self {
+        self.set_storage_slot(address, key, value);
+        self
+    }
+
     pub fn set_run_config(&mut self, run_config: Option<RunConfig>) -> &mut Self {
         self.run_config = run_config;
         self
@@ -231,6 +241,17 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     ) -> &mut Self {
         self.chain
             .set_evm_bytecode(ruint::aliases::B160::from_alloy(address), bytecode);
+        self
+    }
+
+    pub fn set_storage_slot(
+        &mut self,
+        address: alloy::primitives::Address,
+        key: ruint::aliases::U256,
+        value: ruint::aliases::B256,
+    ) -> &mut Self {
+        self.chain
+            .set_storage_slot(ruint::aliases::B160::from_alloy(address), key, value);
         self
     }
 
@@ -282,7 +303,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         crate::utils::run_block_of_erc20_with_fee(&mut self.chain, n, block_context, fee)
     }
 
-    pub fn execute_block<T: IntoEncodedTx>(&mut self, transactions: Vec<T>) -> BlockOutput {
+    pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
@@ -295,7 +316,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         )
     }
 
-    pub fn simulate_block<T: IntoEncodedTx>(&mut self, transactions: Vec<T>) -> BlockOutput {
+    pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
@@ -304,9 +325,9 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .simulate_block(encoded_txs, self.block_context.clone())
     }
 
-    pub fn execute_block_no_panic<T: IntoEncodedTx>(
+    pub fn execute_block_no_panic(
         &mut self,
-        transactions: Vec<T>,
+        transactions: Vec<ZKsyncTxEnvelope>,
     ) -> Result<BlockOutput, BootloaderSubsystemError> {
         let encoded_txs = transactions
             .into_iter()

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -27,6 +27,7 @@ pub use cli_lib;
 pub use crypto;
 pub use forward_system;
 use forward_system::run::convert_alloy::FromAlloy;
+use forward_system::system::system_types::ForwardRunningSystem;
 #[cfg(feature = "gpu")]
 pub use gpu_prover;
 pub use log;
@@ -38,7 +39,9 @@ pub use system_hooks;
 pub use zk_ee;
 use zk_ee::common_structs::DACommitmentScheme;
 use zk_ee::system::tracer::NopTracer;
+use zk_ee::system::tracer::Tracer;
 use zk_ee::system::validator::NopTxValidator;
+use zk_ee::system::validator::TxValidator;
 pub use zksync_os_api;
 pub use zksync_os_interface;
 use zksync_os_interface::types::BlockOutput;
@@ -336,6 +339,19 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     }
 
     pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
+        self.execute_block_with_tracing(
+            transactions,
+            &mut NopTracer::default(),
+            &mut NopTxValidator,
+        )
+    }
+
+    pub fn execute_block_with_tracing(
+        &mut self,
+        transactions: Vec<ZKsyncTxEnvelope>,
+        tracer: &mut impl Tracer<ForwardRunningSystem>,
+        validator: &mut impl TxValidator<ForwardRunningSystem>,
+    ) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
@@ -347,8 +363,8 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
                 self.block_context.clone(),
                 self.da_commitment_scheme,
                 self.run_config.clone(),
-                &mut NopTracer::default(),
-                &mut NopTxValidator::default(),
+                tracer,
+                validator,
             )
             .unwrap();
 

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -520,6 +520,22 @@ pub fn signer_from_key(key: &str) -> PrivateKeySigner {
     PrivateKeySigner::from_str(key).unwrap()
 }
 
+pub const PRIMARY_TEST_PK: &str =
+    "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+pub const SECONDARY_TEST_PK: &str =
+    "a226d3a5c8c408741c3446c762aee8dff742f21e381a0e5ab85a96c5c00100be";
+pub const TERTIARY_TEST_PK: &str =
+    "abcdebdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+
+pub fn testing_signer(index: u64) -> PrivateKeySigner {
+    match index {
+        0 => signer_from_key(PRIMARY_TEST_PK),
+        1 => signer_from_key(SECONDARY_TEST_PK),
+        2 => signer_from_key(TERTIARY_TEST_PK),
+        _ => panic!("unsupported testing signer index: {index}"),
+    }
+}
+
 pub fn common_target_address() -> alloy::primitives::Address {
     address!("4242000000000000000000000000000000000000")
 }

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -48,7 +48,6 @@ use zksync_os_interface::types::BlockOutput;
 pub use zksync_os_tests_common;
 use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-pub use zksync_web3_rs;
 
 use crate::chain::TestingOracleFactory;
 use crate::chain::{BlockExtraStats, RunConfig};

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -49,6 +49,22 @@ pub fn init_logger() {
     INIT_LOGGER_ONCE.call_once(env_logger::init);
 }
 
+pub trait IntoEncodedTx {
+    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx;
+}
+
+impl IntoEncodedTx for zksync_os_interface::traits::EncodedTx {
+    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx {
+        self
+    }
+}
+
+impl IntoEncodedTx for ZKsyncTxEnvelope {
+    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx {
+        self.encode()
+    }
+}
+
 #[allow(dead_code)]
 mod colors {
     pub const RESET: &str = "\x1b[0m";
@@ -80,7 +96,7 @@ pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
 }
 
 impl ZKsyncOSTester<true> {
-    pub fn new() -> Self {
+    pub fn new_with_randomized_tree() -> Self {
         init_logger();
 
         Self {
@@ -130,6 +146,11 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
+    pub fn set_block_context(&mut self, block_context: Option<BlockContext>) -> &mut Self {
+        self.block_context = block_context;
+        self
+    }
+
     pub fn with_da_commitment_scheme(mut self, da_commitment_scheme: DACommitmentScheme) -> Self {
         self.da_commitment_scheme = Some(da_commitment_scheme);
         self
@@ -140,17 +161,45 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
+    pub fn with_system_contracts(
+        mut self,
+        with_l1_messenger: bool,
+        with_l2_base_token: bool,
+        with_contract_deployer: bool,
+    ) -> Self {
+        crate::testing_utils::install_system_contracts(
+            &mut self.chain,
+            with_l1_messenger,
+            with_l2_base_token,
+            with_contract_deployer,
+        );
+        self
+    }
+
     pub fn with_balance(
         mut self,
         address: ruint::aliases::B160,
         balance: ruint::aliases::U256,
     ) -> Self {
-        self.chain.set_balance(address, balance);
+        self.set_balance(address, balance);
+        self
+    }
+
+    pub fn with_prefunded_account(mut self, address: ruint::aliases::B160) -> Self {
+        self.set_balance(
+            address,
+            ruint::aliases::U256::from(1_000_000_000_000_000_u64),
+        );
         self
     }
 
     pub fn with_evm_contract(mut self, address: ruint::aliases::B160, bytecode: &[u8]) -> Self {
-        self.chain.set_evm_bytecode(address, bytecode);
+        self.set_evm_bytecode(address, bytecode);
+        self
+    }
+
+    pub fn set_run_config(&mut self, run_config: Option<RunConfig>) -> &mut Self {
+        self.run_config = run_config;
         self
     }
 
@@ -178,21 +227,36 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn prefunded_random_signer(&mut self) -> PrivateKeySigner {
         let signer = self.chain.random_signer();
-        self.chain.set_balance(
+        self.set_balance(
             ruint::aliases::B160::from_alloy(signer.address()),
             ruint::aliases::U256::from(1_000_000_000_000_000_u64),
         );
         signer
     }
 
-    pub fn run_block(
+    pub fn run_block<T: IntoEncodedTx>(
         &mut self,
-        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        transactions: Vec<T>,
         block_context: Option<BlockContext>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         run_config: Option<RunConfig>,
     ) -> BlockOutput {
-        self.chain.run_block(
+        let encoded_txs = transactions
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
+            .collect::<Vec<_>>();
+        self.chain
+            .run_block(encoded_txs, block_context, da_commitment_scheme, run_config)
+    }
+
+    pub fn execute_block_with<T: IntoEncodedTx>(
+        &mut self,
+        transactions: Vec<T>,
+        block_context: Option<BlockContext>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        run_config: Option<RunConfig>,
+    ) -> BlockOutput {
+        self.run_block(
             transactions,
             block_context,
             da_commitment_scheme,
@@ -200,22 +264,49 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         )
     }
 
-    pub fn simulate_encoded_block(
+    pub fn simulate_encoded_block<T: IntoEncodedTx>(
         &mut self,
-        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        transactions: Vec<T>,
         block_context: Option<BlockContext>,
     ) -> BlockOutput {
-        self.chain.simulate_block(transactions, block_context)
+        let encoded_txs = transactions
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
+            .collect::<Vec<_>>();
+        self.chain.simulate_block(encoded_txs, block_context)
     }
 
-    pub fn run_block_no_panic(
+    pub fn simulate_block_with<T: IntoEncodedTx>(
         &mut self,
-        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        transactions: Vec<T>,
+        block_context: Option<BlockContext>,
+    ) -> BlockOutput {
+        self.simulate_encoded_block(transactions, block_context)
+    }
+
+    pub fn run_block_no_panic<T: IntoEncodedTx>(
+        &mut self,
+        transactions: Vec<T>,
         block_context: Option<BlockContext>,
         da_commitment_scheme: Option<DACommitmentScheme>,
         run_config: Option<RunConfig>,
     ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
-        self.chain.run_block_no_panic(
+        let encoded_txs = transactions
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
+            .collect::<Vec<_>>();
+        self.chain
+            .run_block_no_panic(encoded_txs, block_context, da_commitment_scheme, run_config)
+    }
+
+    pub fn execute_block_no_panic_with<T: IntoEncodedTx>(
+        &mut self,
+        transactions: Vec<T>,
+        block_context: Option<BlockContext>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        run_config: Option<RunConfig>,
+    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
+        self.run_block_no_panic(
             transactions,
             block_context,
             da_commitment_scheme,
@@ -274,6 +365,37 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .chain
             .simulate_block(encoded_txs, self.block_context.clone());
         block_output
+    }
+
+    pub fn execute_block_no_panic(
+        &mut self,
+        transactions: Vec<ZKsyncTxEnvelope>,
+    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
+        let encoded_txs = transactions
+            .iter()
+            .map(|tx| tx.clone().encode())
+            .collect::<Vec<_>>();
+        self.chain.run_block_no_panic(
+            encoded_txs,
+            self.block_context.clone(),
+            self.da_commitment_scheme.clone(),
+            self.run_config.clone(),
+        )
+    }
+
+    pub fn assert_all_txs_succeded(&self, block_output: &BlockOutput) {
+        assert!(block_output
+            .tx_results
+            .iter()
+            .cloned()
+            .enumerate()
+            .all(|(i, r)| {
+                let success = r.clone().is_ok_and(|o| o.is_success());
+                if !success {
+                    println!("Transaction {i} failed with: {r:?}")
+                }
+                success
+            }));
     }
 }
 

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -11,6 +11,7 @@ pub mod testing_utils;
 pub mod utils;
 
 pub use alloy;
+use alloy::signers::local::PrivateKeySigner;
 pub use alloy_rlp;
 pub use alloy_sol_types;
 pub use basic_bootloader;
@@ -22,6 +23,7 @@ pub use chain::Chain;
 pub use cli_lib;
 pub use crypto;
 pub use forward_system;
+use forward_system::run::convert_alloy::FromAlloy;
 #[cfg(feature = "gpu")]
 pub use gpu_prover;
 pub use log;
@@ -31,10 +33,16 @@ pub use risc_v_simulator::sim::ProfilerConfig;
 pub use ruint;
 pub use system_hooks;
 pub use zk_ee;
+use zk_ee::common_structs::DACommitmentScheme;
 pub use zksync_os_api;
 pub use zksync_os_interface;
+use zksync_os_interface::types::BlockOutput;
 pub use zksync_os_tests_common;
+use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
+use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 pub use zksync_web3_rs;
+
+use crate::chain::RunConfig;
 
 static INIT_LOGGER_ONCE: Once = Once::new();
 pub fn init_logger() {
@@ -62,4 +70,225 @@ mod colors {
     pub const BRIGHT_MAGENTA: &str = "\x1b[95m";
     pub const BRIGHT_CYAN: &str = "\x1b[96m";
     pub const BRIGHT_WHITE: &str = "\x1b[97m";
+}
+
+pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
+    pub chain: Chain<RANDOMIZED_TREE>,
+    pub block_context: Option<BlockContext>,
+    pub da_commitment_scheme: Option<DACommitmentScheme>,
+    pub run_config: Option<RunConfig>,
+}
+
+impl ZKsyncOSTester<true> {
+    pub fn new() -> Self {
+        init_logger();
+
+        Self {
+            chain: Chain::empty_randomized(None),
+            block_context: None,
+            da_commitment_scheme: None,
+            run_config: None,
+        }
+    }
+}
+
+impl ZKsyncOSTester<false> {
+    pub fn new() -> Self {
+        init_logger();
+
+        Self {
+            chain: Chain::empty(None),
+            block_context: None,
+            da_commitment_scheme: None,
+            run_config: None,
+        }
+    }
+}
+
+impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
+    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain.set_chain_id(chain_id);
+        self
+    }
+
+    pub fn with_block_hashes(mut self, block_hashes: [ruint::aliases::U256; 256]) -> Self {
+        self.chain.set_block_hashes(block_hashes);
+        self
+    }
+
+    pub fn with_block_number(mut self, block_number: u64) -> Self {
+        self.chain.set_last_block_number(
+            block_number
+                .checked_sub(1)
+                .expect("block number should be > 0"),
+        );
+        self
+    }
+
+    pub fn with_block_context(mut self, block_context: BlockContext) -> Self {
+        self.block_context = Some(block_context);
+        self
+    }
+
+    pub fn with_da_commitment_scheme(mut self, da_commitment_scheme: DACommitmentScheme) -> Self {
+        self.da_commitment_scheme = Some(da_commitment_scheme);
+        self
+    }
+
+    pub fn with_run_config(mut self, run_config: RunConfig) -> Self {
+        self.run_config = Some(run_config);
+        self
+    }
+
+    pub fn with_balance(
+        mut self,
+        address: ruint::aliases::B160,
+        balance: ruint::aliases::U256,
+    ) -> Self {
+        self.chain.set_balance(address, balance);
+        self
+    }
+
+    pub fn with_evm_contract(mut self, address: ruint::aliases::B160, bytecode: &[u8]) -> Self {
+        self.chain.set_evm_bytecode(address, bytecode);
+        self
+    }
+
+    pub fn set_balance(
+        &mut self,
+        address: ruint::aliases::B160,
+        balance: ruint::aliases::U256,
+    ) -> &mut Self {
+        self.chain.set_balance(address, balance);
+        self
+    }
+
+    pub fn set_evm_bytecode(
+        &mut self,
+        address: ruint::aliases::B160,
+        bytecode: &[u8],
+    ) -> &mut Self {
+        self.chain.set_evm_bytecode(address, bytecode);
+        self
+    }
+
+    pub fn random_signer(&self) -> PrivateKeySigner {
+        self.chain.random_signer()
+    }
+
+    pub fn prefunded_random_signer(&mut self) -> PrivateKeySigner {
+        let signer = self.chain.random_signer();
+        self.chain.set_balance(
+            ruint::aliases::B160::from_alloy(signer.address()),
+            ruint::aliases::U256::from(1_000_000_000_000_000_u64),
+        );
+        signer
+    }
+
+    pub fn run_block(
+        &mut self,
+        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        block_context: Option<BlockContext>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        run_config: Option<RunConfig>,
+    ) -> BlockOutput {
+        self.chain.run_block(
+            transactions,
+            block_context,
+            da_commitment_scheme,
+            run_config,
+        )
+    }
+
+    pub fn simulate_encoded_block(
+        &mut self,
+        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        block_context: Option<BlockContext>,
+    ) -> BlockOutput {
+        self.chain.simulate_block(transactions, block_context)
+    }
+
+    pub fn run_block_no_panic(
+        &mut self,
+        transactions: Vec<zksync_os_interface::traits::EncodedTx>,
+        block_context: Option<BlockContext>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        run_config: Option<RunConfig>,
+    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
+        self.chain.run_block_no_panic(
+            transactions,
+            block_context,
+            da_commitment_scheme,
+            run_config,
+        )
+    }
+
+    pub fn mint_tokens_to_treasury(&mut self) {
+        self.chain.mint_tokens_to_treasury();
+    }
+
+    pub fn get_account_properties(
+        &mut self,
+        address: &ruint::aliases::B160,
+    ) -> basic_system::system_implementation::flat_storage_model::AccountProperties {
+        self.chain.get_account_properties(address)
+    }
+
+    pub fn run_block_of_erc20(
+        &mut self,
+        n: usize,
+        block_context: Option<BlockContext>,
+    ) -> BlockOutput {
+        crate::utils::run_block_of_erc20(&mut self.chain, n, block_context)
+    }
+
+    pub fn run_block_of_erc20_with_fee(
+        &mut self,
+        n: usize,
+        block_context: Option<BlockContext>,
+        fee: u128,
+    ) -> BlockOutput {
+        crate::utils::run_block_of_erc20_with_fee(&mut self.chain, n, block_context, fee)
+    }
+
+    pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
+        let encoded_txs = transactions
+            .iter()
+            .map(|tx| tx.clone().encode())
+            .collect::<Vec<_>>();
+        let block_output = self.chain.run_block(
+            encoded_txs,
+            self.block_context.clone(),
+            self.da_commitment_scheme.clone(),
+            self.run_config.clone(),
+        );
+        block_output
+    }
+
+    pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
+        let encoded_txs = transactions
+            .iter()
+            .map(|tx| tx.clone().encode())
+            .collect::<Vec<_>>();
+        let block_output = self
+            .chain
+            .simulate_block(encoded_txs, self.block_context.clone());
+        block_output
+    }
+}
+
+impl ZKsyncOSTester<false> {
+    pub fn install_system_contracts(
+        &mut self,
+        with_l1_messenger: bool,
+        with_l2_base_token: bool,
+        with_contract_deployer: bool,
+    ) {
+        crate::testing_utils::install_system_contracts(
+            &mut self.chain,
+            with_l1_messenger,
+            with_l2_base_token,
+            with_contract_deployer,
+        );
+    }
 }

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -470,18 +470,10 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     }
 
     pub fn assert_all_txs_succeeded(&self, block_output: &BlockOutput) {
-        assert!(block_output
-            .tx_results
-            .iter()
-            .cloned()
-            .enumerate()
-            .all(|(i, r)| {
-                let success = r.clone().is_ok_and(|o| o.is_success());
-                if !success {
-                    println!("Transaction {i} failed with: {r:?}")
-                }
-                success
-            }));
+        for (i, result) in block_output.tx_results.iter().enumerate() {
+            let success = result.as_ref().is_ok_and(|o| o.is_success());
+            assert!(success, "Transaction {i} failed with: {result:?}");
+        }
     }
 }
 

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -97,6 +97,7 @@ pub struct TestingFramework<const RANDOMIZED_TREE: bool = false> {
 }
 
 impl TestingFramework<true> {
+    /// Creates a framework instance backed by a randomized in-memory tree.
     pub fn new_with_randomized_tree() -> Self {
         init_logger();
 
@@ -118,6 +119,7 @@ impl Default for TestingFramework<false> {
 }
 
 impl TestingFramework<false> {
+    /// Creates a framework instance backed by the default in-memory tree.
     pub fn new() -> Self {
         init_logger();
 
@@ -133,17 +135,20 @@ impl TestingFramework<false> {
 }
 
 impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
+    /// Builder: sets the chain ID used for block metadata and transaction signing.
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain.set_chain_id(chain_id);
         self
     }
 
+    /// Builder: sets the 256 previous block hashes exposed to execution.
     pub fn with_block_hashes(mut self, block_hashes: [ruint::aliases::U256; 256]) -> Self {
         self.chain.set_block_hashes(block_hashes);
         self
     }
 
-    pub fn with_block_number(mut self, block_number: u64) -> Self {
+    /// Builder: sets the next block number to execute.
+    pub fn with_next_block_number(mut self, block_number: u64) -> Self {
         self.chain.set_last_block_number(
             block_number
                 .checked_sub(1)
@@ -152,27 +157,33 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: sets default block context used by subsequent block execution.
     pub fn with_block_context(mut self, block_context: BlockContext) -> Self {
         self.block_context = Some(block_context);
         self
     }
 
+    /// Setter: replaces the default block context for subsequent block execution.
     pub fn set_block_context(&mut self, block_context: Option<BlockContext>) -> &mut Self {
         self.block_context = block_context;
         self
     }
 
+    /// Builder: sets the DA commitment scheme used for block execution.
     pub fn with_da_commitment_scheme(mut self, da_commitment_scheme: DACommitmentScheme) -> Self {
         self.da_commitment_scheme = Some(da_commitment_scheme);
         self
     }
 
+    /// Builder: sets run-level configuration for forward/proving execution.
     pub fn with_run_config(mut self, run_config: RunConfig) -> Self {
         self.run_config = Some(run_config);
         self
     }
 
-    pub fn with_oracle_factory(
+    /// Builder: installs a custom oracle factory for forward/proof runs.
+    /// Can be used for testing cases with corrupted or malicious oracles
+    pub fn with_custom_oracle_factory(
         mut self,
         oracle_factory: impl TestingOracleFactory<RANDOMIZED_TREE> + 'static,
     ) -> Self {
@@ -180,6 +191,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: installs selected system contracts into the in-memory chain state.
     pub fn with_system_contracts(
         mut self,
         with_l1_messenger: bool,
@@ -195,6 +207,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: sets account balance for the provided address.
     pub fn with_balance(
         mut self,
         address: alloy::primitives::Address,
@@ -204,6 +217,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: funds account with a fixed default testing balance.
     pub fn with_prefunded_account(mut self, address: alloy::primitives::Address) -> Self {
         self.set_balance(
             address,
@@ -212,6 +226,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: deploys EVM bytecode on the given address.
     pub fn with_evm_contract(
         mut self,
         address: alloy::primitives::Address,
@@ -221,6 +236,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: writes a storage slot value for the given account.
     pub fn with_storage_slot(
         mut self,
         address: alloy::primitives::Address,
@@ -231,22 +247,27 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Builder: injects a preimage value under the provided hash key.
     pub fn with_preimage(mut self, key: zk_ee::utils::Bytes32, value: &[u8]) -> Self {
         self.set_preimage(key, value);
         self
     }
 
+    /// Builder: mints base tokens to the protocol treasury account.
     pub fn with_minted_tokens_to_treasury(mut self) -> Self {
         self.mint_tokens_to_treasury();
         self
     }
 
+    /// Setter: updates run configuration for subsequent block execution.
     pub fn set_run_config(&mut self, run_config: Option<RunConfig>) -> &mut Self {
         self.run_config = run_config;
         self
     }
 
-    pub fn set_oracle_factory(
+    /// Setter: updates custom oracle factory used for subsequent block execution.
+    /// Can be used for testing cases with corrupted or malicious oracles
+    pub fn set_custom_oracle_factory(
         &mut self,
         oracle_factory: Option<Box<dyn TestingOracleFactory<RANDOMIZED_TREE>>>,
     ) -> &mut Self {
@@ -254,6 +275,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Setter: sets account balance in chain state.
     pub fn set_balance(
         &mut self,
         address: alloy::primitives::Address,
@@ -264,6 +286,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Setter: deploys EVM bytecode at the provided address.
     pub fn set_evm_contract(
         &mut self,
         address: alloy::primitives::Address,
@@ -274,6 +297,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Setter: writes a raw storage slot for the provided account.
     pub fn set_storage_slot(
         &mut self,
         address: alloy::primitives::Address,
@@ -285,15 +309,18 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self
     }
 
+    /// Setter: stores a preimage entry under the provided hash key.
     pub fn set_preimage(&mut self, key: zk_ee::utils::Bytes32, value: &[u8]) -> &mut Self {
         self.chain.set_preimage(key, value);
         self
     }
 
+    /// Returns a random signer configured for the active chain ID.
     pub fn random_signer(&self) -> PrivateKeySigner {
         self.chain.random_signer()
     }
 
+    /// Returns a random signer and prefunds it with the default testing balance.
     pub fn prefunded_random_signer(&mut self) -> PrivateKeySigner {
         let signer = self.random_signer();
         self.set_balance(
@@ -303,10 +330,12 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         signer
     }
 
+    /// Mints base tokens to the protocol treasury account.
     pub fn mint_tokens_to_treasury(&mut self) {
         self.chain.mint_tokens_to_treasury();
     }
 
+    /// Returns decoded account properties for the provided address.
     pub fn get_account_properties(
         &mut self,
         address: &alloy::primitives::Address,
@@ -315,16 +344,19 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
             .get_account_properties(&ruint::aliases::B160::from_alloy(address))
     }
 
+    /// Returns native token balance for the provided address.
     pub fn get_balance(&mut self, address: &alloy::primitives::Address) -> ruint::aliases::U256 {
         self.chain
             .get_account_properties(&ruint::aliases::B160::from_alloy(address))
             .balance
     }
 
+    /// Returns execution metadata of the most recently executed block, if any.
     pub fn last_executed_block_info(&self) -> Option<&LastExecutedBlockInfo> {
         self.last_executed_block_info.as_ref()
     }
 
+    /// Builds and executes an ERC20 transfer block using default fee settings.
     pub fn run_block_of_erc20(
         &mut self,
         n: usize,
@@ -333,6 +365,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         self.run_block_of_erc20_with_fee(n, block_context, 1000)
     }
 
+    /// Builds and executes an ERC20 transfer block with an explicit max fee.
     pub fn run_block_of_erc20_with_fee(
         &mut self,
         n: usize,
@@ -351,6 +384,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         output
     }
 
+    /// Executes a block using no-op tracer and validator.
     pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
         self.execute_block_with_tracing(
             transactions,
@@ -359,6 +393,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         )
     }
 
+    /// Executes a block with custom tracer and validator hooks.
     pub fn execute_block_with_tracing(
         &mut self,
         transactions: Vec<ZKsyncTxEnvelope>,
@@ -369,31 +404,32 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
             .into_iter()
             .map(ZKsyncTxEnvelope::encode)
             .collect::<Vec<_>>();
-        let (block_output, block_extra_stats, proof_input) =
-            if let Some(oracle_factory) = &self.oracle_factory {
-                self.chain
-                    .run_block_with_extra_stats_with_oracle_factory(
-                        encoded_txs,
-                        self.block_context.clone(),
-                        self.da_commitment_scheme,
-                        self.run_config.clone(),
-                        tracer,
-                        validator,
-                        oracle_factory.as_ref(),
-                    )
-                    .unwrap_or_else(|err| panic!("block execution failed with custom oracle: {err:?}"))
-            } else {
-                self.chain
-                    .run_block_with_extra_stats(
-                        encoded_txs,
-                        self.block_context.clone(),
-                        self.da_commitment_scheme,
-                        self.run_config.clone(),
-                        tracer,
-                        validator,
-                    )
-                    .unwrap_or_else(|err| panic!("block execution failed: {err:?}"))
-            };
+        let (block_output, block_extra_stats, proof_input) = if let Some(oracle_factory) =
+            &self.oracle_factory
+        {
+            self.chain
+                .run_block_with_extra_stats_with_oracle_factory(
+                    encoded_txs,
+                    self.block_context.clone(),
+                    self.da_commitment_scheme,
+                    self.run_config.clone(),
+                    tracer,
+                    validator,
+                    oracle_factory.as_ref(),
+                )
+                .unwrap_or_else(|err| panic!("block execution failed with custom oracle: {err:?}"))
+        } else {
+            self.chain
+                .run_block_with_extra_stats(
+                    encoded_txs,
+                    self.block_context.clone(),
+                    self.da_commitment_scheme,
+                    self.run_config.clone(),
+                    tracer,
+                    validator,
+                )
+                .unwrap_or_else(|err| panic!("block execution failed: {err:?}"))
+        };
 
         self.last_executed_block_info = Some(LastExecutedBlockInfo {
             block_output: block_output.clone(),
@@ -419,6 +455,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     }
 
     #[allow(clippy::result_large_err)]
+    /// Executes a block and returns a typed error instead of panicking.
     pub fn execute_block_no_panic(
         &mut self,
         transactions: Vec<ZKsyncTxEnvelope>,
@@ -458,6 +495,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         })
     }
 
+    /// Asserts that every transaction in block output completed successfully.
     pub fn assert_all_txs_succeeded(&self, block_output: &BlockOutput) {
         for (i, result) in block_output.tx_results.iter().enumerate() {
             let success = result.as_ref().is_ok_and(|o| o.is_success());

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -58,22 +58,6 @@ pub fn init_logger() {
     INIT_LOGGER_ONCE.call_once(env_logger::init);
 }
 
-pub trait IntoEncodedTx {
-    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx;
-}
-
-impl IntoEncodedTx for zksync_os_interface::traits::EncodedTx {
-    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx {
-        self
-    }
-}
-
-impl IntoEncodedTx for ZKsyncTxEnvelope {
-    fn into_encoded_tx(self) -> zksync_os_interface::traits::EncodedTx {
-        self.encode()
-    }
-}
-
 #[allow(dead_code)]
 mod colors {
     pub const RESET: &str = "\x1b[0m";
@@ -383,7 +367,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     ) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
+            .map(ZKsyncTxEnvelope::encode)
             .collect::<Vec<_>>();
         let (block_output, block_extra_stats, proof_input) =
             if let Some(oracle_factory) = &self.oracle_factory {
@@ -423,7 +407,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
         let encoded_txs = transactions
             .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
+            .map(ZKsyncTxEnvelope::encode)
             .collect::<Vec<_>>();
         self.chain
             .simulate_block(encoded_txs, self.block_context.clone())
@@ -436,7 +420,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
     ) -> Result<BlockOutput, BootloaderSubsystemError> {
         let encoded_txs = transactions
             .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
+            .map(ZKsyncTxEnvelope::encode)
             .collect::<Vec<_>>();
         let block_execution_result = if let Some(oracle_factory) = &self.oracle_factory {
             self.chain.run_block_with_extra_stats_with_oracle_factory(

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -5,12 +5,14 @@
 //! It contains `Chain` - in memory chain state structure with methods to run blocks, change state
 //! and few utility methods(in the `utils` module) to encode transactions, load contracts, etc.
 //!
+use std::str::FromStr;
 use std::sync::Once;
 pub mod chain;
 pub mod testing_utils;
 pub mod utils;
 
 pub use alloy;
+use alloy::primitives::address;
 use alloy::signers::local::PrivateKeySigner;
 pub use alloy_rlp;
 pub use alloy_sol_types;
@@ -219,6 +221,16 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
+    pub fn with_preimage(mut self, key: zk_ee::utils::Bytes32, value: &[u8]) -> Self {
+        self.set_preimage(key, value);
+        self
+    }
+
+    pub fn with_minted_tokens_to_treasury(mut self) -> Self {
+        self.mint_tokens_to_treasury();
+        self
+    }
+
     pub fn set_run_config(&mut self, run_config: Option<RunConfig>) -> &mut Self {
         self.run_config = run_config;
         self
@@ -252,6 +264,11 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     ) -> &mut Self {
         self.chain
             .set_storage_slot(ruint::aliases::B160::from_alloy(address), key, value);
+        self
+    }
+
+    pub fn set_preimage(&mut self, key: zk_ee::utils::Bytes32, value: &[u8]) -> &mut Self {
+        self.chain.set_preimage(key, value);
         self
     }
 
@@ -355,4 +372,24 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
                 success
             }));
     }
+}
+
+pub fn tx_succeeded(output: &BlockOutput, idx: usize) -> bool {
+    output.tx_results[idx]
+        .as_ref()
+        .ok()
+        .map(|o| o.is_success())
+        .unwrap_or(false)
+}
+
+pub fn tx_failed(output: &BlockOutput, idx: usize) -> bool {
+    !tx_succeeded(output, idx)
+}
+
+pub fn signer_from_key(key: &str) -> PrivateKeySigner {
+    PrivateKeySigner::from_str(key).unwrap()
+}
+
+pub fn common_target_address() -> alloy::primitives::Address {
+    address!("4242000000000000000000000000000000000000")
 }

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -50,6 +50,7 @@ use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 pub use zksync_web3_rs;
 
+use crate::chain::TestingOracleFactory;
 use crate::chain::{BlockExtraStats, RunConfig};
 
 static INIT_LOGGER_ONCE: Once = Once::new();
@@ -108,6 +109,7 @@ pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
     da_commitment_scheme: Option<DACommitmentScheme>,
     run_config: Option<RunConfig>,
     last_executed_block_info: Option<LastExecutedBlockInfo>,
+    oracle_factory: Option<Box<dyn TestingOracleFactory<RANDOMIZED_TREE>>>,
 }
 
 impl ZKsyncOSTester<true> {
@@ -120,6 +122,7 @@ impl ZKsyncOSTester<true> {
             da_commitment_scheme: None,
             run_config: None,
             last_executed_block_info: None,
+            oracle_factory: None,
         }
     }
 }
@@ -140,6 +143,7 @@ impl ZKsyncOSTester<false> {
             da_commitment_scheme: None,
             run_config: None,
             last_executed_block_info: None,
+            oracle_factory: None,
         }
     }
 }
@@ -181,6 +185,14 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn with_run_config(mut self, run_config: RunConfig) -> Self {
         self.run_config = Some(run_config);
+        self
+    }
+
+    pub fn with_oracle_factory(
+        mut self,
+        oracle_factory: impl TestingOracleFactory<RANDOMIZED_TREE> + 'static,
+    ) -> Self {
+        self.oracle_factory = Some(Box::new(oracle_factory));
         self
     }
 
@@ -247,6 +259,14 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn set_run_config(&mut self, run_config: Option<RunConfig>) -> &mut Self {
         self.run_config = run_config;
+        self
+    }
+
+    pub fn set_oracle_factory(
+        &mut self,
+        oracle_factory: Option<Box<dyn TestingOracleFactory<RANDOMIZED_TREE>>>,
+    ) -> &mut Self {
+        self.oracle_factory = oracle_factory;
         self
     }
 
@@ -356,17 +376,31 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
-        let (block_output, block_extra_stats, proof_input) = self
-            .chain
-            .run_block_with_extra_stats(
-                encoded_txs,
-                self.block_context.clone(),
-                self.da_commitment_scheme,
-                self.run_config.clone(),
-                tracer,
-                validator,
-            )
-            .unwrap();
+        let (block_output, block_extra_stats, proof_input) =
+            if let Some(oracle_factory) = &self.oracle_factory {
+                self.chain
+                    .run_block_with_extra_stats_with_oracle_factory(
+                        encoded_txs,
+                        self.block_context.clone(),
+                        self.da_commitment_scheme,
+                        self.run_config.clone(),
+                        tracer,
+                        validator,
+                        oracle_factory.as_ref(),
+                    )
+                    .unwrap()
+            } else {
+                self.chain
+                    .run_block_with_extra_stats(
+                        encoded_txs,
+                        self.block_context.clone(),
+                        self.da_commitment_scheme,
+                        self.run_config.clone(),
+                        tracer,
+                        validator,
+                    )
+                    .unwrap()
+            };
 
         self.last_executed_block_info = Some(LastExecutedBlockInfo {
             block_output: block_output.clone(),

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -397,7 +397,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
                         validator,
                         oracle_factory.as_ref(),
                     )
-                    .unwrap()
+                    .unwrap_or_else(|err| panic!("block execution failed with custom oracle: {err:?}"))
             } else {
                 self.chain
                     .run_block_with_extra_stats(
@@ -408,7 +408,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
                         tracer,
                         validator,
                     )
-                    .unwrap()
+                    .unwrap_or_else(|err| panic!("block execution failed: {err:?}"))
             };
 
         self.last_executed_block_info = Some(LastExecutedBlockInfo {

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -194,7 +194,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     }
 
     pub fn with_evm_contract(mut self, address: ruint::aliases::B160, bytecode: &[u8]) -> Self {
-        self.set_evm_bytecode(address, bytecode);
+        self.set_evm_contract(address, bytecode);
         self
     }
 
@@ -212,7 +212,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
-    pub fn set_evm_bytecode(
+    pub fn set_evm_contract(
         &mut self,
         address: ruint::aliases::B160,
         bytecode: &[u8],
@@ -342,38 +342,35 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         crate::utils::run_block_of_erc20_with_fee(&mut self.chain, n, block_context, fee)
     }
 
-    pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
+    pub fn execute_block<T: IntoEncodedTx>(&mut self, transactions: Vec<T>) -> BlockOutput {
         let encoded_txs = transactions
-            .iter()
-            .map(|tx| tx.clone().encode())
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
-        let block_output = self.chain.run_block(
+        self.chain.run_block(
             encoded_txs,
             self.block_context.clone(),
             self.da_commitment_scheme.clone(),
             self.run_config.clone(),
-        );
-        block_output
+        )
     }
 
-    pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {
+    pub fn simulate_block<T: IntoEncodedTx>(&mut self, transactions: Vec<T>) -> BlockOutput {
         let encoded_txs = transactions
-            .iter()
-            .map(|tx| tx.clone().encode())
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
-        let block_output = self
-            .chain
-            .simulate_block(encoded_txs, self.block_context.clone());
-        block_output
+        self.chain
+            .simulate_block(encoded_txs, self.block_context.clone())
     }
 
-    pub fn execute_block_no_panic(
+    pub fn execute_block_no_panic<T: IntoEncodedTx>(
         &mut self,
-        transactions: Vec<ZKsyncTxEnvelope>,
+        transactions: Vec<T>,
     ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
         let encoded_txs = transactions
-            .iter()
-            .map(|tx| tx.clone().encode())
+            .into_iter()
+            .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
         self.chain.run_block_no_panic(
             encoded_txs,

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -429,12 +429,35 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
-        self.chain.run_block_no_panic(
-            encoded_txs,
-            self.block_context.clone(),
-            self.da_commitment_scheme,
-            self.run_config.clone(),
-        )
+        let block_execution_result = if let Some(oracle_factory) = &self.oracle_factory {
+            self.chain.run_block_with_extra_stats_with_oracle_factory(
+                encoded_txs,
+                self.block_context.clone(),
+                self.da_commitment_scheme,
+                self.run_config.clone(),
+                &mut NopTracer::default(),
+                &mut NopTxValidator,
+                oracle_factory.as_ref(),
+            )
+        } else {
+            self.chain.run_block_with_extra_stats(
+                encoded_txs,
+                self.block_context.clone(),
+                self.da_commitment_scheme,
+                self.run_config.clone(),
+                &mut NopTracer::default(),
+                &mut NopTxValidator,
+            )
+        };
+
+        block_execution_result.map(|(block_output, block_extra_stats, proof_input)| {
+            self.last_executed_block_info = Some(LastExecutedBlockInfo {
+                block_output: block_output.clone(),
+                block_extra_stats,
+                proof_input,
+            });
+            block_output
+        })
     }
 
     pub fn assert_all_txs_succeeded(&self, block_output: &BlockOutput) {

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -420,6 +420,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .simulate_block(encoded_txs, self.block_context.clone())
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn execute_block_no_panic(
         &mut self,
         transactions: Vec<ZKsyncTxEnvelope>,

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -37,6 +37,8 @@ pub use ruint;
 pub use system_hooks;
 pub use zk_ee;
 use zk_ee::common_structs::DACommitmentScheme;
+use zk_ee::system::tracer::NopTracer;
+use zk_ee::system::validator::NopTxValidator;
 pub use zksync_os_api;
 pub use zksync_os_interface;
 use zksync_os_interface::types::BlockOutput;
@@ -45,7 +47,7 @@ use zksync_os_tests_common::zksync_tx::encoding::ZKsyncOsEncodable;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 pub use zksync_web3_rs;
 
-use crate::chain::RunConfig;
+use crate::chain::{BlockExtraStats, RunConfig};
 
 static INIT_LOGGER_ONCE: Once = Once::new();
 pub fn init_logger() {
@@ -91,11 +93,18 @@ mod colors {
     pub const BRIGHT_WHITE: &str = "\x1b[97m";
 }
 
+pub struct LastExecutedBlockInfo {
+    pub block_output: BlockOutput,
+    pub block_extra_stats: BlockExtraStats,
+    pub proof_input: Vec<u32>,
+}
+
 pub struct ZKsyncOSTester<const RANDOMIZED_TREE: bool = false> {
     chain: Chain<RANDOMIZED_TREE>,
     block_context: Option<BlockContext>,
     da_commitment_scheme: Option<DACommitmentScheme>,
     run_config: Option<RunConfig>,
+    last_executed_block_info: Option<LastExecutedBlockInfo>,
 }
 
 impl ZKsyncOSTester<true> {
@@ -107,6 +116,7 @@ impl ZKsyncOSTester<true> {
             block_context: None,
             da_commitment_scheme: None,
             run_config: None,
+            last_executed_block_info: None,
         }
     }
 }
@@ -126,6 +136,7 @@ impl ZKsyncOSTester<false> {
             block_context: None,
             da_commitment_scheme: None,
             run_config: None,
+            last_executed_block_info: None,
         }
     }
 }
@@ -303,6 +314,10 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .balance
     }
 
+    pub fn last_executed_block_info(&self) -> Option<&LastExecutedBlockInfo> {
+        self.last_executed_block_info.as_ref()
+    }
+
     pub fn run_block_of_erc20(
         &mut self,
         n: usize,
@@ -325,12 +340,25 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
             .into_iter()
             .map(IntoEncodedTx::into_encoded_tx)
             .collect::<Vec<_>>();
-        self.chain.run_block(
-            encoded_txs,
-            self.block_context.clone(),
-            self.da_commitment_scheme,
-            self.run_config.clone(),
-        )
+        let (block_output, block_extra_stats, proof_input) = self
+            .chain
+            .run_block_with_extra_stats(
+                encoded_txs,
+                self.block_context.clone(),
+                self.da_commitment_scheme,
+                self.run_config.clone(),
+                &mut NopTracer::default(),
+                &mut NopTxValidator::default(),
+            )
+            .unwrap();
+
+        self.last_executed_block_info = Some(LastExecutedBlockInfo {
+            block_output: block_output.clone(),
+            block_extra_stats,
+            proof_input,
+        });
+
+        block_output
     }
 
     pub fn simulate_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -346,7 +346,7 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         n: usize,
         block_context: Option<BlockContext>,
     ) -> BlockOutput {
-        crate::utils::run_block_of_erc20(&mut self.chain, n, block_context)
+        self.run_block_of_erc20_with_fee(n, block_context, 1000)
     }
 
     pub fn run_block_of_erc20_with_fee(
@@ -355,7 +355,16 @@ impl<const RANDOMIZED_TREE: bool> TestingFramework<RANDOMIZED_TREE> {
         block_context: Option<BlockContext>,
         fee: u128,
     ) -> BlockOutput {
-        crate::utils::run_block_of_erc20_with_fee(&mut self.chain, n, block_context, fee)
+        let transactions = crate::utils::prepare_block_of_erc20_with_fee(&mut self.chain, n, fee);
+        let previous_block_context = self.block_context.clone();
+        if let Some(block_context) = block_context {
+            self.block_context = Some(block_context);
+        }
+
+        let output = self.execute_block(transactions);
+        self.block_context = previous_block_context;
+        self.assert_all_txs_succeeded(&output);
+        output
     }
 
     pub fn execute_block(&mut self, transactions: Vec<ZKsyncTxEnvelope>) -> BlockOutput {

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -178,14 +178,14 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn with_balance(
         mut self,
-        address: ruint::aliases::B160,
+        address: alloy::primitives::Address,
         balance: ruint::aliases::U256,
     ) -> Self {
         self.set_balance(address, balance);
         self
     }
 
-    pub fn with_prefunded_account(mut self, address: ruint::aliases::B160) -> Self {
+    pub fn with_prefunded_account(mut self, address: alloy::primitives::Address) -> Self {
         self.set_balance(
             address,
             ruint::aliases::U256::from(1_000_000_000_000_000_u64),
@@ -193,7 +193,11 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         self
     }
 
-    pub fn with_evm_contract(mut self, address: ruint::aliases::B160, bytecode: &[u8]) -> Self {
+    pub fn with_evm_contract(
+        mut self,
+        address: alloy::primitives::Address,
+        bytecode: &[u8],
+    ) -> Self {
         self.set_evm_contract(address, bytecode);
         self
     }
@@ -205,19 +209,21 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn set_balance(
         &mut self,
-        address: ruint::aliases::B160,
+        address: alloy::primitives::Address,
         balance: ruint::aliases::U256,
     ) -> &mut Self {
-        self.chain.set_balance(address, balance);
+        self.chain
+            .set_balance(ruint::aliases::B160::from_alloy(address), balance);
         self
     }
 
     pub fn set_evm_contract(
         &mut self,
-        address: ruint::aliases::B160,
+        address: alloy::primitives::Address,
         bytecode: &[u8],
     ) -> &mut Self {
-        self.chain.set_evm_bytecode(address, bytecode);
+        self.chain
+            .set_evm_bytecode(ruint::aliases::B160::from_alloy(address), bytecode);
         self
     }
 
@@ -228,7 +234,7 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     pub fn prefunded_random_signer(&mut self) -> PrivateKeySigner {
         let signer = self.random_signer();
         self.set_balance(
-            ruint::aliases::B160::from_alloy(signer.address()),
+            signer.address(),
             ruint::aliases::U256::from(1_000_000_000_000_000_u64),
         );
         signer
@@ -240,13 +246,16 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
 
     pub fn get_account_properties(
         &mut self,
-        address: &ruint::aliases::B160,
+        address: &alloy::primitives::Address,
     ) -> basic_system::system_implementation::flat_storage_model::AccountProperties {
-        self.chain.get_account_properties(address)
+        self.chain
+            .get_account_properties(&ruint::aliases::B160::from_alloy(address))
     }
 
-    pub fn get_balance(&mut self, address: &ruint::aliases::B160) -> ruint::aliases::U256 {
-        self.chain.get_account_properties(address).balance
+    pub fn get_balance(&mut self, address: &alloy::primitives::Address) -> ruint::aliases::U256 {
+        self.chain
+            .get_account_properties(&ruint::aliases::B160::from_alloy(address))
+            .balance
     }
 
     pub fn run_block_of_erc20(

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -226,92 +226,12 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
     }
 
     pub fn prefunded_random_signer(&mut self) -> PrivateKeySigner {
-        let signer = self.chain.random_signer();
+        let signer = self.random_signer();
         self.set_balance(
             ruint::aliases::B160::from_alloy(signer.address()),
             ruint::aliases::U256::from(1_000_000_000_000_000_u64),
         );
         signer
-    }
-
-    pub fn run_block<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-        da_commitment_scheme: Option<DACommitmentScheme>,
-        run_config: Option<RunConfig>,
-    ) -> BlockOutput {
-        let encoded_txs = transactions
-            .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
-            .collect::<Vec<_>>();
-        self.chain
-            .run_block(encoded_txs, block_context, da_commitment_scheme, run_config)
-    }
-
-    pub fn execute_block_with<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-        da_commitment_scheme: Option<DACommitmentScheme>,
-        run_config: Option<RunConfig>,
-    ) -> BlockOutput {
-        self.run_block(
-            transactions,
-            block_context,
-            da_commitment_scheme,
-            run_config,
-        )
-    }
-
-    pub fn simulate_encoded_block<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-    ) -> BlockOutput {
-        let encoded_txs = transactions
-            .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
-            .collect::<Vec<_>>();
-        self.chain.simulate_block(encoded_txs, block_context)
-    }
-
-    pub fn simulate_block_with<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-    ) -> BlockOutput {
-        self.simulate_encoded_block(transactions, block_context)
-    }
-
-    pub fn run_block_no_panic<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-        da_commitment_scheme: Option<DACommitmentScheme>,
-        run_config: Option<RunConfig>,
-    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
-        let encoded_txs = transactions
-            .into_iter()
-            .map(IntoEncodedTx::into_encoded_tx)
-            .collect::<Vec<_>>();
-        self.chain
-            .run_block_no_panic(encoded_txs, block_context, da_commitment_scheme, run_config)
-    }
-
-    pub fn execute_block_no_panic_with<T: IntoEncodedTx>(
-        &mut self,
-        transactions: Vec<T>,
-        block_context: Option<BlockContext>,
-        da_commitment_scheme: Option<DACommitmentScheme>,
-        run_config: Option<RunConfig>,
-    ) -> Result<BlockOutput, basic_bootloader::bootloader::errors::BootloaderSubsystemError> {
-        self.run_block_no_panic(
-            transactions,
-            block_context,
-            da_commitment_scheme,
-            run_config,
-        )
     }
 
     pub fn mint_tokens_to_treasury(&mut self) {
@@ -323,6 +243,10 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
         address: &ruint::aliases::B160,
     ) -> basic_system::system_implementation::flat_storage_model::AccountProperties {
         self.chain.get_account_properties(address)
+    }
+
+    pub fn get_balance(&mut self, address: &ruint::aliases::B160) -> ruint::aliases::U256 {
+        self.chain.get_account_properties(address).balance
     }
 
     pub fn run_block_of_erc20(
@@ -393,21 +317,5 @@ impl<const RANDOMIZED_TREE: bool> ZKsyncOSTester<RANDOMIZED_TREE> {
                 }
                 success
             }));
-    }
-}
-
-impl ZKsyncOSTester<false> {
-    pub fn install_system_contracts(
-        &mut self,
-        with_l1_messenger: bool,
-        with_l2_base_token: bool,
-        with_contract_deployer: bool,
-    ) {
-        crate::testing_utils::install_system_contracts(
-            &mut self.chain,
-            with_l1_messenger,
-            with_l2_base_token,
-            with_contract_deployer,
-        );
     }
 }

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -393,3 +393,13 @@ pub fn signer_from_key(key: &str) -> PrivateKeySigner {
 pub fn common_target_address() -> alloy::primitives::Address {
     address!("4242000000000000000000000000000000000000")
 }
+
+pub fn default_run_config() -> RunConfig {
+    RunConfig {
+        app: Some("for_tests".to_string()),
+        only_forward: false,
+        check_storage_diff_hashes: true,
+        skip_minting_tokens_to_treasury: false,
+        ..Default::default()
+    }
+}

--- a/tests/rig/src/testing_utils.rs
+++ b/tests/rig/src/testing_utils.rs
@@ -110,8 +110,8 @@ pub fn call_address_and_measure_gas_cost(
 
 /// Installation of system contracts required by tests.
 /// Use booleans to keep it flexible per test.
-pub fn install_system_contracts(
-    chain: &mut Chain,
+pub fn install_system_contracts<const RANDOMIZED_TREE: bool>(
+    chain: &mut Chain<RANDOMIZED_TREE>,
     with_l1_messenger: bool,
     with_l2_base_token: bool,
     with_contract_deployer: bool,

--- a/tests/rig/src/testing_utils.rs
+++ b/tests/rig/src/testing_utils.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::Address;
+use alloy::{hex, primitives::Address};
 use forward_system::run::convert_alloy::FromAlloy;
 use forward_system::system::tracers::call_tracer::CallTracer;
 use once_cell::sync::Lazy;

--- a/tests/rig/src/utils/mod.rs
+++ b/tests/rig/src/utils/mod.rs
@@ -110,12 +110,18 @@ pub fn run_block_of_erc20<const RANDOMIZED: bool>(
     run_block_of_erc20_with_fee(chain, n, block_context, 1000)
 }
 
-pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
+pub fn prepare_block_of_erc20<const RANDOMIZED: bool>(
     chain: &mut Chain<RANDOMIZED>,
     n: usize,
-    block_context: Option<BlockContext>,
+) -> Vec<ZKsyncTxEnvelope> {
+    prepare_block_of_erc20_with_fee(chain, n, 1000)
+}
+
+pub fn prepare_block_of_erc20_with_fee<const RANDOMIZED: bool>(
+    chain: &mut Chain<RANDOMIZED>,
+    n: usize,
     fee: u128,
-) -> BlockOutput {
+) -> Vec<ZKsyncTxEnvelope> {
     let wallets: Vec<_> = (1..=n).map(|_| PrivateKeySigner::random()).collect();
     let dsts: Vec<_> = (1..=n)
         .map(|i| {
@@ -144,7 +150,7 @@ pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
                 access_list: Default::default(),
                 input: hex::decode(ERC_20_TRANSFER_CALLDATA).unwrap().into(),
             };
-            ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone()).encode()
+            ZKsyncTxEnvelope::from_eth_tx(transfer_tx, wallet.clone())
         })
         .collect();
 
@@ -154,7 +160,7 @@ pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
         chain.set_evm_bytecode(ruint::aliases::B160::from_alloy(to), &bytecode);
     });
 
-    wallets.iter().zip(dsts.clone()).for_each(|(wallet, to)| {
+    wallets.iter().zip(dsts).for_each(|(wallet, to)| {
         chain.set_balance(
             ruint::aliases::B160::from_alloy(wallet.address()),
             ruint::aliases::U256::from(1_000_000_000_000_000_u64),
@@ -164,6 +170,20 @@ pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
             ruint::aliases::B256::from(ruint::aliases::U256::from(1_000_000_000_000_000_u64));
         chain.set_storage_slot(ruint::aliases::B160::from_alloy(to), key, value)
     });
+
+    transactions
+}
+
+pub fn run_block_of_erc20_with_fee<const RANDOMIZED: bool>(
+    chain: &mut Chain<RANDOMIZED>,
+    n: usize,
+    block_context: Option<BlockContext>,
+    fee: u128,
+) -> BlockOutput {
+    let transactions = prepare_block_of_erc20_with_fee(chain, n, fee)
+        .into_iter()
+        .map(ZKsyncTxEnvelope::encode)
+        .collect();
 
     let output = chain.run_block(
         transactions,

--- a/tests/rig/src/utils/mod.rs
+++ b/tests/rig/src/utils/mod.rs
@@ -7,6 +7,7 @@ use crate::Chain;
 use alloy::consensus::SidecarBuilder;
 use alloy::consensus::SimpleCoder;
 use alloy::consensus::TxEip1559;
+use alloy::hex;
 use alloy::primitives::TxKind;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::sol;

--- a/zk_ee/src/oracle/usize_serialization/tests.rs
+++ b/zk_ee/src/oracle/usize_serialization/tests.rs
@@ -13,7 +13,7 @@ fn test_unit_serialization() {
 
     // Test deserialization
     let mut empty_iter = core::iter::empty();
-    let deserialized = <() as UsizeDeserializable>::from_iter(&mut empty_iter).unwrap();
+    let _ = <() as UsizeDeserializable>::from_iter(&mut empty_iter).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## What ❔

Additional layer of abstraction between tests and `Chain`. This is an intermediate step - in following PRs I will better separate concerns between `Chain` and `TestingFramework`. Additionally this separation will make RevmRunner integration easier and more effective.

Note that in this PR we'll change how testing works in general - by default locally RISC-V simulation will be disabled, it will be enabled in CI. This change makes testing setup a bit more friendly for AI agents.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted.