### PR TITLE
test(rig): add TestingFramework-first chain and tx builders

### DIFF
--- a/tests/rig/src/assertions.rs
+++ b/tests/rig/src/assertions.rs
@@ -1,0 +1,303 @@
+//! Domain-specific assertion macros for ZKsync OS integration tests.
+//!
+//! These macros wrap `BlockOutput` checks in readable, descriptive panics.
+
+/// Assert that transaction at `$idx` succeeded (bootloader accepted AND EVM succeeded).
+#[macro_export]
+macro_rules! assert_tx_success {
+    ($output:expr, $idx:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_tx_success: no tx at index {idx}"));
+        match result {
+            Ok(tx_out) if tx_out.is_success() => {}
+            Ok(tx_out) => panic!(
+                "assert_tx_success!(output, {idx}): tx was accepted but EVM reverted.\n  output: {tx_out:?}"
+            ),
+            Err(e) => panic!(
+                "assert_tx_success!(output, {idx}): tx was rejected by bootloader.\n  error: {e:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that transaction at `$idx` was EVM-level reverted (accepted by bootloader, failed in EVM).
+#[macro_export]
+macro_rules! assert_tx_reverted {
+    ($output:expr, $idx:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_tx_reverted: no tx at index {idx}"));
+        match result {
+            Ok(tx_out) if !tx_out.is_success() => {}
+            Ok(tx_out) => panic!(
+                "assert_tx_reverted!(output, {idx}): expected EVM revert but tx succeeded.\n  output: {tx_out:?}"
+            ),
+            Err(e) => panic!(
+                "assert_tx_reverted!(output, {idx}): tx was rejected by bootloader (not an EVM revert).\n  error: {e:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that transaction at `$idx` was rejected at the bootloader level.
+#[macro_export]
+macro_rules! assert_tx_failed {
+    ($output:expr, $idx:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_tx_failed: no tx at index {idx}"));
+        match result {
+            Err(_) => {}
+            Ok(tx_out) => panic!(
+                "assert_tx_failed!(output, {idx}): expected bootloader rejection but tx was processed.\n  output: {tx_out:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that every transaction in `$output` succeeded.
+#[macro_export]
+macro_rules! assert_all_success {
+    ($output:expr) => {{
+        let output = &$output;
+        for (idx, result) in output.tx_results.iter().enumerate() {
+            match result {
+                Ok(tx_out) if tx_out.is_success() => {}
+                Ok(tx_out) => panic!(
+                    "assert_all_success!: tx {idx} was accepted but EVM reverted.\n  output: {tx_out:?}"
+                ),
+                Err(e) => panic!(
+                    "assert_all_success!: tx {idx} was rejected by bootloader.\n  error: {e:?}"
+                ),
+            }
+        }
+    }};
+}
+
+/// Assert that `computational_native_used` for transaction `$idx` is less than `$max`.
+#[macro_export]
+macro_rules! assert_gas_used_lt {
+    ($output:expr, $idx:expr, $max:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let max: u64 = $max;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_gas_used_lt: no tx at index {idx}"));
+        match result {
+            Ok(tx_out) => {
+                let used = tx_out.computational_native_used;
+                if used >= max {
+                    panic!("assert_gas_used_lt!(output, {idx}, {max}): used {used} >= {max}");
+                }
+            }
+            Err(e) => panic!(
+                "assert_gas_used_lt!(output, {idx}, {max}): tx was rejected by bootloader.\n  error: {e:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that `computational_native_used` for transaction `$idx` is greater than `$min`.
+#[macro_export]
+macro_rules! assert_gas_used_gt {
+    ($output:expr, $idx:expr, $min:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let min: u64 = $min;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_gas_used_gt: no tx at index {idx}"));
+        match result {
+            Ok(tx_out) => {
+                let used = tx_out.computational_native_used;
+                if used <= min {
+                    panic!("assert_gas_used_gt!(output, {idx}, {min}): used {used} <= {min}");
+                }
+            }
+            Err(e) => panic!(
+                "assert_gas_used_gt!(output, {idx}, {min}): tx was rejected by bootloader.\n  error: {e:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that `computational_native_used` for transaction `$idx` is within `[$min, $max)`.
+#[macro_export]
+macro_rules! assert_gas_used_between {
+    ($output:expr, $idx:expr, $min:expr, $max:expr) => {{
+        let output = &$output;
+        let idx: usize = $idx;
+        let min: u64 = $min;
+        let max: u64 = $max;
+        let result = output
+            .tx_results
+            .get(idx)
+            .unwrap_or_else(|| panic!("assert_gas_used_between: no tx at index {idx}"));
+        match result {
+            Ok(tx_out) => {
+                let used = tx_out.computational_native_used;
+                if used < min || used >= max {
+                    panic!(
+                        "assert_gas_used_between!(output, {idx}, {min}, {max}): used {used} is not in [{min}, {max})"
+                    );
+                }
+            }
+            Err(e) => panic!(
+                "assert_gas_used_between!(output, {idx}, {min}, {max}): tx was rejected by bootloader.\n  error: {e:?}"
+            ),
+        }
+    }};
+}
+
+/// Assert that the block output contains a storage write:
+/// `address + key => value`.
+///
+/// Expected types:
+/// - `$address`: `alloy::primitives::Address`
+/// - `$key`: `alloy::primitives::B256`
+/// - `$value`: `alloy::primitives::B256`
+#[macro_export]
+macro_rules! assert_storage_written {
+    ($output:expr, $address:expr, $key:expr, $value:expr) => {{
+        let output = &$output;
+        let expected_addr = $address;
+        let expected_key = $key;
+        let expected_val = $value;
+        let found = output.storage_writes.iter().any(|w| {
+            w.account == expected_addr && w.account_key == expected_key && w.value == expected_val
+        });
+        if !found {
+            panic!(
+                "assert_storage_written!: no storage write found for address {:?}, key {:?}, value {:?}",
+                expected_addr, expected_key, expected_val
+            );
+        }
+    }};
+}
+
+/// Assert that the block output contains at least one event log from `$address` with `$topic0`.
+#[macro_export]
+macro_rules! assert_event_emitted {
+    ($output:expr, $address:expr, $topic0:expr) => {{
+        let output = &$output;
+        let expected_addr = $address;
+        let expected_topic0 = $topic0;
+        let found = output.tx_results.iter().any(|r| {
+            r.as_ref()
+                .ok()
+                .map(|tx_out| {
+                    tx_out.logs.iter().any(|ev| {
+                        ev.address == expected_addr
+                            && ev
+                                .topics()
+                                .first()
+                                .map(|t| *t == expected_topic0)
+                                .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if !found {
+            panic!(
+                "assert_event_emitted!: no event found from address {:?} with topic0 {:?}",
+                expected_addr, expected_topic0
+            );
+        }
+    }};
+}
+
+/// Assert that the block output does NOT contain any event log from `$address` with `$topic0`.
+#[macro_export]
+macro_rules! assert_event_not_emitted {
+    ($output:expr, $address:expr, $topic0:expr) => {{
+        let output = &$output;
+        let expected_addr = $address;
+        let expected_topic0 = $topic0;
+        let found = output.tx_results.iter().any(|r| {
+            r.as_ref()
+                .ok()
+                .map(|tx_out| {
+                    tx_out.logs.iter().any(|ev| {
+                        ev.address == expected_addr
+                            && ev
+                                .topics()
+                                .first()
+                                .map(|t| *t == expected_topic0)
+                                .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if found {
+            panic!(
+                "assert_event_not_emitted!: unexpected event from address {:?} with topic0 {:?}",
+                expected_addr, expected_topic0
+            );
+        }
+    }};
+}
+
+/// Assert the total number of event logs emitted in the block equals `$expected_count`.
+#[macro_export]
+macro_rules! assert_block_events_count {
+    ($output:expr, $expected_count:expr) => {{
+        let output = &$output;
+        let expected: usize = $expected_count;
+        let actual: usize = output
+            .tx_results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|tx_out| tx_out.logs.len())
+            .sum();
+        if actual != expected {
+            panic!("assert_block_events_count!: expected {expected} events, got {actual}");
+        }
+    }};
+}
+
+/// Assert that `chain.get_account_properties(&addr).balance` equals `$expected_balance`.
+#[macro_export]
+macro_rules! assert_account_balance {
+    ($chain:expr, $addr:expr, $expected_balance:expr) => {{
+        let chain = &mut $chain;
+        let addr = $addr;
+        let expected = $expected_balance;
+        let actual = chain.get_account_properties(&addr).balance;
+        if actual != expected {
+            panic!(
+                "assert_account_balance!: address {:?} has balance {actual}, expected {expected}",
+                addr
+            );
+        }
+    }};
+}
+
+/// Assert that `chain.get_account_properties(&addr).nonce` equals `$expected_nonce`.
+#[macro_export]
+macro_rules! assert_nonce {
+    ($chain:expr, $addr:expr, $expected_nonce:expr) => {{
+        let chain = &mut $chain;
+        let addr = $addr;
+        let expected: u64 = $expected_nonce;
+        let actual = chain.get_account_properties(&addr).nonce;
+        if actual != expected {
+            panic!(
+                "assert_nonce!: address {:?} has nonce {actual}, expected {expected}",
+                addr
+            );
+        }
+    }};
+}

--- a/tests/rig/src/builder.rs
+++ b/tests/rig/src/builder.rs
@@ -1,0 +1,423 @@
+//! Fluent builders for test framework setup and transaction construction.
+
+use crate::chain::RunConfig;
+use crate::constants::{CALL_GAS_LIMIT, DEFAULT_MAX_FEE, DEFAULT_PRIORITY_FEE, TEST_CHAIN_ID};
+use crate::TestingFramework;
+use alloy::consensus::{TxEip1559, TxEip2930, TxLegacy};
+use alloy::eips::eip2930::AccessList;
+use alloy::primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy::signers::local::PrivateKeySigner;
+use ruint::aliases::{B160, B256 as RuintB256, U256 as RuintU256};
+use zk_ee::utils::Bytes32;
+use zksync_os_tests_common::zksync_tx::l1_tx::ZKsyncL1Tx;
+use zksync_os_tests_common::zksync_tx::upgrade_tx::ZKsyncUpgradeTx;
+use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+/// Fluent builder for [`TestingFramework<false>`].
+///
+/// This is a small wrapper over existing `TestingFramework` builder methods, meant to keep test
+/// setup concise and readable.
+pub struct ChainBuilder {
+    framework: TestingFramework<false>,
+}
+
+impl ChainBuilder {
+    /// Start a new chain builder with default testing settings.
+    pub fn new() -> Self {
+        Self {
+            framework: TestingFramework::new(),
+        }
+    }
+
+    /// Override chain ID.
+    pub fn chain_id(mut self, chain_id: u64) -> Self {
+        self.framework = self.framework.with_chain_id(chain_id);
+        self
+    }
+
+    /// Fund an account.
+    pub fn with_balance(mut self, address: Address, amount: RuintU256) -> Self {
+        self.framework = self.framework.with_balance(address, amount);
+        self
+    }
+
+    /// Fund an account (B160 overload).
+    pub fn with_balance_b160(self, address: B160, amount: RuintU256) -> Self {
+        self.with_balance(Address::from(address.to_be_bytes::<20>()), amount)
+    }
+
+    /// Deploy EVM bytecode at `address`.
+    pub fn with_evm_bytecode(mut self, address: Address, bytecode: Vec<u8>) -> Self {
+        self.framework = self.framework.with_evm_contract(address, &bytecode);
+        self
+    }
+
+    /// Deploy EVM bytecode at `address` (B160 overload).
+    pub fn with_evm_bytecode_b160(self, address: B160, bytecode: Vec<u8>) -> Self {
+        self.with_evm_bytecode(Address::from(address.to_be_bytes::<20>()), bytecode)
+    }
+
+    /// Set a storage slot.
+    pub fn with_storage_slot(mut self, address: Address, key: RuintU256, value: RuintB256) -> Self {
+        self.framework = self.framework.with_storage_slot(address, key, value);
+        self
+    }
+
+    /// Register a preimage.
+    pub fn with_preimage(mut self, hash: Bytes32, data: Vec<u8>) -> Self {
+        self.framework = self.framework.with_preimage(hash, &data);
+        self
+    }
+
+    /// Install selected system contracts.
+    pub fn with_system_contracts(
+        mut self,
+        with_l1_messenger: bool,
+        with_l2_base_token: bool,
+        with_contract_deployer: bool,
+    ) -> Self {
+        self.framework = self.framework.with_system_contracts(
+            with_l1_messenger,
+            with_l2_base_token,
+            with_contract_deployer,
+        );
+        self
+    }
+
+    /// Override run configuration.
+    pub fn with_run_config(mut self, run_config: RunConfig) -> Self {
+        self.framework = self.framework.with_run_config(run_config);
+        self
+    }
+
+    /// Consume the builder and return a configured testing framework.
+    pub fn build(self) -> TestingFramework<false> {
+        self.framework
+    }
+}
+
+impl Default for ChainBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Supported transaction kinds for [`TxBuilder`].
+#[derive(Debug, Clone, Copy, Default)]
+pub enum TxType {
+    #[default]
+    Eip1559,
+    Legacy,
+    Eip2930,
+    L1,
+    Upgrade,
+}
+
+/// Fluent builder for [`ZKsyncTxEnvelope`].
+pub struct TxBuilder {
+    tx_type: TxType,
+    chain_id: u64,
+    signer: Option<PrivateKeySigner>,
+    from: Option<Address>,
+    to: TxKind,
+    calldata: Vec<u8>,
+    value: U256,
+    gas_limit: u64,
+    nonce: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+    access_list: AccessList,
+    gas_per_pubdata_byte_limit: u128,
+    refund_recipient: Option<Address>,
+    to_mint: Option<U256>,
+    factory_deps: Vec<B256>,
+}
+
+impl TxBuilder {
+    /// Create a new builder defaulting to EIP-1559 with sensible test values.
+    pub fn new() -> Self {
+        Self {
+            tx_type: TxType::Eip1559,
+            chain_id: TEST_CHAIN_ID,
+            signer: None,
+            from: None,
+            to: TxKind::Call(Address::ZERO),
+            calldata: Vec::new(),
+            value: U256::ZERO,
+            gas_limit: CALL_GAS_LIMIT,
+            nonce: 0,
+            max_fee_per_gas: DEFAULT_MAX_FEE,
+            max_priority_fee_per_gas: DEFAULT_PRIORITY_FEE,
+            access_list: AccessList::default(),
+            gas_per_pubdata_byte_limit: 0,
+            refund_recipient: None,
+            to_mint: None,
+            factory_deps: Vec::new(),
+        }
+    }
+
+    /// Build an EIP-1559 transaction.
+    pub fn eip1559(mut self) -> Self {
+        self.tx_type = TxType::Eip1559;
+        self
+    }
+
+    /// Build a legacy transaction.
+    pub fn legacy(mut self) -> Self {
+        self.tx_type = TxType::Legacy;
+        self
+    }
+
+    /// Build an EIP-2930 transaction.
+    pub fn eip2930(mut self) -> Self {
+        self.tx_type = TxType::Eip2930;
+        self
+    }
+
+    /// Build an L1 priority transaction.
+    pub fn l1(mut self) -> Self {
+        self.tx_type = TxType::L1;
+        self
+    }
+
+    /// Build an upgrade transaction.
+    pub fn upgrade(mut self) -> Self {
+        self.tx_type = TxType::Upgrade;
+        self
+    }
+
+    /// Set chain ID (used by signed Ethereum transaction kinds).
+    pub fn chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    /// Set signer/sender wallet.
+    pub fn from(mut self, signer: PrivateKeySigner) -> Self {
+        self.from = Some(signer.address());
+        self.signer = Some(signer);
+        self
+    }
+
+    /// Set sender address directly (useful for L1/upgrade tx kinds).
+    pub fn from_address(mut self, address: Address) -> Self {
+        self.from = Some(address);
+        self
+    }
+
+    /// Set recipient address.
+    pub fn to(mut self, address: Address) -> Self {
+        self.to = TxKind::Call(address);
+        self
+    }
+
+    /// Mark as contract creation (`to = null`) for Ethereum transaction kinds.
+    pub fn create(mut self) -> Self {
+        self.to = TxKind::Create;
+        self
+    }
+
+    /// Set calldata/input bytes.
+    pub fn calldata(mut self, calldata: Vec<u8>) -> Self {
+        self.calldata = calldata;
+        self
+    }
+
+    /// Set ETH value.
+    pub fn value(mut self, value: U256) -> Self {
+        self.value = value;
+        self
+    }
+
+    /// Set gas limit.
+    pub fn gas_limit(mut self, gas_limit: u64) -> Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Set nonce.
+    pub fn nonce(mut self, nonce: u64) -> Self {
+        self.nonce = nonce;
+        self
+    }
+
+    /// Set max fee per gas.
+    pub fn max_fee(mut self, max_fee_per_gas: u128) -> Self {
+        self.max_fee_per_gas = max_fee_per_gas;
+        self
+    }
+
+    /// Set max priority fee per gas.
+    pub fn priority_fee(mut self, max_priority_fee_per_gas: u128) -> Self {
+        self.max_priority_fee_per_gas = max_priority_fee_per_gas;
+        self
+    }
+
+    /// Set EIP-2930/EIP-1559 access list.
+    pub fn access_list(mut self, access_list: AccessList) -> Self {
+        self.access_list = access_list;
+        self
+    }
+
+    /// Set gas-per-pubdata-byte limit (L1/upgrade kinds).
+    pub fn gas_per_pubdata_byte_limit(mut self, limit: u128) -> Self {
+        self.gas_per_pubdata_byte_limit = limit;
+        self
+    }
+
+    /// Set refund recipient (L1/upgrade kinds).
+    pub fn refund_recipient(mut self, recipient: Address) -> Self {
+        self.refund_recipient = Some(recipient);
+        self
+    }
+
+    /// Set amount to mint on L2 (L1/upgrade kinds).
+    pub fn to_mint(mut self, to_mint: U256) -> Self {
+        self.to_mint = Some(to_mint);
+        self
+    }
+
+    /// Set factory dependencies (L1/upgrade kinds).
+    pub fn factory_deps(mut self, factory_deps: Vec<B256>) -> Self {
+        self.factory_deps = factory_deps;
+        self
+    }
+
+    /// Build a [`ZKsyncTxEnvelope`].
+    pub fn build(self) -> ZKsyncTxEnvelope {
+        match self.tx_type {
+            TxType::Eip1559 => {
+                let signer = self
+                    .signer
+                    .expect("TxBuilder: no signer set for EIP-1559 tx — call .from(signer)");
+                let tx = TxEip1559 {
+                    chain_id: self.chain_id,
+                    nonce: self.nonce,
+                    max_fee_per_gas: self.max_fee_per_gas,
+                    max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                    gas_limit: self.gas_limit,
+                    to: self.to,
+                    value: self.value,
+                    access_list: self.access_list,
+                    input: Bytes::from(self.calldata),
+                };
+                ZKsyncTxEnvelope::from_eth_tx(tx, signer)
+            }
+            TxType::Legacy => {
+                let signer = self
+                    .signer
+                    .expect("TxBuilder: no signer set for legacy tx — call .from(signer)");
+                let tx = TxLegacy {
+                    chain_id: Some(self.chain_id),
+                    nonce: self.nonce,
+                    gas_price: self.max_fee_per_gas,
+                    gas_limit: self.gas_limit,
+                    to: self.to,
+                    value: self.value,
+                    input: Bytes::from(self.calldata),
+                };
+                ZKsyncTxEnvelope::from_eth_tx(tx, signer)
+            }
+            TxType::Eip2930 => {
+                let signer = self
+                    .signer
+                    .expect("TxBuilder: no signer set for EIP-2930 tx — call .from(signer)");
+                let tx = TxEip2930 {
+                    chain_id: self.chain_id,
+                    nonce: self.nonce,
+                    gas_price: self.max_fee_per_gas,
+                    gas_limit: self.gas_limit,
+                    to: self.to,
+                    value: self.value,
+                    access_list: self.access_list,
+                    input: Bytes::from(self.calldata),
+                };
+                ZKsyncTxEnvelope::from_eth_tx(tx, signer)
+            }
+            TxType::L1 => {
+                let from = self.from.expect(
+                    "TxBuilder: no sender set for L1 tx — call .from(signer) or .from_address(addr)",
+                );
+                let to = match self.to {
+                    TxKind::Call(address) => address,
+                    TxKind::Create => panic!("TxBuilder: L1 tx cannot be a Create"),
+                };
+                let to_mint = self.to_mint.unwrap_or_else(|| {
+                    U256::from(self.gas_limit) * U256::from(self.max_fee_per_gas)
+                });
+                ZKsyncTxEnvelope::from(ZKsyncL1Tx {
+                    from,
+                    to,
+                    gas_limit: self.gas_limit as u128,
+                    gas_per_pubdata_byte_limit: self.gas_per_pubdata_byte_limit,
+                    max_fee_per_gas: self.max_fee_per_gas,
+                    max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                    nonce: self.nonce as u128,
+                    value: self.value,
+                    to_mint,
+                    refund_recipient: self.refund_recipient.unwrap_or_default(),
+                    input: Bytes::from(self.calldata),
+                    factory_deps: self.factory_deps,
+                })
+            }
+            TxType::Upgrade => {
+                let from = self.from.expect("TxBuilder: no sender set for upgrade tx — call .from(signer) or .from_address(addr)");
+                let to = match self.to {
+                    TxKind::Call(address) => address,
+                    TxKind::Create => panic!("TxBuilder: upgrade tx cannot be a Create"),
+                };
+                let to_mint = self.to_mint.unwrap_or_else(|| {
+                    U256::from(self.gas_limit) * U256::from(self.max_fee_per_gas)
+                });
+                ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
+                    from,
+                    to,
+                    gas_limit: self.gas_limit as u128,
+                    gas_per_pubdata_byte_limit: self.gas_per_pubdata_byte_limit,
+                    max_fee_per_gas: self.max_fee_per_gas,
+                    max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+                    nonce: self.nonce as u128,
+                    value: self.value,
+                    to_mint,
+                    refund_recipient: self.refund_recipient.unwrap_or_default(),
+                    input: Bytes::from(self.calldata),
+                    factory_deps: self.factory_deps,
+                })
+            }
+        }
+    }
+}
+
+impl Default for TxBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::eips::Typed2718;
+
+    #[test]
+    fn l1_builder_defaults_to_computed_to_mint() {
+        let tx = TxBuilder::new()
+            .l1()
+            .from_address(Address::ZERO)
+            .to(Address::from([1u8; 20]))
+            .gas_limit(10)
+            .max_fee(3)
+            .build();
+        assert_eq!(tx.ty(), 0x7f);
+    }
+
+    #[test]
+    fn upgrade_builder_sets_upgrade_type() {
+        let tx = TxBuilder::new()
+            .upgrade()
+            .from_address(Address::ZERO)
+            .to(Address::from([2u8; 20]))
+            .build();
+        assert_eq!(tx.ty(), 0x7e);
+    }
+}

--- a/tests/rig/src/builder.rs
+++ b/tests/rig/src/builder.rs
@@ -2,6 +2,7 @@
 
 use crate::chain::RunConfig;
 use crate::constants::{CALL_GAS_LIMIT, DEFAULT_MAX_FEE, DEFAULT_PRIORITY_FEE, TEST_CHAIN_ID};
+use crate::utils::L1TxBuilder;
 use crate::TestingFramework;
 use alloy::consensus::{TxEip1559, TxEip2930, TxLegacy};
 use alloy::eips::eip2930::AccessList;
@@ -9,7 +10,6 @@ use alloy::primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy::signers::local::PrivateKeySigner;
 use ruint::aliases::{B160, B256 as RuintB256, U256 as RuintU256};
 use zk_ee::utils::Bytes32;
-use zksync_os_tests_common::zksync_tx::l1_tx::ZKsyncL1Tx;
 use zksync_os_tests_common::zksync_tx::upgrade_tx::ZKsyncUpgradeTx;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -342,23 +342,23 @@ impl TxBuilder {
                     TxKind::Call(address) => address,
                     TxKind::Create => panic!("TxBuilder: L1 tx cannot be a Create"),
                 };
-                let to_mint = self.to_mint.unwrap_or_else(|| {
-                    U256::from(self.gas_limit) * U256::from(self.max_fee_per_gas)
-                });
-                ZKsyncTxEnvelope::from(ZKsyncL1Tx {
-                    from,
-                    to,
-                    gas_limit: self.gas_limit as u128,
-                    gas_per_pubdata_byte_limit: self.gas_per_pubdata_byte_limit,
-                    max_fee_per_gas: self.max_fee_per_gas,
-                    max_priority_fee_per_gas: self.max_priority_fee_per_gas,
-                    nonce: self.nonce as u128,
-                    value: self.value,
-                    to_mint,
-                    refund_recipient: self.refund_recipient.unwrap_or_default(),
-                    input: Bytes::from(self.calldata),
-                    factory_deps: self.factory_deps,
-                })
+                let mut builder = L1TxBuilder::new()
+                    .from(from)
+                    .to(to)
+                    .gas_price(self.max_fee_per_gas)
+                    .gas_limit(self.gas_limit as u128)
+                    .input(self.calldata)
+                    .value(self.value)
+                    .nonce(self.nonce as u128)
+                    .gas_per_pubdata_byte_limit(self.gas_per_pubdata_byte_limit)
+                    .factory_deps(self.factory_deps);
+                if let Some(refund_recipient) = self.refund_recipient {
+                    builder = builder.refund_recipient(refund_recipient);
+                }
+                if let Some(to_mint) = self.to_mint {
+                    builder = builder.to_mint(to_mint);
+                }
+                builder.build()
             }
             TxType::Upgrade => {
                 let from = self.from.expect("TxBuilder: no sender set for upgrade tx — call .from(signer) or .from_address(addr)");
@@ -397,7 +397,75 @@ impl Default for TxBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::consensus::TxEnvelope;
     use alloy::eips::Typed2718;
+    use zksync_os_tests_common::zksync_tx::ZKsyncSpecificTxEnvelope;
+
+    #[test]
+    fn eip1559_builder_sets_type_and_sender() {
+        let signer = PrivateKeySigner::random();
+        let to = Address::from([0x11; 20]);
+        let tx = TxBuilder::new()
+            .eip1559()
+            .from(signer.clone())
+            .to(to)
+            .nonce(7)
+            .value(U256::from(9u8))
+            .build();
+
+        match &tx {
+            ZKsyncTxEnvelope::Ethereum(TxEnvelope::Eip1559(_), from) => {
+                assert_eq!(*from, signer.address());
+            }
+            _ => panic!("expected eip1559 ethereum tx envelope"),
+        }
+        assert_eq!(tx.ty(), 0x2);
+        assert_eq!(tx.to(), Some(to));
+    }
+
+    #[test]
+    fn legacy_builder_sets_type_and_sender() {
+        let signer = PrivateKeySigner::random();
+        let to = Address::from([0x22; 20]);
+        let tx = TxBuilder::new()
+            .legacy()
+            .from(signer.clone())
+            .to(to)
+            .nonce(3)
+            .value(U256::from(5u8))
+            .build();
+
+        match &tx {
+            ZKsyncTxEnvelope::Ethereum(TxEnvelope::Legacy(_), from) => {
+                assert_eq!(*from, signer.address());
+            }
+            _ => panic!("expected legacy ethereum tx envelope"),
+        }
+        assert_eq!(tx.ty(), 0x0);
+        assert_eq!(tx.to(), Some(to));
+    }
+
+    #[test]
+    fn eip2930_builder_sets_type_and_sender() {
+        let signer = PrivateKeySigner::random();
+        let to = Address::from([0x33; 20]);
+        let tx = TxBuilder::new()
+            .eip2930()
+            .from(signer.clone())
+            .to(to)
+            .nonce(11)
+            .value(U256::from(7u8))
+            .build();
+
+        match &tx {
+            ZKsyncTxEnvelope::Ethereum(TxEnvelope::Eip2930(_), from) => {
+                assert_eq!(*from, signer.address());
+            }
+            _ => panic!("expected eip2930 ethereum tx envelope"),
+        }
+        assert_eq!(tx.ty(), 0x1);
+        assert_eq!(tx.to(), Some(to));
+    }
 
     #[test]
     fn l1_builder_defaults_to_computed_to_mint() {
@@ -407,6 +475,24 @@ mod tests {
             .to(Address::from([1u8; 20]))
             .gas_limit(10)
             .max_fee(3)
+            .build();
+
+        match tx {
+            ZKsyncTxEnvelope::ZKsync(ZKsyncSpecificTxEnvelope::L1(l1_tx)) => {
+                assert_eq!(l1_tx.to_mint, U256::from(30u8));
+                assert_eq!(l1_tx.max_fee_per_gas, 3);
+                assert_eq!(l1_tx.max_priority_fee_per_gas, 3);
+            }
+            _ => panic!("expected l1 tx envelope"),
+        }
+    }
+
+    #[test]
+    fn l1_builder_sets_l1_type() {
+        let tx = TxBuilder::new()
+            .l1()
+            .from_address(Address::ZERO)
+            .to(Address::from([1u8; 20]))
             .build();
         assert_eq!(tx.ty(), 0x7f);
     }

--- a/tests/rig/src/constants.rs
+++ b/tests/rig/src/constants.rs
@@ -1,0 +1,52 @@
+//! Named constants for ZKsync OS integration tests.
+
+use alloy::primitives::address;
+use alloy::primitives::Address;
+
+/// Default chain ID used in tests.
+pub const TEST_CHAIN_ID: u64 = 37;
+
+/// A conservative default gas limit suitable for simple calls.
+pub const DEFAULT_GAS_LIMIT: u64 = 200_000;
+
+/// Gas limit used for ETH-transfer transactions.
+pub const TRANSFER_GAS_LIMIT: u64 = 60_000;
+
+/// Gas limit used when deploying contracts.
+pub const DEPLOY_GAS_LIMIT: u64 = 900_000;
+
+/// Gas limit used for generic contract calls.
+pub const CALL_GAS_LIMIT: u64 = 200_000;
+
+/// Default EIP-1559 base fee.
+pub const DEFAULT_BASEFEE: u128 = 1_000;
+
+/// Default `max_fee_per_gas` value for test transactions.
+pub const DEFAULT_MAX_FEE: u128 = 1_000;
+
+/// Default `max_priority_fee_per_gas` value for test transactions.
+pub const DEFAULT_PRIORITY_FEE: u128 = 1_000;
+
+/// Default native-token price used by the default block context.
+pub const DEFAULT_NATIVE_PRICE: u64 = 10;
+
+/// A large ETH balance suitable for most test senders (1_000_000_000_000_000 wei).
+pub const DEFAULT_BALANCE: u64 = 1_000_000_000_000_000;
+
+/// `ContractDeployer` system contract (0x0000…8006).
+pub const CONTRACT_DEPLOYER: Address = address!("0000000000000000000000000000000000008006");
+
+/// L2 base-token (ETH) system contract (0x0000…800a).
+pub const L2_BASE_TOKEN: Address = address!("000000000000000000000000000000000000800a");
+
+/// L1 messenger system contract (0x0000…8008).
+pub const L1_MESSENGER: Address = address!("0000000000000000000000000000000000008008");
+
+/// `MsgValueSimulator` system contract (0x0000…8009).
+pub const MSG_VALUE_SIMULATOR: Address = address!("0000000000000000000000000000000000008009");
+
+/// `NonceHolder` system contract (0x0000…8003).
+pub const NONCE_HOLDER: Address = address!("0000000000000000000000000000000000008003");
+
+/// `AccountCodeStorage` system contract (0x0000…8002).
+pub const ACCOUNT_CODE_STORAGE: Address = address!("0000000000000000000000000000000000008002");

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -7,7 +7,10 @@
 //!
 use std::str::FromStr;
 use std::sync::Once;
+pub mod assertions;
 pub mod chain;
+pub mod constants;
+pub mod run_config;
 pub mod testing_utils;
 pub mod utils;
 

--- a/tests/rig/src/lib.rs
+++ b/tests/rig/src/lib.rs
@@ -8,6 +8,7 @@
 use std::str::FromStr;
 use std::sync::Once;
 pub mod assertions;
+pub mod builder;
 pub mod chain;
 pub mod constants;
 pub mod run_config;

--- a/tests/rig/src/run_config.rs
+++ b/tests/rig/src/run_config.rs
@@ -19,7 +19,8 @@ pub fn with_profiler(path: impl Into<PathBuf>) -> RunConfig {
 
     let mut config = full_proof();
     let mut profiler_config = ProfilerConfig::new(path.into());
-    profiler_config.frequency_recip = 1;
+    // Keep sampling aligned with existing run_block_generate_witness defaults.
+    profiler_config.frequency_recip = 10;
     config.profiler_config = Some(profiler_config);
     config
 }

--- a/tests/rig/src/run_config.rs
+++ b/tests/rig/src/run_config.rs
@@ -1,0 +1,32 @@
+//! Preset [`RunConfig`] constructors for common testing scenarios.
+
+use crate::chain::RunConfig;
+use std::path::PathBuf;
+
+/// Forward-only run — fastest option, no RISC-V simulation.
+pub fn forward_only() -> RunConfig {
+    RunConfig::without_riscv_run()
+}
+
+/// Full proof run using the current test binary setup.
+pub fn full_proof() -> RunConfig {
+    RunConfig::with_riscv_run()
+}
+
+/// Full proof run that also writes a flamegraph SVG to `path`.
+pub fn with_profiler(path: impl Into<PathBuf>) -> RunConfig {
+    use crate::ProfilerConfig;
+
+    let mut config = full_proof();
+    let mut profiler_config = ProfilerConfig::new(path.into());
+    profiler_config.frequency_recip = 1;
+    config.profiler_config = Some(profiler_config);
+    config
+}
+
+/// Full proof run that saves the witness to a file.
+pub fn with_witness_dump(path: impl Into<PathBuf>) -> RunConfig {
+    let mut config = full_proof();
+    config.witness_output_file = Some(path.into());
+    config
+}


### PR DESCRIPTION
## What ❔

This PR adds `tests/rig/src/builder.rs` with fluent builders adapted to current `dev` testing infrastructure:
- `ChainBuilder` (TestingFramework-first): wraps `TestingFramework<false>` setup methods for concise state/config construction.
- `TxBuilder`: constructs `ZKsyncTxEnvelope` for
  - EIP-1559 / Legacy / EIP-2930 (signed Ethereum txs)
  - L1 priority txs
  - Upgrade txs

Also wires the new module in `tests/rig/src/lib.rs`.

## Why ❔

This is Step 2 of the testing ergonomics refactor. It keeps the codebase aligned with `TestingFramework` usage while reducing repetitive tx construction boilerplate, which improves readability for both humans and AI agents.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.
