### PR TITLE
feat(basic_bootloader): add pre-L1-tx contract call to L2AssetTracker

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -18,6 +18,7 @@ use crate::require_internal;
 use arrayvec::ArrayVec;
 use core::fmt::Write;
 use ruint::aliases::{B160, U256};
+use system_hooks::addresses_constants::L2_ASSET_TRACKER_ADDRESS;
 use zk_ee::common_structs::system_hooks::HooksStorage;
 use zk_ee::execution_environment_type::ExecutionEnvironmentType;
 use zk_ee::system::errors::root_cause::GetRootCause;
@@ -473,7 +474,7 @@ fn execute_l1_transaction_and_notify_result<
 >(
     system: &mut System<S>,
     system_functions: &mut HooksStorage<S, S::Allocator>,
-    memories: RunnerMemoryBuffers<'a>,
+    mut memories: RunnerMemoryBuffers<'a>,
     transaction: &AbiEncodedTransaction<S::Allocator>,
     from: B160,
     to: B160,
@@ -524,6 +525,40 @@ where
     let to_transfer = total_deposited
         .checked_sub(max_fee_commitment)
         .ok_or(internal_error!("mfc+tic"))?;
+
+    // PoC: Make a contract call to L2AssetTracker before the L1 tx execution.
+    // This call happens BEFORE any balance changes, matching the Solidity
+    // invariant that the asset tracker is notified before totalSupply/balances
+    // change. The call is inside the outer frame so it rolls back if the main
+    // tx reverts.
+    //
+    // Uses FORMAL_INFINITE resources since this is bootloader-level overhead.
+    // A real implementation would encode the proper function selector and
+    // arguments (e.g., handleFinalizeBaseTokenBridgingOnL2(chainId, amount))
+    // and would need to account for native resource consumption.
+    {
+        let pre_call_resources = S::Resources::FORMAL_INFINITE;
+        let pre_call_result =
+            BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
+                system,
+                system_functions,
+                memories.reborrow(),
+                &[], // empty calldata — real impl would encode function selector + args
+                &from,
+                &L2_ASSET_TRACKER_ADDRESS,
+                pre_call_resources,
+                &U256::ZERO, // no value transfer
+                true,        // make frame for rollback isolation
+                tracer,
+                validator,
+            )?;
+        let pre_call_failed = pre_call_result.result.failed();
+        if pre_call_failed {
+            system_log!(system, "Pre-L1-tx call to L2AssetTracker reverted\n");
+        } else {
+            system_log!(system, "Pre-L1-tx call to L2AssetTracker succeeded\n");
+        }
+    }
 
     // First we transfer from treasury
     // We want to ensure that the simulation of a transaction

--- a/system_hooks/src/addresses_constants.rs
+++ b/system_hooks/src/addresses_constants.rs
@@ -43,6 +43,9 @@ pub const L2_INTEROP_CENTER_ADDRESS_LOW: u32 = 0x1000d;
 pub const L2_INTEROP_CENTER_ADDRESS: B160 =
     B160::from_limbs([L2_INTEROP_CENTER_ADDRESS_LOW as u64, 0, 0]);
 
