### PR TITLE
feat: add run_from_bytes and generate_proof_input_from_bytes APIs

### DIFF
--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -169,8 +169,12 @@ pub fn generate_proof_input_from_bytes<T: ReadStorageTree, PS: PreimageSource, T
     let copy_source = ReadWitnessSource::new(oracle);
     let items = copy_source.get_read_items();
 
-    let _proof_output =
-        zksync_os_runner::run_from_bytes(zk_os_program_bytes, None, 1 << 36, copy_source);
+    let (_proof_output, _) = zksync_os_runner::run_and_get_effective_cycles_from_bytes(
+        zk_os_program_bytes,
+        None,
+        1 << 36,
+        copy_source,
+    );
 
     Ok(std::rc::Rc::try_unwrap(items).unwrap().into_inner())
 }

--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -112,6 +112,28 @@ pub fn generate_proof_input<T: ReadStorageTree, PS: PreimageSource, TS: TxSource
     preimage_source: PS,
     tx_source: TS,
 ) -> Result<Vec<u32>, ForwardSubsystemError> {
+    let img_bytes = std::fs::read(&zk_os_program_path)
+        .unwrap_or_else(|_| panic!("ZKsync OS bin file missing: {zk_os_program_path:?}"));
+    generate_proof_input_from_bytes(
+        &img_bytes,
+        block_context,
+        proof_data,
+        da_commitment_scheme,
+        tree,
+        preimage_source,
+        tx_source,
+    )
+}
+
+pub fn generate_proof_input_from_bytes<T: ReadStorageTree, PS: PreimageSource, TS: TxSource>(
+    zk_os_program_bytes: &[u8],
+    block_context: BlockContext,
+    proof_data: ProofData<StorageCommitment>,
+    da_commitment_scheme: DACommitmentScheme,
+    tree: T,
+    preimage_source: PS,
+    tx_source: TS,
+) -> Result<Vec<u32>, ForwardSubsystemError> {
     let block_metadata_responder = BlockMetadataResponder {
         block_metadata: block_context,
     };
@@ -147,7 +169,8 @@ pub fn generate_proof_input<T: ReadStorageTree, PS: PreimageSource, TS: TxSource
     let copy_source = ReadWitnessSource::new(oracle);
     let items = copy_source.get_read_items();
 
-    let _proof_output = zksync_os_runner::run(zk_os_program_path, None, 1 << 36, copy_source);
+    let _proof_output =
+        zksync_os_runner::run_from_bytes(zk_os_program_bytes, None, 1 << 36, copy_source);
 
     Ok(std::rc::Rc::try_unwrap(items).unwrap().into_inner())
 }

--- a/zksync_os_runner/src/lib.rs
+++ b/zksync_os_runner/src/lib.rs
@@ -53,57 +53,16 @@ pub fn run(
     run_and_get_effective_cycles(img_path, diagnostics, cycles, non_determinism_source).0
 }
 
