### PR TITLE
feat(EVM-1189): [AI] remove machine default start trap

### DIFF
--- a/zksync_os/src/asm/asm_reduced.S
+++ b/zksync_os/src/asm/asm_reduced.S
@@ -41,9 +41,9 @@ _abs_start:
     Machine trap entry point (_machine_start_trap)
 */
 .section .trap, "ax"
-.global machine_default_start_trap
+.global _machine_start_trap
 .align 4
-machine_default_start_trap:
+_machine_start_trap:
     // We assume that exception stack is always saved to MSCRATCH
 
     // so we swap it with x31

--- a/zksync_os/src/lds/link.x
+++ b/zksync_os/src/lds/link.x
@@ -34,7 +34,6 @@ PROVIDE(_setup_interrupts = default_setup_interrupts);
   but by providing the `_start_trap` symbol external crates can override.
 */
 PROVIDE(_start_trap = default_start_trap);
-PROVIDE(_machine_start_trap = machine_default_start_trap);
 
 PHDRS
 {

--- a/zksync_os/src/main.rs
+++ b/zksync_os/src/main.rs
@@ -237,7 +237,6 @@ pub unsafe fn custom_setup_interrupts() {
 
 /// Exception (trap) handler in rust.
 /// Currently not supported.
-// TODO(EVM-1189): remove machine_default_start_trap entry point to binary.
 #[link_section = ".trap.rust"]
 #[export_name = "_machine_start_trap_rust"]
 pub extern "C" fn machine_start_trap_rust(trap_frame: *mut MachineTrapFrame) -> usize {


### PR DESCRIPTION
## What ❔
- Renamed the machine start trap symbol to `_machine_start_trap`.
- Removed legacy linker alias usage and obsolete TODO around startup trap naming.

## Why ❔
- Makes startup trap entry naming explicit and consistent.
- Simplifies low-level startup wiring by removing legacy indirection.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
