### PR TITLE
fix: Fix the singleblock and multiblock oracle reads divergence

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -219,6 +219,41 @@ pub fn read_multichain_root<
 }
 
 ///
+/// Reads values that must consume the oracle in the same order in both proving
+/// flows.
+///
+pub fn read_batch_context_inputs<
+    A: Allocator + Clone + Default,
+    R: Resources,
+    P: StorageAccessPolicy<R, Bytes32> + Default,
+    SF: StackFactory<N>,
+    const N: usize,
+    O: IOOracle,
+    const PROOF_ENV: bool,
+>(
+    io: &mut FullIO<
+        A,
+        R,
+        P,
+        SF,
+        N,
+        O,
+        FlatTreeWithAccountsUnderHashesStorageModel<A, R, P, SF, N, PROOF_ENV>,
+        PROOF_ENV,
+    >,
+) -> (Bytes32, U256) {
+    let multichain_root = read_multichain_root(io);
+    let settlement_layer_chain_id = read_settlement_layer_chain_id(io);
+    if let Some(new_settlement_layer_chain_id) = io.new_settlement_layer_chain_id_storage.value() {
+        // If the SL chain id was updated, make sure the updated one matches
+        // the one read from storage.
+        assert_eq!(new_settlement_layer_chain_id, &settlement_layer_chain_id);
+    }
+
+    (multichain_root, settlement_layer_chain_id)
+}
+
+///
 /// Calculates storage slot of multichain tree root in L2MessageRoot(0x10005) contract.
 ///
 /// By convention storage slot for it should stay the same(depend only on `tree_height`).

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -110,16 +110,7 @@ where
             .apply_to_array_vec(&mut batch_data.logs_storage);
 
         let upgrade_tx_hash = block_data.upgrade_tx_recorder.finish();
-        let settlement_layer_chain_id = read_settlement_layer_chain_id(&mut io);
-        if let Some(new_settlement_layer_chain_id) =
-            io.new_settlement_layer_chain_id_storage.value()
-        {
-            // If the SL chain id was updated, make sure the updated one matches
-            // the one read from storage
-            assert_eq!(new_settlement_layer_chain_id, &settlement_layer_chain_id)
-        }
-
-        let multichain_root = read_multichain_root(&mut io);
+        let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
 
         let (mut state_commitment, last_block_timestamp) = {
             let proof_data: ProofData<FlatStorageCommitment<TREE_HEIGHT>> =

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -94,7 +94,7 @@ where
             &mut io,
         );
 
-        let multichain_root = read_multichain_root(&mut io);
+        let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
 
         let mut full_root_hasher = crypto::sha3::Keccak256::new();
         full_root_hasher.update(io.logs_storage.tree_root().as_u8_ref());
@@ -116,15 +116,6 @@ where
             io.interop_root_storage.iter(),
             &mut crypto::sha3::Keccak256::new(),
         );
-
-        let settlement_layer_chain_id = read_settlement_layer_chain_id(&mut io);
-        if let Some(new_settlement_layer_chain_id) =
-            io.new_settlement_layer_chain_id_storage.value()
-        {
-            // If the SL chain id was updated, make sure the updated one matches
-            // the one read from storage
-            assert_eq!(new_settlement_layer_chain_id, &settlement_layer_chain_id)
-        }
 
         let (mut state_commitment, last_block_timestamp) = {
             let proof_data: ProofData<FlatStorageCommitment<TREE_HEIGHT>> =

--- a/forward_system/src/run/query_processors/read_tree.rs
+++ b/forward_system/src/run/query_processors/read_tree.rs
@@ -66,7 +66,7 @@ impl<T: ReadStorageTree, M: MemorySource> OracleQueryProcessor<M> for ReadTreeRe
                 DynUsizeIterator::from_constructor(prev_index, UsizeSerializable::iter)
             }
             ExactIndexQuery::QUERY_ID => {
-                let key = <PreviousIndexQuery as SimpleOracleQuery>::Input::from_iter(
+                let key = <ExactIndexQuery as SimpleOracleQuery>::Input::from_iter(
                     &mut query.into_iter(),
                 )
                 .expect("must deserialize key");


### PR DESCRIPTION
## What ❔

We had reads in a different order

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.