### PR TITLE
fix: fix service block invariants

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/mod.rs
@@ -93,32 +93,34 @@ where
     }
 }
 
-/// Check the service block invariants:
-/// 1. If the first tx is a service tx, then the block is a service block
-/// 2. Service transactions can only be processed in service blocks,
-///    unless the first tx in the block was an upgrade tx
-/// 3. Non-service transactions cannot be processed in service blocks
+/// Check the service block invariants.
+///
+/// Returns `true` if the accepted transaction starts a service block.
+///
+/// A block may become a service block in two cases:
+/// 1. the first accepted tx is a service tx
+/// 2. the first accepted tx was an upgrade tx and no other non-service tx was
+///    accepted after it
+///
+/// Once a block is a service block, only service txs may follow.
 fn check_for_service_block_invariants(
-    is_service_block: &mut bool,
+    is_service_block: bool,
     is_first_tx: bool,
     is_service_tx: bool,
-    first_tx_was_upgrade: bool,
-) -> Result<(), InternalError> {
-    //  1. If the first tx is a service tx, then the block is a service block
-    if is_first_tx && is_service_tx {
-        *is_service_block = true;
-    }
-    if *is_service_block {
-        if !is_service_tx {
-            // 3. Non-service transactions cannot be processed in service blocks
-            return Err(internal_error!("Non-service tx in service block"));
+    can_start_service_block_after_upgrade: bool,
+) -> Result<bool, InternalError> {
+    let starts_service_block =
+        is_service_tx && (is_first_tx || can_start_service_block_after_upgrade);
+
+    if is_service_tx {
+        if is_service_block || starts_service_block {
+            Ok(starts_service_block)
+        } else {
+            Err(internal_error!("Service tx in non-service block"))
         }
+    } else if is_service_block {
+        Err(internal_error!("Non-service tx in service block"))
     } else {
-        // 2. Service transactions can only be processed in service blocks,
-        //    unless the first tx in the block was an upgrade tx
-        if is_service_tx && !first_tx_was_upgrade {
-            return Err(internal_error!("Service tx in non-service block"));
-        }
+        Ok(false)
     }
-    Ok(())
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -32,11 +32,10 @@ where
         cycle_marker::start!("run_tx_loop");
 
         let mut is_first_tx = true;
-        // Service blocks are blocks that only contain service transactions.
-        // Service transactions can only be included in service blocks,
-        // unless the first tx in the block was an upgrade tx.
+        // Service blocks are blocks that only contain service transactions,
+        // optionally prefixed by a single upgrade tx.
         let mut is_service_block = false;
-        let mut first_tx_was_upgrade = false;
+        let mut can_start_service_block_after_upgrade = false;
 
         // TODO use preallocated data buffer?
 
@@ -129,16 +128,12 @@ where
                             );
 
                             // Check for service block invariants
-                            check_for_service_block_invariants(
-                                &mut is_service_block,
+                            let starts_service_block = check_for_service_block_invariants(
+                                is_service_block,
                                 is_first_tx,
                                 tx_processing_result.is_service_tx,
-                                first_tx_was_upgrade,
+                                can_start_service_block_after_upgrade,
                             )?;
-
-                            if is_first_tx && tx_processing_result.is_upgrade_tx {
-                                first_tx_was_upgrade = true;
-                            }
 
                             // Do not update the accumulators yet, we may need to revert the transaction
                             let next_block_gas_used =
@@ -172,6 +167,18 @@ where
                                     next_block_computational_native_used;
                                 block_data.block_pubdata_used = next_block_pubdata_used;
                                 block_data.block_blob_gas_used = next_block_blob_gas_used;
+
+                                if starts_service_block {
+                                    is_service_block = true;
+                                    can_start_service_block_after_upgrade = false;
+                                } else if is_first_tx && tx_processing_result.is_upgrade_tx {
+                                    can_start_service_block_after_upgrade = true;
+                                } else if can_start_service_block_after_upgrade
+                                    && !tx_processing_result.is_service_tx
+                                {
+                                    can_start_service_block_after_upgrade = false;
+                                }
+
                                 is_first_tx = false;
 
                                 // Finish the frame opened before processing the tx

--- a/tests/instances/interop/src/lib.rs
+++ b/tests/instances/interop/src/lib.rs
@@ -456,6 +456,38 @@ fn test_set_sl_chain_id_after_upgrade_tx() {
     assert_eq!(read_sl_chain_id_slot(&mut tester), U256::from(42));
 }
 
+/// Once a service tx follows an upgrade tx, the block must remain service-only.
+#[test]
+fn test_l2_tx_after_service_tx_after_upgrade_fails() {
+    let wallet = testing_signer(0);
+    let upgrade_target = address!("0000000000000000000000000000000000010003");
+    let success_bytecode = hex::decode("60006000f3").unwrap(); // RETURN(0,0)
+
+    let mut tester = with_system_context_contracts(TestingFramework::new())
+        .with_evm_contract(upgrade_target, &success_bytecode)
+        .with_prefunded_account(wallet.address());
+
+    let upgrade_tx = ZKsyncTxEnvelope::from(ZKsyncUpgradeTx {
+        from: address!("1234000000000000000000000000000000000000"),
+        to: upgrade_target,
+        gas_limit: 100_000u128,
+        ..Default::default()
+    });
+
+    let error = tester
+        .execute_block_no_panic(vec![
+            upgrade_tx,
+            set_sl_chain_id_tx(U256::from(42), 0),
+            simple_tx(0),
+        ])
+        .expect_err("block with [upgrade, service, l2] should fail");
+    let error_debug = format!("{error:?}");
+    assert!(
+        error_debug.contains("Non-service tx in service block"),
+        "expected service isolation error, got: {error_debug}"
+    );
+}
+
 #[test]
 fn test_set_interop_fee_updates_slot_and_emits_event() {
     let mut tester = with_interop_center_contract(TestingFramework::new())


### PR DESCRIPTION
## What ❔
The previous PR (#579) allowed to add service tx after an upgrade. However, this change allowed blocks of the shape [upgrade, service, l2_tx], which breaks the assumptions that service work shouldn't be mixed with normal L2 txs.
This PR prevents this situation.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.