### PR TITLE
fix: fix pubdata estimation for l1 transactions

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -526,6 +526,14 @@ where
         .ok_or(internal_error!("mfc+tic"))?;
 
     // First we transfer from treasury
+    // We want to ensure that the simulation of a transaction
+    // never underestimates gas/pubdata compared to the actual execution
+    // of said transaction.
+    // During simulation the gas price is typically set to 0. So we need
+    // to be conservative about operations that incur in gas/pubdata depending
+    // on the value of the fee. For that reason, we always perform the
+    // following transfer on simulation, and avoid compressing the pubdata
+    // for the balance changes resulting from it.
     if to_transfer > U256::ZERO || Config::SIMULATION {
         resources
             .with_infinite_ergs(|inf_resources| {

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -157,7 +157,7 @@ where
         // Tx execution
         let from = transaction.from.read();
         let to = transaction.to.read();
-        match execute_l1_transaction_and_notify_result::<S>(
+        match execute_l1_transaction_and_notify_result::<S, Config>(
             system,
             system_functions,
             memories,
@@ -466,7 +466,11 @@ where
 }
 
 // Returns (execution_result, pubdata_used, to_charge_for_pubdata, resources_before_refund)
-fn execute_l1_transaction_and_notify_result<'a, S: EthereumLikeTypes + 'a>(
+fn execute_l1_transaction_and_notify_result<
+    'a,
+    S: EthereumLikeTypes + 'a,
+    Config: BasicBootloaderExecutionConfig,
+>(
     system: &mut System<S>,
     system_functions: &mut HooksStorage<S, S::Allocator>,
     memories: RunnerMemoryBuffers<'a>,
@@ -522,7 +526,7 @@ where
         .ok_or(internal_error!("mfc+tic"))?;
 
     // First we transfer from treasury
-    if to_transfer > U256::ZERO {
+    if to_transfer > U256::ZERO || Config::SIMULATION {
         resources
             .with_infinite_ergs(|inf_resources| {
                 transfer_from_treasury::<S>(
@@ -530,7 +534,7 @@ where
                     &to_transfer,
                     &from,
                     inf_resources,
-                    false, // Not a fee-related mint
+                    Config::SIMULATION,
                 )
             })
             .map_err(|e| match e.root_cause() {

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -452,11 +452,11 @@ impl<
             // we don't consider this diff in the pubdata charging.
             // This change will be optimized away, so it's actually reducing
             // pubdata.
-            if current.value() == initial.value() {
+            if current.value() == initial.value() && !current.metadata().not_compress_balance {
                 continue;
             }
 
-            if current.value() != at_tx_start.value() {
+            if current.value() != at_tx_start.value() || current.metadata().not_compress_balance {
                 pubdata_used += 32; // key
                 pubdata_used += AccountProperties::diff_compression_length(
                     at_tx_start.value(),

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
@@ -258,13 +258,15 @@ impl AccountProperties {
                     + 4 // observable bytecode len
             })
         } else {
-            if initial.nonce == r#final.nonce && initial.balance == r#final.balance {
+            let has_balance_diff = initial.balance != r#final.balance || not_compress_balance;
+            let has_nonce_diff = initial.nonce != r#final.nonce;
+            if !has_nonce_diff && !has_balance_diff {
                 return Err(internal_error!(
                     "Account properties diff compression shouldn't be called for same values",
                 ));
             }
             let mut length = 1u32; // metadata byte
-            if initial.nonce != r#final.nonce {
+            if has_nonce_diff {
                 length += ValueDiffCompressionStrategy::optimal_compression_length_u256(
                     initial
                         .nonce
@@ -276,7 +278,7 @@ impl AccountProperties {
                         .map_err(|_| internal_error!("u64 into U256"))?,
                 ) as u32; // nonce diff
             }
-            if initial.balance != r#final.balance || not_compress_balance {
+            if has_balance_diff {
                 length += ValueDiffCompressionStrategy::optimal_compression_length_u256_optional(
                     initial.balance,
                     r#final.balance,

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -17,6 +17,7 @@ use rig::{utils::*, BlockContext};
 use std::str::FromStr;
 use zksync_os_tests_common::zksync_tx::service_tx::ZKsyncServiceTx;
 use zksync_os_tests_common::zksync_tx::upgrade_tx::ZKsyncUpgradeTx;
+use zksync_os_tests_common::zksync_tx::ZKsyncSpecificTxEnvelope;
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 mod l1_tx_resilience;
@@ -1661,6 +1662,89 @@ fn test_simulation_gas_and_native_used() {
         tx_result_simulation.native_used, tx_result_normal.native_used,
         "Mismatch in native used"
     );
+}
+
+#[test]
+fn test_l1_simulation_zero_gas_price_gas_used_matches_execution_leftover_balance() {
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = common_target_address();
+    let value = U256::from(1_000u64);
+    let gas_limit = 100_000u128;
+    let base_fee = 1_000u128;
+    let simulation_total_deposited = U256::from(1_000u64);
+    let execution_total_deposited =
+        U256::from(gas_limit) * U256::from(base_fee) + value + U256::from(100u64);
+
+    let simulation_tx = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(0)
+        .gas_limit(gas_limit)
+        .value(value)
+        .to_mint(simulation_total_deposited)
+        .build();
+
+    let simulation_l1_tx = match &simulation_tx {
+        ZKsyncTxEnvelope::ZKsync(ZKsyncSpecificTxEnvelope::L1(tx)) => tx,
+        _ => panic!("Expected L1 transaction"),
+    };
+    assert_eq!(
+        simulation_l1_tx.to_mint, simulation_total_deposited,
+        "L1 total_deposited (reserved[0]) must equal 1000"
+    );
+
+    let execution_tx = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(base_fee)
+        .gas_limit(gas_limit)
+        .value(value)
+        .to_mint(execution_total_deposited)
+        .build();
+
+    let execution_l1_tx = match &execution_tx {
+        ZKsyncTxEnvelope::ZKsync(ZKsyncSpecificTxEnvelope::L1(tx)) => tx,
+        _ => panic!("Expected L1 transaction"),
+    };
+    assert_eq!(
+        execution_l1_tx.to_mint, execution_total_deposited,
+        "Execution total_deposited must cover max fee plus transferred value"
+    );
+
+    let block_context = BlockContext {
+        // In simulation, L1 txs with 0 gas price use basefee/10 as native_per_gas.
+        // In execution, L1 txs use gas_price/10. Set execution gas_price == basefee.
+        eip1559_basefee: U256::from(base_fee),
+        ..Default::default()
+    };
+
+    let mut simulation_tester = TestingFramework::new().with_block_context(block_context.clone());
+    simulation_tester.mint_tokens_to_treasury();
+    let simulation_output = simulation_tester.simulate_block(vec![simulation_tx]);
+    let simulation_result = simulation_output.tx_results[0]
+        .clone()
+        .expect("Simulation must process L1 tx");
+    assert!(
+        simulation_result.is_success(),
+        "Simulation result must be successful"
+    );
+
+    let mut execution_tester = TestingFramework::new().with_block_context(block_context);
+    execution_tester.mint_tokens_to_treasury();
+    let execution_output = execution_tester.execute_block(vec![execution_tx]);
+    let execution_result = execution_output.tx_results[0]
+        .clone()
+        .expect("Execution must process L1 tx");
+    assert!(
+        execution_result.is_success(),
+        "Execution result must be successful"
+    );
+
+    assert_eq!(
+        simulation_result.gas_used, execution_result.gas_used,
+        "Mismatch in gas used between simulation and execution"
+    );
+    assert!(simulation_result.pubdata_used >= execution_result.pubdata_used);
 }
 
 /// Check that gas price doesn't affect gas used in simulation.


### PR DESCRIPTION
## What ❔
There's an issue when L1 transactions are understimated in pubdata needed.
The issue is caused by the sender balance being considered "empty" after transferring the value to the destination on simulation, but having some leftovers in actual execution. This PR avoids compression of the sender balance in simulation.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.