### PR TITLE
fix(ci): restore direct PR comment in bench workflow

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       pull-requests: write
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: [matterlabs-ci-runner-highmem]
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,8 +111,13 @@ jobs:
           done
           MARKER_PATH=$(pwd)/head_precompiles.bench cargo test --release -j 3 --features rig/no_print,precompiles/cycle_marker,rig/unlimited_native -p precompiles -- test_precompiles
           pairs="${pairs},(\"precompiles\", \"base_precompiles.bench\", \"head_precompiles.bench\")"
-          # Save comparison result to file for the comment workflow
+          # Save comparison to file (for artifact + comment workflow fallback)
           python3 bench_scripts/compare_bench.py "[${pairs}]" > bench_results/comparison.md
+          # Also write to step output for direct comment
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "result<<$EOF" >> $GITHUB_OUTPUT
+          cat bench_results/comparison.md >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > bench_results/pr_number.txt
@@ -120,3 +126,15 @@ jobs:
         with:
           name: bench_results
           path: bench_results/
+
+      - name: Comment on PR
+        # For fork PRs the token is read-only, so this will fail.
+        # bench-comment.yml (workflow_run) handles that case.
+        continue-on-error: true
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
+        with:
+          message: |
+            ${{ steps.comparison.outputs.result }}
+          comment_tag: vm-performance-changes
+          mode: recreate
+          create_if_not_exists: true


### PR DESCRIPTION
## What ❔
Fixes bug introduced in #556 that removed bench ci comment
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.