### PR TITLE
feat(EVM-1116): [AI] document observable bytecode len

### DIFF
--- a/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
@@ -130,7 +130,12 @@ pub struct AccountProperties {
     pub unpadded_code_len: u32,
     pub artifacts_len: u32,
     pub observable_bytecode_hash: Bytes32,
-    // TODO(EVM-1116): document the need for observable_bytecode_len
+    /// Externally visible bytecode length (without padding/artifacts).
+    ///
+    /// We keep it separate from `unpadded_code_len` to preserve account payload
+    /// semantics and encoding stability for observable code metadata, while
+    /// `unpadded_code_len` participates in internal full-bytecode/preimage
+    /// accounting with cached artifacts (`full_bytecode_len`).
     pub observable_bytecode_len: u32,
 }
 


### PR DESCRIPTION
## What ❔
- Replaced the TODO in account cache entry with a clear explanation of `observable_bytecode_len` semantics.
- Documented why this value can differ from historical account metadata lengths.

## Why ❔
- Clarifies an important invariant in account metadata handling.
- Reduces ambiguity in a security-sensitive code path.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
