### PR TITLE
feat(evm_interpreter): add spend_native_only fast path for hot loop step cost

### DIFF
--- a/evm_interpreter/src/gas.rs
+++ b/evm_interpreter/src/gas.rs
@@ -74,6 +74,17 @@ impl<S: EthereumLikeTypes> Gas<S> {
     }
 
     #[inline(always)]
+    /// Spend only the "native" (proving) resource, without touching gas/ergs.
+    /// More efficient than `spend_gas_and_native(0, native)` as it skips the
+    /// ergs multiplication and ergs charge entirely.
+    pub(crate) fn spend_native_only(&mut self, native: u64) -> Result<(), ExitCode> {
+        use zk_ee::system::Computational;
+        let native_cost = Computational::from_computational(native);
+        self.resources.charge_native_only(&native_cost)?;
+        Ok(())
+    }
+
+    #[inline(always)]
     /// Spend gas and "native" (proving) resource. This double accounting approach is used to keep track of actual proving cost
     pub(crate) fn spend_gas_and_native(&mut self, gas: u64, native: u64) -> Result<(), ExitCode> {
         use zk_ee::system::Computational;

--- a/evm_interpreter/src/interpreter.rs
+++ b/evm_interpreter/src/interpreter.rs
@@ -142,7 +142,7 @@ impl<'ee, S: EthereumLikeTypes> Interpreter<'ee, S> {
             self.instruction_pointer += 1;
             let result = self
                 .gas
-                .spend_gas_and_native(0, STEP_NATIVE_COST)
+                .spend_native_only(STEP_NATIVE_COST)
                 .and_then(|_| match opcode {
                     opcodes::CREATE => self.create::<false>(system, external_call_dest, tracer),
                     opcodes::CREATE2 => self.create::<true>(system, external_call_dest, tracer),

--- a/zk_ee/src/reference_implementations/mod.rs
+++ b/zk_ee/src/reference_implementations/mod.rs
@@ -193,6 +193,10 @@ impl<Native: Resource + Computational> Resources for BaseResources<Native> {
         self.ergs = old_ergs;
         o
     }
+
+    fn charge_native_only(&mut self, native: &Native) -> Result<(), SystemError> {
+        self.native.charge(native)
+    }
 }
 
 #[cfg(test)]

--- a/zk_ee/src/system/resources.rs
+++ b/zk_ee/src/system/resources.rs
@@ -169,4 +169,12 @@ pub trait Resources:
     ///   system.do_something(inf_resources,...)
     /// )
     fn with_infinite_ergs<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R;
+
+    /// Charge only the native resource, leaving ergs unchanged.
+    /// More efficient than `charge(&Self::from_native(...))` when only native
+    /// needs to be deducted.
+    fn charge_native_only(&mut self, native: &Self::Native) -> Result<(), SystemError> {
+        let cost = Self::from_native(native.clone());
+        self.charge(&cost)
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a `Resources::charge_native_only` trait method and `Gas::spend_native_only` to directly charge only the native (proving) resource, bypassing the ergs multiplication and ergs charge entirely. Uses this in the interpreter hot loop where the per-step cost charges only native resources (gas=0).

## Why?

The interpreter hot loop calls `spend_gas_and_native(0, STEP_NATIVE_COST)` every iteration. With gas=0, this performs unnecessary work:
- `checked_mul(0, ERGS_PER_GAS)` multiplication
- `BaseResources` construction with `Ergs(0)`
- `Ergs::charge(0)` comparison + subtraction (always a no-op)

The new `spend_native_only` path eliminates all ergs-related overhead, going directly to `self.native.charge(native)`.

This replaces the previous approach (control flow restructuring) which caused RISC-V benchmark regression. The new approach reduces actual per-iteration work instead of rearranging existing code.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs)
- [x] Code is formatted via `cargo fmt`
- [x] Tests are passing via `cargo test`
- [ ] Tests are added for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)