+// L2 Asset Tracker contract
+pub const L2_ASSET_TRACKER_ADDRESS: B160 = B160::from_limbs([0x1000f, 0, 0]);
+
 // Treasury contract used for "minting" base tokens on L2
 pub const BASE_TOKEN_HOLDER_ADDRESS_LOW: u32 = 0x10011;
 pub const BASE_TOKEN_HOLDER_ADDRESS: B160 =

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -167,9 +167,7 @@ fn test_l1_tx_pre_call_does_not_break_execution() {
         .nonce(0)
         .build();
 
-    let mut tester = TestingFramework::new()
-        .without_revm_consistency_check()
-        .with_balance(sender, U256::from(u64::MAX));
+    let mut tester = TestingFramework::new().with_balance(sender, U256::from(u64::MAX));
 
     let output = tester.execute_block(vec![tx]);
     assert!(
@@ -197,9 +195,7 @@ fn test_l1_tx_deposit_with_pre_call() {
         .nonce(0)
         .build();
 
-    let mut tester = TestingFramework::new()
-        .without_revm_consistency_check()
-        .with_balance(sender, U256::from(u64::MAX));
+    let mut tester = TestingFramework::new().with_balance(sender, U256::from(u64::MAX));
 
     let output = tester.execute_block(vec![tx]);
     assert!(

--- a/tests/instances/transactions/src/l1_tx_resilience.rs
+++ b/tests/instances/transactions/src/l1_tx_resilience.rs
@@ -14,7 +14,7 @@
 use rig::alloy::primitives::address;
 use rig::ruint::aliases::U256;
 use rig::utils::L1TxBuilder;
-use rig::{alloy, TestingFramework};
+use rig::{alloy, tx_succeeded, TestingFramework};
 
 use super::common_target_address;
 
@@ -141,5 +141,69 @@ fn test_l1_tx_intrinsic_gas_overflow() {
     assert!(
         res.is_success(),
         "This L1 transaction with gas overflow should not be reverted"
+    );
+}
+
+/// PoC test: verify that the pre-L1-tx contract call to L2AssetTracker
+/// does not interfere with normal L1 transaction processing.
+///
+/// The pre-call targets an address with no deployed code, so it completes
+/// as a no-op. This test validates that the call mechanism (resources, frames,
+/// caches) works correctly and does not break the main L1 tx execution.
+#[test]
+fn test_l1_tx_pre_call_does_not_break_execution() {
+    let sender = address!("1234567890123456789012345678901234567890");
+    let recipient = address!("2222567890123456789012345678901234567890");
+    let value = alloy::primitives::U256::from(1_000_000u64);
+
+    let tx = L1TxBuilder::new()
+        .from(sender)
+        .to(recipient)
+        .input(Vec::new())
+        .value(value)
+        .to_mint(value)
+        .gas_price(0)
+        .gas_limit(200_000)
+        .nonce(0)
+        .build();
+
+    let mut tester = TestingFramework::new()
+        .without_revm_consistency_check()
+        .with_balance(sender, U256::from(u64::MAX));
+
+    let output = tester.execute_block(vec![tx]);
+    assert!(
+        tx_succeeded(&output, 0),
+        "L1 tx must succeed despite the pre-call"
+    );
+}
+
+/// PoC test: verify that a value-bearing L1 deposit transaction succeeds
+/// with the pre-call mechanism in place.
+#[test]
+fn test_l1_tx_deposit_with_pre_call() {
+    let sender = address!("aabb000000000000000000000000000000000000");
+    let recipient = address!("ccdd000000000000000000000000000000000000");
+    let deposit_value = alloy::primitives::U256::from(5_000_000_000u64);
+
+    let tx = L1TxBuilder::new()
+        .from(sender)
+        .to(recipient)
+        .input(Vec::new())
+        .value(deposit_value)
+        .to_mint(deposit_value)
+        .gas_price(0)
+        .gas_limit(300_000)
+        .nonce(0)
+        .build();
+
+    let mut tester = TestingFramework::new()
+        .without_revm_consistency_check()
+        .with_balance(sender, U256::from(u64::MAX));
+
+    let output = tester.execute_block(vec![tx]);
+    assert!(
+        tx_succeeded(&output, 0),
+        "L1 deposit tx must succeed with pre-call"
     );
 }


### PR DESCRIPTION
## What

Proof-of-concept that adds a proper EVM contract call to L2AssetTracker (0x1000f)
before L1 transaction execution, as an alternative to inline storage manipulation.

The pre-call is inserted in `execute_l1_transaction_and_notify_result`, after the
global frame starts but before any balance changes. It uses:
- `memories.reborrow()` to reuse the runner memory buffers for two sequential calls
- `FORMAL_INFINITE` resources (bootloader-level overhead, not user-paid)
- `should_make_frame=true` for rollback isolation of the pre-call
- Empty calldata (a real implementation would encode the function selector and arguments)

Key considerations addressed:
- **Resources**: Pre-call uses infinite ergs since it's bootloader overhead. Native
  resource tracking for the pre-call is not implemented (noted for real implementation).
- **Caches**: The pre-call goes through the same IO subsystem, so storage changes
  share the same cache layer. Frame nesting ensures proper rollback semantics.
- **Context**: The call happens inside the outer rollback frame, so if the main L1
  tx reverts, the pre-call's state changes also revert (matching the Solidity invariant).

Also adds `L2_ASSET_TRACKER_ADDRESS` (0x1000f) to `system_hooks::addresses_constants`.

## Why

Explores whether the logic in PR #557 (which replicates `handleFinalizeBaseTokenBridgingOnL2`
via direct storage reads/writes) can instead be done as a proper smart contract call.
This PoC validates that the call mechanism works correctly with the existing resource
accounting, frame management, and storage cache infrastructure.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.