-pub fn run_from_bytes(
-    img_bytes: &[u8],
-    diagnostics: Option<DiagnosticsConfig>,
-    cycles: usize,
-    non_determinism_source: impl NonDeterminismCSRSource<VectorMemoryImpl>,
-) -> [u32; 8] {
-    println!("ZK RISC-V simulator is starting");
-
-    let config = SimulatorConfig {
-        bin: BinarySource::Slice(img_bytes),
-        cycles,
-        entry_point: 0,
-        diagnostics,
-    };
-
-    let run_result =
-        risc_v_simulator::runner::run_simple_with_entry_point_and_non_determimism_source(
-            config,
-            non_determinism_source,
-        );
-
-    risc_v_simulator::cycle::state::output_opcode_stats();
-
-    #[allow(unused_mut, unused_assignments)]
-    let mut _block_effective: Option<u64> = None;
-
-    #[cfg(feature = "cycle_marker")]
-    {
-        _block_effective = cycle_marker::print_cycle_markers();
-    }
-
-    #[allow(deprecated)]
-    run_result.state.registers[10..18].try_into().unwrap()
-}
-
-pub fn run_and_get_effective_cycles(
-    img_path: PathBuf,
+fn run_and_get_effective_cycles_inner(
+    img_source: BinarySource,
     diagnostics: Option<DiagnosticsConfig>,
     cycles: usize,
     non_determinism_source: impl NonDeterminismCSRSource<VectorMemoryImpl>,
 ) -> ([u32; 8], Option<u64>) {
     println!("ZK RISC-V simulator is starting");
 
-    // Check that the bin file is present and readable.
-    let mut file = std::fs::File::open(img_path.clone())
-        .unwrap_or_else(|_| panic!("ZKsync OS bin file missing: {img_path:?}"));
-    let mut buffer = vec![];
-    file.read_to_end(&mut buffer).expect("must read the file");
-
     let config = SimulatorConfig {
-        bin: BinarySource::Path(img_path),
+        bin: img_source,
         cycles,
         entry_point: 0,
         diagnostics,
@@ -132,6 +91,40 @@ pub fn run_and_get_effective_cycles(
     (
         run_result.state.registers[10..18].try_into().unwrap(),
         block_effective,
+    )
+}
+
+pub fn run_and_get_effective_cycles_from_bytes(
+    img_bytes: &[u8],
+    diagnostics: Option<DiagnosticsConfig>,
+    cycles: usize,
+    non_determinism_source: impl NonDeterminismCSRSource<VectorMemoryImpl>,
+) -> ([u32; 8], Option<u64>) {
+    run_and_get_effective_cycles_inner(
+        BinarySource::Slice(img_bytes),
+        diagnostics,
+        cycles,
+        non_determinism_source,
+    )
+}
+
+pub fn run_and_get_effective_cycles(
+    img_path: PathBuf,
+    diagnostics: Option<DiagnosticsConfig>,
+    cycles: usize,
+    non_determinism_source: impl NonDeterminismCSRSource<VectorMemoryImpl>,
+) -> ([u32; 8], Option<u64>) {
+    // Check that the bin file is present and readable.
+    let mut file = std::fs::File::open(img_path.clone())
+        .unwrap_or_else(|_| panic!("ZKsync OS bin file missing: {img_path:?}"));
+    let mut buffer = vec![];
+    file.read_to_end(&mut buffer).expect("must read the file");
+
+    run_and_get_effective_cycles_inner(
+        BinarySource::Path(img_path),
+        diagnostics,
+        cycles,
+        non_determinism_source,
     )
 }
 

--- a/zksync_os_runner/src/lib.rs
+++ b/zksync_os_runner/src/lib.rs
@@ -53,6 +53,41 @@ pub fn run(
     run_and_get_effective_cycles(img_path, diagnostics, cycles, non_determinism_source).0
 }
 
+pub fn run_from_bytes(
+    img_bytes: &[u8],
+    diagnostics: Option<DiagnosticsConfig>,
+    cycles: usize,
+    non_determinism_source: impl NonDeterminismCSRSource<VectorMemoryImpl>,
+) -> [u32; 8] {
+    println!("ZK RISC-V simulator is starting");
+
+    let config = SimulatorConfig {
+        bin: BinarySource::Slice(img_bytes),
+        cycles,
+        entry_point: 0,
+        diagnostics,
+    };
+
+    let run_result =
+        risc_v_simulator::runner::run_simple_with_entry_point_and_non_determimism_source(
+            config,
+            non_determinism_source,
+        );
+
+    risc_v_simulator::cycle::state::output_opcode_stats();
+
+    #[allow(unused_mut, unused_assignments)]
+    let mut _block_effective: Option<u64> = None;
+
+    #[cfg(feature = "cycle_marker")]
+    {
+        _block_effective = cycle_marker::print_cycle_markers();
+    }
+
+    #[allow(deprecated)]
+    run_result.state.registers[10..18].try_into().unwrap()
+}
+
 pub fn run_and_get_effective_cycles(
     img_path: PathBuf,
     diagnostics: Option<DiagnosticsConfig>,


### PR DESCRIPTION
## Summary

- Add `run_from_bytes` to `zksync_os_runner` to run the RISC-V simulator from an in-memory byte slice instead of a file path
- Refactor `generate_proof_input` in `forward_system` to delegate to a new `generate_proof_input_from_bytes`, enabling callers to skip file I/O when the binary is already loaded

## Test plan

- [ ] `cargo check -p zksync_os_runner` passes cleanly
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)