### PR TITLE
fix: add missing import for `alloc::format`

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
@@ -16,6 +16,7 @@ use crate::bootloader::transaction_flow::TxExecutionResult;
 use crate::bootloader::transaction_flow::{ExecutionOutput, ExecutionResult};
 use crate::bootloader::BasicBootloaderExecutionConfig;
 use crate::bootloader::TxProcessingOutput;
+use alloc::format;
 use core::fmt::Write;
 use errors::cascade::CascadedError;
 use errors::root_cause::RootCause;


### PR DESCRIPTION
## What ❔

add missing import for `alloc::format`

## Why ❔

fix build, I guess CI compiles with `testing` feature on which doesn't enable no_std

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.