### PR TITLE
feat: per-opcode EVM benchmarking infrastructure

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           for dir in tests/instances/eth_runner/blocks/*; do
             blk=$(basename "$dir")
-            MARKER_PATH=$(pwd)/base_block_${blk}.bench cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" > base_block_${blk}.out
+            MARKER_PATH=$(pwd)/base_block_${blk}.bench cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" --opcode-stats > base_block_${blk}.out
           done
           MARKER_PATH=$(pwd)/base_precompiles.bench cargo test --release -j 3 --features rig/no_print,precompiles/cycle_marker,rig/unlimited_native -p precompiles -- test_precompiles
 
@@ -104,7 +104,7 @@ jobs:
             OPCODE_CYCLE_SAMPLES_DIR=$(pwd)/opcode_cycles/head_${blk} \
             OPCODE_STATS_PATH=$(pwd)/bench_results/head_block_${blk}_opcode_stats.csv \
             MARKER_PATH=$(pwd)/head_block_${blk}.bench \
-            cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" > head_block_${blk}.out
+            cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" --opcode-stats > head_block_${blk}.out
             python3 bench_scripts/parse_opcodes.py base_block_${blk}.out bench_results/base_block_${blk}.csv bench_results/base_block_${blk}.png
             python3 bench_scripts/parse_opcodes.py head_block_${blk}.out bench_results/head_block_${blk}.csv bench_results/head_block_${blk}.png
             if [ -z "$pairs" ]; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -113,6 +113,14 @@ jobs:
           pairs="${pairs},(\"precompiles\", \"base_precompiles.bench\", \"head_precompiles.bench\")"
           # Save comparison to file (for artifact + comment workflow fallback)
           python3 bench_scripts/compare_bench.py "[${pairs}]" > bench_results/comparison.md
+          # Compare per-opcode stats (gas/native/ratios). Produces no output
+          # if base branch lacks opcode stats or nothing changed.
+          for dir in tests/instances/eth_runner/blocks/*; do
+            blk=$(basename "$dir")
+            python3 bench_scripts/compare_opcode_stats.py \
+              "base_block_${blk}.out" "head_block_${blk}.out" "block_${blk}" \
+              >> bench_results/comparison.md 2>/dev/null || true
+          done
           # Also write to step output for direct comment
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "result<<$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -100,7 +100,11 @@ jobs:
           pairs=""
           for dir in tests/instances/eth_runner/blocks/*; do
             blk=$(basename "$dir")
-            MARKER_PATH=$(pwd)/head_block_${blk}.bench cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" > head_block_${blk}.out
+            OPCODE_SAMPLES_DIR=$(pwd)/opcode_samples/head_${blk} \
+            OPCODE_CYCLE_SAMPLES_DIR=$(pwd)/opcode_cycles/head_${blk} \
+            OPCODE_STATS_PATH=$(pwd)/bench_results/head_block_${blk}_opcode_stats.csv \
+            MARKER_PATH=$(pwd)/head_block_${blk}.bench \
+            cargo run --manifest-path tests/instances/eth_runner/Cargo.toml --release -j 3 --features rig/no_print,rig/cycle_marker,rig/unlimited_native -- single-run --block-dir "$dir" > head_block_${blk}.out
             python3 bench_scripts/parse_opcodes.py base_block_${blk}.out bench_results/base_block_${blk}.csv bench_results/base_block_${blk}.png
             python3 bench_scripts/parse_opcodes.py head_block_${blk}.out bench_results/head_block_${blk}.csv bench_results/head_block_${blk}.png
             if [ -z "$pairs" ]; then
@@ -126,6 +130,32 @@ jobs:
           echo "result<<$EOF" >> $GITHUB_OUTPUT
           cat bench_results/comparison.md >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
+
+      - name: Collect per-opcode artifacts
+        shell: bash
+        run: |
+          for dir in tests/instances/eth_runner/blocks/*; do
+            blk=$(basename "$dir")
+            # Combined gas+native+cycles stats CSV
+            python3 bench_scripts/join_opcode_stats.py \
+              head_block_${blk}.out head_block_${blk}.bench \
+              --csv bench_results/head_block_${blk}_joined_stats.csv 2>/dev/null || true
+            # Per-execution joined CSVs
+            if [ -d "opcode_samples/head_${blk}" ] && [ -d "opcode_cycles/head_${blk}" ]; then
+              python3 bench_scripts/join_samples.py \
+                opcode_samples/head_${blk} opcode_cycles/head_${blk} \
+                --out-dir bench_results/per_opcode/block_${blk} 2>/dev/null || true
+            fi
+          done
+          # Generate visualization charts
+          for dir in tests/instances/eth_runner/blocks/*; do
+            blk=$(basename "$dir")
+            if [ -d "bench_results/per_opcode/block_${blk}" ]; then
+              python3 bench_scripts/visualize_opcode_stats.py \
+                bench_results/per_opcode/block_${blk} \
+                --out-dir bench_results/per_opcode/block_${blk}/charts 2>/dev/null || true
+            fi
+          done
 
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > bench_results/pr_number.txt

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -21,7 +21,8 @@ pub mod public_input;
 
 /// Version byte for pubdata encoding format.
 /// Version 1: Initial versioned pubdata format
-pub const PUBDATA_ENCODING_VERSION: u8 = 1;
+/// Version 2: Remove artifacts_len and artifacts from pubdata
+pub const PUBDATA_ENCODING_VERSION: u8 = 2;
 
 /// Helper method to write the pubdata to the DA commitment generator and result keeper.
 fn write_pubdata<

--- a/basic_bootloader/src/bootloader/transaction/authorization_list.rs
+++ b/basic_bootloader/src/bootloader/transaction/authorization_list.rs
@@ -17,6 +17,7 @@ use zk_ee::system::Ergs;
 use zk_ee::system::IOSubsystem;
 use zk_ee::system::NonceError;
 use zk_ee::system::Resource;
+use zk_ee::system::SystemFunctionsExt;
 use zk_ee::system::{AccountDataRequest, EthereumLikeTypes, IOSubsystemExt, Resources, System};
 use zk_ee::system_log;
 use zk_ee::{internal_error, wrap_error};
@@ -235,8 +236,10 @@ fn recover_authority<S: EthereumLikeTypes>(
     resources: &mut S::Resources,
     auth_sig_data: (u8, &[u8], &[u8]),
     msg: &[u8; 32],
-) -> Result<Option<B160>, TxError> {
-    use zk_ee::system::SystemFunctions;
+) -> Result<Option<B160>, TxError>
+where
+    S::IO: IOSubsystemExt,
+{
     let mut ecrecover_input = [0u8; 128];
     let (parity, r, s) = auth_sig_data;
     if parity > 1 {
@@ -247,14 +250,18 @@ fn recover_authority<S: EthereumLikeTypes>(
     ecrecover_input[64..96][(32 - r.len())..].copy_from_slice(r);
     ecrecover_input[96..128][(32 - s.len())..].copy_from_slice(s);
     let mut ecrecover_output = ArrayBuilder::default();
+    let mut logger = system.get_logger();
+    let allocator = system.get_allocator();
     // Recover is counted in intrinsic gas
     resources
         .with_infinite_ergs(|inf_ergs| {
-            S::SystemFunctions::secp256k1_ec_recover(
+            S::SystemFunctionsExt::secp256k1_ec_recover(
                 ecrecover_input.as_slice(),
                 &mut ecrecover_output,
                 inf_ergs,
-                system.get_allocator(),
+                system.io.oracle(),
+                &mut logger,
+                allocator,
             )
         })
         .map_err(SystemError::from)?;

--- a/basic_bootloader/src/bootloader/transaction_flow/ethereum/validation_impl.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/ethereum/validation_impl.rs
@@ -213,14 +213,18 @@ where
 
         let mut ecrecover_output = ArrayBuilder::default();
         // We already charged gas for ecrecover in intrinsic cost, so we only need to charge native resources here.
+        let mut logger = system.get_logger();
+        let allocator = system.get_allocator();
         tx_resources
             .main_resources
             .with_infinite_ergs(|resources| {
-                S::SystemFunctions::secp256k1_ec_recover(
+                S::SystemFunctionsExt::secp256k1_ec_recover(
                     ecrecover_input.as_slice(),
                     &mut ecrecover_output,
                     resources,
-                    system.get_allocator(),
+                    system.io.oracle(),
+                    &mut logger,
+                    allocator,
                 )
                 .map_err(SystemError::from)
             })?;

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
@@ -25,7 +25,7 @@ use zk_ee::system::metadata::zk_metadata::TxLevelMetadata;
 use zk_ee::system::resources::Computational;
 use zk_ee::system::tracer::Tracer;
 use zk_ee::system::{errors::system::SystemError, EthereumLikeTypes, System};
-use zk_ee::system::{AccountDataRequest, SystemFunctions};
+use zk_ee::system::{AccountDataRequest, SystemFunctionsExt};
 use zk_ee::system::{Ergs, IOSubsystemExt, Resources};
 use zk_ee::system::{IOSubsystem, NonceError};
 use zk_ee::system::{Resource, SystemTypes};
@@ -201,14 +201,18 @@ where
 
             let mut ecrecover_output = ArrayBuilder::default();
             // We already charged gas for ecrecover in intrinsic cost, so we only need to charge native resources here.
+            let mut logger = system.get_logger();
+            let allocator = system.get_allocator();
             tx_resources
                 .main_resources
                 .with_infinite_ergs(|resources| {
-                    S::SystemFunctions::secp256k1_ec_recover(
+                    S::SystemFunctionsExt::secp256k1_ec_recover(
                         ecrecover_input.as_slice(),
                         &mut ecrecover_output,
                         resources,
-                        system.get_allocator(),
+                        system.io.oracle(),
+                        &mut logger,
+                        allocator,
                     )
                     .map_err(SystemError::from)
                 })?;

--- a/basic_system/Cargo.toml
+++ b/basic_system/Cargo.toml
@@ -44,6 +44,8 @@ proptest = { workspace = true }
 crypto = { path = "../crypto", default-features = false, features = ["secp256k1-static-context", "testing"]}
 num-bigint = { workspace = true, default-features = true }
 num-traits = { workspace = true, default-features = true }
+callable_oracles = { path = "../callable_oracles" }
+oracle_provider = { path = "../oracle_provider" }
 arbitrary = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }
 alloy-rpc-types-debug = { workspace = true }

--- a/basic_system/src/system_functions/ecrecover.rs
+++ b/basic_system/src/system_functions/ecrecover.rs
@@ -1,44 +1,62 @@
 use super::*;
 use crate::cost_constants::{ECRECOVER_COST_ERGS, ECRECOVER_NATIVE_COST};
+use crypto::secp256k1::hooks::DefaultSecp256k1Hooks;
+use field_ops::Secp256k1HooksWithOracle;
 use zk_ee::common_traits::TryExtend;
+use zk_ee::oracle::IOOracle;
 use zk_ee::out_of_return_memory;
-use zk_ee::system::base_system_functions::{Secp256k1ECRecoverErrors, SystemFunction};
+use zk_ee::system::base_system_functions::Secp256k1ECRecoverErrors;
 use zk_ee::system::errors::{subsystem::SubsystemError, system::SystemError};
-use zk_ee::system::Computational;
+use zk_ee::system::{Computational, SystemFunctionExt};
 
 ///
 /// ecrecover system function implementation.
 ///
-pub struct EcRecoverImpl;
+pub struct EcRecoverImpl<const USE_ADVICE: bool = { cfg!(target_arch = "riscv32") }>;
 
-impl<R: Resources> SystemFunction<R, Secp256k1ECRecoverErrors> for EcRecoverImpl {
+impl<R: Resources, const USE_ADVICE: bool> SystemFunctionExt<R, Secp256k1ECRecoverErrors>
+    for EcRecoverImpl<USE_ADVICE>
+{
     /// If the input size is less than expected - it will be padded with zeroes.
     /// If the input size is greater - redundant bytes will be ignored.
     /// If the input is invalid(v != 27|28 or failed to recover signer) returns `Ok(0)`.
     ///
     /// Returns `OutOfGas` if not enough resources provided.
-    fn execute<D: TryExtend<u8> + ?Sized, A: core::alloc::Allocator + Clone>(
+    fn execute<O: IOOracle, L, D: TryExtend<u8> + ?Sized, A: core::alloc::Allocator + Clone>(
         input: &[u8],
         output: &mut D,
         resources: &mut R,
+        oracle: &mut O,
+        _logger: &mut L,
         _allocator: A,
     ) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
         Ok(cycle_marker::wrap_with_resources!(
             "ecrecover",
             resources,
-            { ecrecover_as_system_function_inner(input, output, resources) }
+            {
+                ecrecover_as_system_function_inner::<_, _, _, _, USE_ADVICE>(
+                    input,
+                    output,
+                    resources,
+                    Some(oracle),
+                )
+            }
         )?)
     }
 }
 
+// if the oracle is provided, it will be used for field operations
 fn ecrecover_as_system_function_inner<
+    O: IOOracle,
     S: ?Sized + MinimalByteAddressableSlice,
     D: ?Sized + TryExtend<u8>,
     R: Resources,
+    const USE_ADVICE: bool,
 >(
     src: &S,
     dst: &mut D,
     resources: &mut R,
+    oracle: Option<&mut O>,
 ) -> Result<(), SystemError> {
     resources.charge(&R::from_ergs_and_native(
         ECRECOVER_COST_ERGS,
@@ -68,7 +86,9 @@ fn ecrecover_as_system_function_inner<
             return Ok(());
         }
 
-        let Ok(pk_bytes) = ecrecover_inner(digest, r, s, rec_id) else {
+        let oracle = if USE_ADVICE { oracle } else { None };
+
+        let Ok(pk_bytes) = ecrecover_inner(digest, r, s, rec_id, oracle) else {
             return Ok(());
         };
 
@@ -85,11 +105,12 @@ fn ecrecover_as_system_function_inner<
     Ok(())
 }
 
-pub fn ecrecover_inner(
+pub fn ecrecover_inner<O: IOOracle>(
     digest: &[u8; 32],
     r: &[u8; 32],
     s: &[u8; 32],
     rec_id: u8,
+    oracle: Option<&mut O>,
 ) -> Result<crypto::k256::EncodedPoint, ()> {
     use crypto::k256::{
         ecdsa::{hazmat::bits2field, RecoveryId, Signature},
@@ -104,7 +125,22 @@ pub fn ecrecover_inner(
         &bits2field::<crypto::k256::Secp256k1>(digest).map_err(|_| ())?,
     );
 
-    let Ok(pk) = crypto::secp256k1::recover(&message, &signature, &recovery_id) else {
+    let res = match oracle {
+        Some(oracle) => crypto::secp256k1::recover(
+            &message,
+            &signature,
+            &recovery_id,
+            &mut Secp256k1HooksWithOracle::new(oracle),
+        ),
+        None => crypto::secp256k1::recover(
+            &message,
+            &signature,
+            &recovery_id,
+            &mut DefaultSecp256k1Hooks,
+        ),
+    };
+
+    let Ok(pk) = res else {
         return Err(());
     };
 
@@ -117,6 +153,7 @@ pub fn ecrecover_inner(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::system_implementation::flat_storage_model::TestingTree;
     use hex;
     use zk_ee::reference_implementations::BaseResources;
     use zk_ee::reference_implementations::DecreasingNative;
@@ -140,8 +177,13 @@ mod test {
 
         let mut resources = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
 
-        ecrecover_as_system_function_inner(input.as_slice(), &mut pubkey, &mut resources)
-            .expect("ecrecover");
+        ecrecover_as_system_function_inner::<TestingTree<false>, _, _, _, false>(
+            input.as_slice(),
+            &mut pubkey,
+            &mut resources,
+            None,
+        )
+        .expect("ecrecover");
         assert_eq!(pubkey.len(), 32, "Size should be 32");
         assert_eq!(
             pubkey, expected_pubkey,
@@ -156,8 +198,13 @@ mod test {
 
         let mut resources = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
 
-        ecrecover_as_system_function_inner(input.as_slice(), &mut pubkey, &mut resources)
-            .expect("ecrecover");
+        ecrecover_as_system_function_inner::<TestingTree<false>, _, _, _, false>(
+            input.as_slice(),
+            &mut pubkey,
+            &mut resources,
+            None,
+        )
+        .expect("ecrecover");
         assert_eq!(pubkey.len(), 0, "Size should be 0");
     }
 
@@ -173,8 +220,13 @@ mod test {
 
         let mut resources = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
 
-        ecrecover_as_system_function_inner(input.as_slice(), &mut pubkey, &mut resources)
-            .expect("ecrecover");
+        ecrecover_as_system_function_inner::<TestingTree<false>, _, _, _, false>(
+            input.as_slice(),
+            &mut pubkey,
+            &mut resources,
+            None,
+        )
+        .expect("ecrecover");
         assert_eq!(pubkey.len(), 0, "Size should be 0 in case of error");
     }
 
@@ -190,8 +242,13 @@ mod test {
 
         let mut resources = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
 
-        ecrecover_as_system_function_inner(input.as_slice(), &mut pubkey, &mut resources)
-            .expect("ecrecover");
+        ecrecover_as_system_function_inner::<TestingTree<false>, _, _, _, false>(
+            input.as_slice(),
+            &mut pubkey,
+            &mut resources,
+            None,
+        )
+        .expect("ecrecover");
         assert_eq!(pubkey.len(), 0, "Size should be 0 in case of error");
     }
 
@@ -213,9 +270,13 @@ mod test {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 249, 114, 95, 16, 115, 88, 201, 17, 91, 201,
             216, 108, 114, 221, 88, 35, 233, 177, 230,
         ];
-
-        ecrecover_as_system_function_inner(input.as_slice(), &mut pubkey, &mut resources)
-            .expect("ecrecover");
+        ecrecover_as_system_function_inner::<TestingTree<false>, _, _, _, false>(
+            input.as_slice(),
+            &mut pubkey,
+            &mut resources,
+            None,
+        )
+        .expect("ecrecover");
         assert_eq!(pubkey.len(), 32, "Size should be 32");
         assert_eq!(
             pubkey, expected_pubkey,

--- a/basic_system/src/system_functions/field_ops.rs
+++ b/basic_system/src/system_functions/field_ops.rs
@@ -1,0 +1,701 @@
+//! Query for field operations hints, such as square root and inverse in secp256k1 fields together with their use for implementing secp256k1 hooks.
+
+use crypto::secp256k1::{FieldElement, Scalar};
+use zk_ee::{
+    oracle::{query_ids::ADVICE_SUBSPACE_MASK, usize_serialization::UsizeDeserializable, IOOracle},
+    utils::Bytes32,
+};
+
+pub const FIELD_OPS_ADVISE_QUERY_ID: u32 = ADVICE_SUBSPACE_MASK | 0x11;
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct GenericFieldOpsHint<W> {
+    pub op: u32,
+    pub src_ptr: W,
+    pub src_len_u32_words: u32,
+}
+
+pub type FieldOpsHint = GenericFieldOpsHint<u32>;
+pub type FieldOpsHint64 = GenericFieldOpsHint<u64>;
+
+#[repr(u32)]
+#[non_exhaustive]
+pub enum FieldHintOp {
+    Secp256k1BaseFieldSqrt = 0,
+    Secp256k1BaseFieldInverse,
+    Secp256k1ScalarFieldInverse,
+}
+
+impl FieldHintOp {
+    pub fn parse_u32(value: u32) -> Option<Self> {
+        match value {
+            a if a == (Self::Secp256k1BaseFieldSqrt as u32) => Some(Self::Secp256k1BaseFieldSqrt),
+            a if a == (Self::Secp256k1BaseFieldInverse as u32) => {
+                Some(Self::Secp256k1BaseFieldInverse)
+            }
+            a if a == (Self::Secp256k1ScalarFieldInverse as u32) => {
+                Some(Self::Secp256k1ScalarFieldInverse)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Secp256k1 hooks implementation that uses an IOOracle for field operations.
+pub struct Secp256k1HooksWithOracle<'a, O: IOOracle> {
+    oracle: &'a mut O,
+}
+
+impl<'a, O: IOOracle> Secp256k1HooksWithOracle<'a, O> {
+    pub fn new(oracle: &'a mut O) -> Self {
+        Self { oracle }
+    }
+}
+
+impl<'a, O: IOOracle> crypto::secp256k1::hooks::Secp256k1Hooks for Secp256k1HooksWithOracle<'a, O> {
+    fn fe_sqrt_and_assign(&mut self, x: &mut FieldElement) -> bool {
+        // Match default hook semantics: sqrt(0) exists and equals 0.
+        if x.normalizes_to_zero() {
+            return true;
+        }
+
+        let input = Bytes32::from_array(x.to_bytes().into());
+        let (sqrt_candidate, is_quadratic_non_residue): (Bytes32, bool) =
+            self.query_field_op(FieldHintOp::Secp256k1BaseFieldSqrt, &input);
+
+        // Answer must be a valid field element
+        let fe = FieldElement::from_bytes(sqrt_candidate.as_u8_array_ref()).unwrap();
+
+        // Verify the oracle's hint is correct.
+        // The oracle computes candidate = x^((p+1)/4). For secp256k1's prime p ≡ 3 (mod 4):
+        // - If x is a quadratic residue (has a sqrt): candidate² == x
+        // - If x is a quadratic non-residue (no sqrt): candidate² == -x
+        let mut squared = fe;
+        squared.square_in_place();
+        if is_quadratic_non_residue == false {
+            squared.sub_in_place(&x);
+            assert!(squared.normalizes_to_zero()); // candidate² - x == 0
+        } else {
+            squared.add_in_place(&x);
+            assert!(squared.normalizes_to_zero()); // candidate² + x == 0  (i.e., candidate² == -x)
+        }
+
+        *x = fe;
+        // Return true if square root exists (x is a quadratic residue)
+        !is_quadratic_non_residue
+    }
+
+    fn fe_invert_and_assign(&mut self, x: &mut crypto::secp256k1::FieldElement) {
+        // Match default hook semantics: invert(0) == 0.
+        if x.normalizes_to_zero() {
+            return;
+        }
+
+        let input = Bytes32::from_array(x.to_bytes().into());
+        let inv: Bytes32 = self.query_field_op(FieldHintOp::Secp256k1BaseFieldInverse, &input);
+
+        // answer must be a field element
+        let inv = FieldElement::from_bytes(inv.as_u8_array_ref()).unwrap();
+
+        // we must check that hint was correct
+        let mut t = *x;
+        t *= inv;
+        t.sub_in_place(&FieldElement::ONE);
+        assert!(t.normalizes_to_zero());
+
+        *x = inv;
+    }
+
+    fn scalar_invert_and_assign(&mut self, x: &mut crypto::secp256k1::Scalar) {
+        // Match default hook semantics: invert(0) == 0.
+        if x.is_zero() {
+            return;
+        }
+
+        let input = Bytes32::from_array(x.to_repr().into());
+        let inverse: Bytes32 =
+            self.query_field_op(FieldHintOp::Secp256k1ScalarFieldInverse, &input);
+
+        // answer is must be a field element
+        use crypto::k256::elliptic_curve::scalar::FromUintUnchecked;
+        use crypto::k256::elliptic_curve::Curve;
+        use crypto::k256::U256;
+
+        let inverse = U256::from_be_slice(inverse.as_u8_array_ref());
+        assert!(inverse < crypto::k256::Secp256k1::ORDER);
+        let inverse: Scalar =
+            Scalar::from_k256_scalar(crypto::k256::Scalar::from_uint_unchecked(inverse));
+        let mut t = *x;
+        t *= inverse;
+        t = t - Scalar::ONE;
+        assert!(t.is_zero());
+
+        *x = inverse;
+    }
+}
+
+impl<'a, O: IOOracle> Secp256k1HooksWithOracle<'a, O> {
+    fn query_field_op<R: UsizeDeserializable>(&mut self, op: FieldHintOp, input: &Bytes32) -> R {
+        // We use different advice params depending on architecture
+        // They are mostly the same, main difference is the width of pointers
+        #[cfg(target_arch = "riscv32")]
+        let r: R = {
+            let hint_request = FieldOpsHint {
+                op: op as u32,
+                src_ptr: input.as_u8_array_ref().as_ptr().addr() as u32,
+                src_len_u32_words: 8,
+            };
+            self.oracle
+                .query_serializable(
+                    FIELD_OPS_ADVISE_QUERY_ID,
+                    &((&hint_request as *const FieldOpsHint).addr() as u32),
+                )
+                .unwrap()
+        };
+        #[cfg(not(target_arch = "riscv32"))]
+        let r: R = {
+            let hint_request = FieldOpsHint64 {
+                op: op as u32,
+                src_ptr: input.as_u8_array_ref().as_ptr().addr() as u64,
+                src_len_u32_words: 8,
+            };
+            self.oracle
+                .query_serializable(
+                    FIELD_OPS_ADVISE_QUERY_ID,
+                    &((&hint_request as *const FieldOpsHint64).addr() as u64),
+                )
+                .unwrap()
+        };
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use callable_oracles::field_hints::NativeFieldOpsQuery;
+    use crypto::secp256k1::hooks::{DefaultSecp256k1Hooks, Secp256k1Hooks};
+    use oracle_provider::{DummyMemorySource, ZkEENonDeterminismSource};
+    use proptest::{prop_assert_eq, proptest};
+
+    fn create_oracle_with_field_ops() -> ZkEENonDeterminismSource<DummyMemorySource> {
+        let mut oracle = ZkEENonDeterminismSource::<DummyMemorySource>::default();
+        oracle.add_external_processor(NativeFieldOpsQuery::<DummyMemorySource>::default());
+        oracle
+    }
+
+    #[test]
+    fn test_fe_sqrt_oracle_matches_default() {
+        proptest!(|(bytes: [u8; 32])| {
+            let Some(fe) = FieldElement::from_bytes(&bytes) else {
+                return Ok(());
+            };
+            if fe.normalizes_to_zero() {
+                return Ok(());
+            }
+
+            let mut fe_default = fe;
+            let result_default = DefaultSecp256k1Hooks.fe_sqrt_and_assign(&mut fe_default);
+
+            let mut oracle = create_oracle_with_field_ops();
+            let mut fe_oracle = fe;
+            let result_oracle = Secp256k1HooksWithOracle::new(&mut oracle)
+                .fe_sqrt_and_assign(&mut fe_oracle);
+
+            prop_assert_eq!(result_default, result_oracle, "sqrt existence should match");
+            prop_assert_eq!(fe_default.to_bytes(), fe_oracle.to_bytes(), "sqrt values should match");
+        });
+    }
+
+    #[test]
+    fn test_fe_invert_oracle_matches_default() {
+        proptest!(|(bytes: [u8; 32])| {
+            let Some(fe) = FieldElement::from_bytes(&bytes) else {
+                return Ok(());
+            };
+            if fe.normalizes_to_zero() {
+                return Ok(());
+            }
+
+            let mut fe_default = fe;
+            DefaultSecp256k1Hooks.fe_invert_and_assign(&mut fe_default);
+
+            let mut oracle = create_oracle_with_field_ops();
+            let mut fe_oracle = fe;
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe_oracle);
+
+            prop_assert_eq!(fe_default.to_bytes(), fe_oracle.to_bytes(), "inverse values should match");
+        });
+    }
+
+    #[test]
+    fn test_scalar_invert_oracle_matches_default() {
+        proptest!(|(bytes: [u8; 32])| {
+            use crypto::k256::elliptic_curve::scalar::FromUintUnchecked;
+            use crypto::k256::elliptic_curve::Curve;
+            use crypto::k256::U256;
+
+            let val = U256::from_be_slice(&bytes);
+            if val >= crypto::k256::Secp256k1::ORDER || val == U256::ZERO {
+                return Ok(());
+            }
+
+            let scalar = Scalar::from_k256_scalar(
+                crypto::k256::Scalar::from_uint_unchecked(val)
+            );
+
+            let mut scalar_default = scalar;
+            DefaultSecp256k1Hooks.scalar_invert_and_assign(&mut scalar_default);
+
+            let mut oracle = create_oracle_with_field_ops();
+            let mut scalar_oracle = scalar;
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar_oracle);
+
+            prop_assert_eq!(scalar_default.to_repr(), scalar_oracle.to_repr(), "scalar inverse values should match");
+        });
+    }
+
+    /// Tests that verify the validation logic catches lying oracles.
+    /// These tests ensure that incorrect oracle responses are rejected.
+    mod malicious_oracle_tests {
+        use super::*;
+        use oracle_provider::{MemorySource, OracleQueryProcessor};
+        use proptest::prop_assert;
+
+        /// Ways to corrupt oracle responses
+        enum Corruption {
+            /// Return all zeros
+            ReturnZero,
+            /// Flip the least significant bit of the result
+            FlipLsb,
+            /// Add 1 to the result (wrapping)
+            AddOne,
+            /// Return a fixed arbitrary value
+            ReturnArbitrary([u8; 32]),
+        }
+
+        impl Corruption {
+            fn apply(&self, data: &mut [u8]) {
+                match self {
+                    Corruption::ReturnZero => data.fill(0),
+                    Corruption::FlipLsb => {
+                        if !data.is_empty() {
+                            data[data.len() - 1] ^= 1;
+                        }
+                    }
+                    Corruption::AddOne => {
+                        // Add 1 with carry propagation (big-endian)
+                        let mut carry = 1u16;
+                        for byte in data.iter_mut().rev() {
+                            let sum = *byte as u16 + carry;
+                            *byte = sum as u8;
+                            carry = sum >> 8;
+                        }
+                    }
+                    Corruption::ReturnArbitrary(val) => {
+                        data.copy_from_slice(val);
+                    }
+                }
+            }
+        }
+
+        /// A malicious oracle processor that wraps a correct one and corrupts its output
+        struct LyingFieldOpsQuery<M: MemorySource> {
+            inner: callable_oracles::field_hints::NativeFieldOpsQuery<M>,
+            corruption: Corruption,
+            /// If set, lie about sqrt existence (flip the boolean)
+            lie_about_sqrt_existence: bool,
+        }
+
+        impl<M: MemorySource> LyingFieldOpsQuery<M> {
+            fn new(corruption: Corruption) -> Self {
+                Self {
+                    inner: callable_oracles::field_hints::NativeFieldOpsQuery::default(),
+                    corruption,
+                    lie_about_sqrt_existence: false,
+                }
+            }
+
+            fn with_sqrt_existence_lie(mut self) -> Self {
+                self.lie_about_sqrt_existence = true;
+                self
+            }
+        }
+
+        impl<M: MemorySource> OracleQueryProcessor<M> for LyingFieldOpsQuery<M> {
+            fn supported_query_ids(&self) -> Vec<u32> {
+                self.inner.supported_query_ids()
+            }
+
+            fn process_buffered_query(
+                &mut self,
+                query_id: u32,
+                query: Vec<usize>,
+                memory: &M,
+            ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+                // Get the correct response
+                let correct_iter = self.inner.process_buffered_query(query_id, query, memory);
+                let correct_response: Vec<usize> = correct_iter.collect();
+
+                // Determine if this is a sqrt query (returns Bytes32 + bool) or inverse query (returns Bytes32)
+                // sqrt response: 4 usize for Bytes32 + 1 usize for bool = 5 usize
+                // inverse response: 4 usize for Bytes32 = 4 usize
+                let is_sqrt_query = correct_response.len() == 5;
+
+                let mut corrupted = correct_response.clone();
+
+                if is_sqrt_query && self.lie_about_sqrt_existence {
+                    // Flip the boolean (last element)
+                    corrupted[4] ^= 1;
+                } else {
+                    // Corrupt the Bytes32 result (first 4 usize = 32 bytes)
+                    let mut bytes = [0u8; 32];
+                    for (i, &word) in corrupted[..4].iter().enumerate() {
+                        bytes[i * 8..(i + 1) * 8].copy_from_slice(&word.to_le_bytes());
+                    }
+                    self.corruption.apply(&mut bytes);
+                    for (i, chunk) in bytes.chunks(8).enumerate() {
+                        corrupted[i] = usize::from_le_bytes(chunk.try_into().unwrap());
+                    }
+                }
+
+                Box::new(corrupted.into_iter())
+            }
+        }
+
+        fn create_lying_oracle(
+            corruption: Corruption,
+        ) -> ZkEENonDeterminismSource<DummyMemorySource> {
+            let mut oracle = ZkEENonDeterminismSource::<DummyMemorySource>::default();
+            oracle.add_external_processor(LyingFieldOpsQuery::<DummyMemorySource>::new(corruption));
+            oracle
+        }
+
+        fn create_sqrt_existence_lying_oracle() -> ZkEENonDeterminismSource<DummyMemorySource> {
+            let mut oracle = ZkEENonDeterminismSource::<DummyMemorySource>::default();
+            oracle.add_external_processor(
+                LyingFieldOpsQuery::<DummyMemorySource>::new(Corruption::ReturnZero)
+                    .with_sqrt_existence_lie(),
+            );
+            oracle
+        }
+
+        // A known valid field element for testing (small value, definitely in field)
+        fn test_field_element() -> FieldElement {
+            let mut bytes = [0u8; 32];
+            bytes[31] = 7; // Small non-zero value
+            FieldElement::from_bytes(&bytes).unwrap()
+        }
+
+        fn test_scalar() -> Scalar {
+            use crypto::k256::elliptic_curve::scalar::FromUintUnchecked;
+            let mut bytes = [0u8; 32];
+            bytes[31] = 7;
+            Scalar::from_k256_scalar(crypto::k256::Scalar::from_uint_unchecked(
+                crypto::k256::U256::from_be_slice(&bytes),
+            ))
+        }
+
+        // ============ fe_invert tests ============
+
+        #[test]
+        #[should_panic]
+        fn test_fe_invert_rejects_zero_answer() {
+            let mut oracle = create_lying_oracle(Corruption::ReturnZero);
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_fe_invert_rejects_flipped_bit() {
+            let mut oracle = create_lying_oracle(Corruption::FlipLsb);
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_fe_invert_rejects_off_by_one() {
+            let mut oracle = create_lying_oracle(Corruption::AddOne);
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_fe_invert_rejects_arbitrary_value() {
+            let arbitrary = [0x42u8; 32];
+            let mut oracle = create_lying_oracle(Corruption::ReturnArbitrary(arbitrary));
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe);
+        }
+
+        // ============ fe_sqrt tests ============
+
+        #[test]
+        #[should_panic]
+        fn test_fe_sqrt_rejects_wrong_sqrt_value() {
+            let mut oracle = create_lying_oracle(Corruption::FlipLsb);
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_sqrt_and_assign(&mut fe);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_fe_sqrt_rejects_zero_answer() {
+            let mut oracle = create_lying_oracle(Corruption::ReturnZero);
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_sqrt_and_assign(&mut fe);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_fe_sqrt_rejects_lie_about_existence() {
+            // This test uses an oracle that returns the correct sqrt value but lies
+            // about whether a sqrt exists (flips the boolean)
+            let mut oracle = create_sqrt_existence_lying_oracle();
+            let mut fe = test_field_element();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_sqrt_and_assign(&mut fe);
+        }
+
+        // ============ scalar_invert tests ============
+
+        #[test]
+        #[should_panic]
+        fn test_scalar_invert_rejects_zero_answer() {
+            let mut oracle = create_lying_oracle(Corruption::ReturnZero);
+            let mut scalar = test_scalar();
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_scalar_invert_rejects_flipped_bit() {
+            let mut oracle = create_lying_oracle(Corruption::FlipLsb);
+            let mut scalar = test_scalar();
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_scalar_invert_rejects_off_by_one() {
+            let mut oracle = create_lying_oracle(Corruption::AddOne);
+            let mut scalar = test_scalar();
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_scalar_invert_rejects_arbitrary_value() {
+            let arbitrary = [0x42u8; 32];
+            let mut oracle = create_lying_oracle(Corruption::ReturnArbitrary(arbitrary));
+            let mut scalar = test_scalar();
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar);
+        }
+
+        // ============ Proptest: random corruptions should be rejected ============
+
+        #[test]
+        fn test_fe_invert_rejects_random_corruptions() {
+            proptest!(|(bytes: [u8; 32], corruption_bytes: [u8; 32])| {
+                let Some(fe) = FieldElement::from_bytes(&bytes) else {
+                    return Ok(());
+                };
+                if fe.normalizes_to_zero() {
+                    return Ok(());
+                }
+
+                // Get the correct inverse first
+                let mut correct_fe = fe;
+                let mut correct_oracle = create_oracle_with_field_ops();
+                Secp256k1HooksWithOracle::new(&mut correct_oracle).fe_invert_and_assign(&mut correct_fe);
+                let correct_inverse = correct_fe.to_bytes();
+
+                // Skip if random corruption happens to equal the correct answer
+                if corruption_bytes == *correct_inverse {
+                    return Ok(());
+                }
+
+                // Now try with the corrupted oracle
+                let mut lying_oracle = create_lying_oracle(Corruption::ReturnArbitrary(corruption_bytes));
+                let mut test_fe = fe;
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    Secp256k1HooksWithOracle::new(&mut lying_oracle).fe_invert_and_assign(&mut test_fe);
+                }));
+
+                // The validation should have caught the lie (panicked)
+                prop_assert!(result.is_err(), "Oracle lie was not detected for input {:?}", bytes);
+            });
+        }
+
+        #[test]
+        fn test_scalar_invert_rejects_random_corruptions() {
+            proptest!(|(bytes: [u8; 32], corruption_bytes: [u8; 32])| {
+                use crypto::k256::elliptic_curve::scalar::FromUintUnchecked;
+                use crypto::k256::elliptic_curve::Curve;
+                use crypto::k256::U256;
+
+                let val = U256::from_be_slice(&bytes);
+                if val >= crypto::k256::Secp256k1::ORDER || val == U256::ZERO {
+                    return Ok(());
+                }
+
+                let scalar = Scalar::from_k256_scalar(
+                    crypto::k256::Scalar::from_uint_unchecked(val)
+                );
+
+                // Get the correct inverse first
+                let mut correct_scalar = scalar;
+                let mut correct_oracle = create_oracle_with_field_ops();
+                Secp256k1HooksWithOracle::new(&mut correct_oracle).scalar_invert_and_assign(&mut correct_scalar);
+                let correct_inverse = correct_scalar.to_repr();
+
+                // Skip if random corruption happens to equal the correct answer
+                if corruption_bytes == *correct_inverse {
+                    return Ok(());
+                }
+
+                // Also skip if corruption_bytes >= ORDER (would fail earlier validation)
+                let corruption_val = U256::from_be_slice(&corruption_bytes);
+                if corruption_val >= crypto::k256::Secp256k1::ORDER {
+                    return Ok(());
+                }
+
+                // Now try with the corrupted oracle
+                let mut lying_oracle = create_lying_oracle(Corruption::ReturnArbitrary(corruption_bytes));
+                let mut test_scalar = scalar;
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    Secp256k1HooksWithOracle::new(&mut lying_oracle).scalar_invert_and_assign(&mut test_scalar);
+                }));
+
+                // The validation should have caught the lie (panicked)
+                prop_assert!(result.is_err(), "Oracle lie was not detected for input {:?}", bytes);
+            });
+        }
+
+        #[test]
+        fn test_fe_sqrt_rejects_random_corruptions() {
+            proptest!(|(bytes: [u8; 32], corruption_bytes: [u8; 32], flip_bool: bool)| {
+                let Some(fe) = FieldElement::from_bytes(&bytes) else {
+                    return Ok(());
+                };
+                if fe.normalizes_to_zero() {
+                    return Ok(());
+                }
+
+                // Get the correct result first
+                let mut correct_fe = fe;
+                let mut correct_oracle = create_oracle_with_field_ops();
+                let correct_exists = Secp256k1HooksWithOracle::new(&mut correct_oracle)
+                    .fe_sqrt_and_assign(&mut correct_fe);
+                let correct_sqrt = correct_fe.to_bytes();
+
+                // Test 1: Corrupt the sqrt candidate value
+                // Skip if random corruption happens to equal the correct answer
+                if corruption_bytes != *correct_sqrt {
+                    let mut lying_oracle = create_lying_oracle(Corruption::ReturnArbitrary(corruption_bytes));
+                    let mut test_fe = fe;
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        Secp256k1HooksWithOracle::new(&mut lying_oracle).fe_sqrt_and_assign(&mut test_fe);
+                    }));
+
+                    // The validation should have caught the lie (panicked)
+                    prop_assert!(result.is_err(),
+                        "Oracle lie about sqrt candidate was not detected for input {:?}", bytes);
+                }
+
+                // Test 2: Lie about sqrt existence (flip the boolean)
+                // Only test if flip_bool is true to reduce test cases
+                if flip_bool {
+                    let mut lying_oracle = create_sqrt_existence_lying_oracle();
+                    let mut test_fe = fe;
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        Secp256k1HooksWithOracle::new(&mut lying_oracle).fe_sqrt_and_assign(&mut test_fe);
+                    }));
+
+                    // The validation should have caught the lie about existence (panicked)
+                    prop_assert!(result.is_err(),
+                        "Oracle lie about sqrt existence was not detected for input {:?} (is_qr={})",
+                        bytes, correct_exists);
+                }
+            });
+        }
+    }
+
+    mod zero_input_regression_tests {
+        use super::*;
+        use oracle_provider::{
+            DummyMemorySource, MemorySource, OracleQueryProcessor, ZkEENonDeterminismSource,
+        };
+
+        /// A processor that should never be reached in these tests.
+        /// Zero-input hook behavior is expected to short-circuit before oracle queries.
+        struct PanickingFieldOpsQuery;
+
+        impl<M: MemorySource> OracleQueryProcessor<M> for PanickingFieldOpsQuery {
+            fn supported_query_ids(&self) -> Vec<u32> {
+                vec![FIELD_OPS_ADVISE_QUERY_ID]
+            }
+
+            fn process_buffered_query(
+                &mut self,
+                query_id: u32,
+                _query: Vec<usize>,
+                _memory: &M,
+            ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+                panic!("field ops oracle should not be queried for zero input, query_id=0x{query_id:08x}");
+            }
+        }
+
+        fn create_panicking_field_ops_oracle() -> ZkEENonDeterminismSource<DummyMemorySource> {
+            let mut oracle = ZkEENonDeterminismSource::<DummyMemorySource>::default();
+            oracle.add_external_processor(PanickingFieldOpsQuery);
+            oracle
+        }
+
+        fn zero_field_element() -> FieldElement {
+            FieldElement::from_bytes(&[0u8; 32]).expect("zero is a valid field element")
+        }
+
+        #[test]
+        fn test_fe_invert_zero_does_not_query_oracle() {
+            let mut fe_default = zero_field_element();
+            DefaultSecp256k1Hooks.fe_invert_and_assign(&mut fe_default);
+            assert!(fe_default.normalizes_to_zero());
+
+            let mut fe_oracle = zero_field_element();
+            let mut oracle = create_panicking_field_ops_oracle();
+            Secp256k1HooksWithOracle::new(&mut oracle).fe_invert_and_assign(&mut fe_oracle);
+            assert!(fe_oracle.normalizes_to_zero());
+        }
+
+        #[test]
+        fn test_scalar_invert_zero_does_not_query_oracle() {
+            let mut scalar_default = Scalar::ZERO;
+            DefaultSecp256k1Hooks.scalar_invert_and_assign(&mut scalar_default);
+            assert!(scalar_default.is_zero());
+
+            let mut scalar_oracle = Scalar::ZERO;
+            let mut oracle = create_panicking_field_ops_oracle();
+            Secp256k1HooksWithOracle::new(&mut oracle).scalar_invert_and_assign(&mut scalar_oracle);
+            assert!(scalar_oracle.is_zero());
+        }
+
+        #[test]
+        fn test_fe_sqrt_zero_does_not_query_oracle_and_matches_default() {
+            let mut fe_default = zero_field_element();
+            let exists_default = DefaultSecp256k1Hooks.fe_sqrt_and_assign(&mut fe_default);
+            assert!(exists_default);
+            assert!(fe_default.normalizes_to_zero());
+
+            let mut fe_oracle = zero_field_element();
+            let mut oracle = create_panicking_field_ops_oracle();
+            let exists_oracle =
+                Secp256k1HooksWithOracle::new(&mut oracle).fe_sqrt_and_assign(&mut fe_oracle);
+            assert!(exists_oracle);
+            assert!(fe_oracle.normalizes_to_zero());
+        }
+    }
+}

--- a/basic_system/src/system_functions/mod.rs
+++ b/basic_system/src/system_functions/mod.rs
@@ -6,6 +6,7 @@ pub mod bn254_ecadd;
 pub mod bn254_ecmul;
 pub mod bn254_pairing_check;
 pub mod ecrecover;
+pub mod field_ops;
 pub mod keccak256;
 pub mod modexp;
 pub mod p256_verify;
@@ -34,7 +35,6 @@ pub struct NoStdSystemFunctions;
 impl<R: Resources> SystemFunctions<R> for NoStdSystemFunctions {
     type Keccak256 = keccak256::Keccak256Impl;
     type Sha256 = sha256::Sha256Impl;
-    type Secp256k1ECRecover = ecrecover::EcRecoverImpl;
     type Secp256k1AddProjective = MissingSystemFunction;
     type Secp256k1MulProjective = MissingSystemFunction;
     type Secp256r1AddProjective = MissingSystemFunction;
@@ -48,5 +48,6 @@ impl<R: Resources> SystemFunctions<R> for NoStdSystemFunctions {
 }
 
 impl<R: Resources> SystemFunctionsExt<R> for NoStdSystemFunctions {
+    type Secp256k1ECRecover = ecrecover::EcRecoverImpl;
     type ModExp = modexp::ModExpImpl;
 }

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
@@ -244,7 +244,6 @@ impl AccountProperties {
                     + ValueDiffCompressionStrategy::optimal_compression_length_u256(initial.nonce.try_into().map_err(|_| internal_error!("u64 into U256"))?, r#final.nonce.try_into().map_err(|_| internal_error!("u64 into U256"))?) as u32 // nonce diff
                     + ValueDiffCompressionStrategy::optimal_compression_length_u256_optional(initial.balance, r#final.balance, not_compress_balance) as u32 // balance diff
                     + 32 // bytecode hash
-                    + 4 // artifacts len
                     + 4 // observable bytecode len
             } else {
                 1u32 // metadata byte
@@ -253,8 +252,7 @@ impl AccountProperties {
                     +
                     ValueDiffCompressionStrategy::optimal_compression_length_u256_optional(initial.balance, r#final.balance, not_compress_balance) as u32 // balance diff
                     + 4 // unpadded code len
-                    + 4 // artifacts len
-                    + r#final.full_bytecode_len() // bytecode
+                    + r#final.unpadded_code_len // bytecode (without padding and artifacts)
                     + 4 // observable bytecode len
             })
         } else {
@@ -299,14 +297,14 @@ impl AccountProperties {
     ///
     /// For account data we have following encoding formats(index encoded in the 5 most significant bits of the metadata byte, 3 less significant == 4):
     /// 0(full data): `versioning_data(8 BE bytes) & nonce_diff(using storage value strategy)
-    /// & balance_diff & unpadded_code_len(4 BE bytes) &  artifacts_len (4 BE bytes) &
-    /// & bytecode & observable_len (4 BE bytes)`
+    /// & balance_diff & unpadded_code_len(4 BE bytes) & bytecode(unpadded_code_len bytes) & observable_len (4 BE bytes)`
     /// 1: `nonce_diff (using storage value strategy)`
     /// 2: `balance_diff (using storage value strategy)`
     /// 3: `nonce_diff (using storage value strategy) & balance_diff (using storage value strategy)`
-    /// 4. `versioning_data(8 BE bytes) & nonce_diff(using storage value strategy) & balance_diff & bytecode_hash (32 bytes) & artifacts_len (4 BE bytes) & observable_len (4 BE bytes)`
+    /// 4. `versioning_data(8 BE bytes) & nonce_diff(using storage value strategy) & balance_diff & bytecode_hash (32 bytes) & observable_len (4 BE bytes)`
     ///
     /// The last format(4) created for force deployments during protocol upgrades. We publish only bytecode hash, but it's guaranteed by the governance that bytecode will be published separately.
+    /// Note: artifacts (jump table, etc.) are not published in pubdata — they are deterministic from the bytecode.
     ///
     pub fn diff_compression<
         const PROOF_ENV: bool,
@@ -367,8 +365,6 @@ impl AccountProperties {
             } else {
                 dst.write(&r#final.unpadded_code_len.to_be_bytes());
                 result_keeper.pubdata(&r#final.unpadded_code_len.to_be_bytes());
-                dst.write(&r#final.artifacts_len.to_be_bytes());
-                result_keeper.pubdata(&r#final.artifacts_len.to_be_bytes());
                 let preimage_type = PreimageRequest {
                     hash: r#final.bytecode_hash,
                     expected_preimage_len_in_bytes: r#final.full_bytecode_len(),
@@ -391,8 +387,17 @@ impl AccountProperties {
                         }
                         SystemError::LeafDefect(i) => i,
                     })?;
-                dst.write(bytecode);
-                result_keeper.pubdata(bytecode);
+                // Only publish the raw code bytes (without padding and artifacts),
+                // since artifacts are deterministic from the bytecode.
+                let code_len = r#final.unpadded_code_len as usize;
+                if bytecode.len() < code_len {
+                    return Err(internal_error!(
+                        "Decommitted bytecode shorter than unpadded_code_len"
+                    ));
+                }
+                let code_bytes = &bytecode[..code_len];
+                dst.write(code_bytes);
+                result_keeper.pubdata(code_bytes);
             }
             dst.write(&r#final.observable_bytecode_len.to_be_bytes());
             result_keeper.pubdata(&r#final.observable_bytecode_len.to_be_bytes());
@@ -441,7 +446,7 @@ impl AccountProperties {
 
 #[cfg(test)]
 mod tests {
-    use super::AccountProperties;
+    use super::{bytecode_padding_len, AccountProperties};
     use crate::system_implementation::flat_storage_model::{
         BytecodeAndAccountDataPreimagesStorage, PreimageRequest, VersioningData,
     };
@@ -587,13 +592,12 @@ mod tests {
         // 8 bytes versioning data
         // 1 byte nonce diff
         // 2 bytes balance diff
-        // 4 bytes bytecode len
-        // bytecode
+        // 4 bytes unpadded code len
+        // bytecode (unpadded_code_len bytes, without padding and artifacts)
         // 4 bytes observable bytecode len
-        // 4 bytes artifacts len
         assert_eq!(
             compression.len() as u32,
-            1 + 8 + 1 + 2 + 4 + bytecode.len() as u32 + 4 + 4
+            1 + 8 + 1 + 2 + 4 + code_len as u32 + 4
         );
         let mut expected = vec![0b00000100];
         expected.extend(r#final.versioning_data.0.to_be_bytes());
@@ -601,10 +605,90 @@ mod tests {
         expected.push(0b00001010); // balance: sub 0xff
         expected.push(0xff); // balance: sub 0xff
         expected.extend((code_len as u32).to_be_bytes());
-        expected.extend([0, 0, 0, 0]); // arifacts len
-        expected.extend_from_slice(&bytecode);
+        expected.extend_from_slice(&bytecode[..code_len]); // only raw code bytes
         expected.extend((code_len as u32).to_be_bytes()); // observable
 
+        assert_eq!(compression, expected);
+    }
+
+    #[test]
+    fn deployment_compression_with_artifacts_test() {
+        let mut initial = AccountProperties::TRIVIAL_VALUE;
+        initial.balance = U256::try_from(0xFF00000000FFu64).unwrap();
+
+        let mut code = vec![1u8, 2, 3, 4, 5];
+        let code_len = code.len();
+        let keccak = Keccak256::digest(&code);
+
+        // Add padding
+        let padding_len = bytecode_padding_len(code_len);
+        code.append(&mut vec![0u8; padding_len]);
+        // Add mock artifacts (jump table)
+        let artifacts = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let artifacts_len = artifacts.len() as u32;
+        code.extend_from_slice(&artifacts);
+        let full_bytecode = code;
+
+        let blake = Blake2s256::digest(&full_bytecode);
+
+        let mut r#final = AccountProperties::TRIVIAL_VALUE;
+        r#final.versioning_data = VersioningData::empty_deployed();
+        r#final.balance = U256::try_from(0xFF0000000000u64).unwrap();
+        r#final.unpadded_code_len = code_len as u32;
+        r#final.artifacts_len = artifacts_len;
+        r#final.observable_bytecode_len = code_len as u32;
+        r#final.bytecode_hash = blake.into();
+        r#final.observable_bytecode_hash = keccak.into();
+
+        let optimal_length =
+            AccountProperties::diff_compression_length(&initial, &r#final, false, false).unwrap();
+
+        let mut nop_hasher = NopHasher::new();
+        let mut result_keeper = TestResultKeeper { pubdata: vec![] };
+        let mut preimages_cache: BytecodeAndAccountDataPreimagesStorage<
+            BaseResources<DecreasingNative>,
+        > = BytecodeAndAccountDataPreimagesStorage::new_from_parts(Global);
+        let mut resources: BaseResources<DecreasingNative> = BaseResources::FORMAL_INFINITE;
+        preimages_cache
+            .record_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &(PreimageRequest {
+                    hash: r#final.bytecode_hash,
+                    expected_preimage_len_in_bytes: r#final.full_bytecode_len(),
+                    preimage_type: PreimageType::Bytecode,
+                }),
+                &mut resources,
+                &[&full_bytecode],
+            )
+            .unwrap();
+        let mut test_oracle = TestOracle;
+
+        AccountProperties::diff_compression::<false, _, _, _>(
+            &initial,
+            &r#final,
+            false,
+            &mut nop_hasher,
+            &mut result_keeper,
+            &mut preimages_cache,
+            &mut test_oracle,
+        )
+        .unwrap();
+        let compression = result_keeper.pubdata;
+
+        assert_eq!(optimal_length, compression.len() as u32);
+        // Verify only raw code bytes are published (no padding, no artifacts)
+        assert_eq!(
+            compression.len() as u32,
+            1 + 8 + 1 + 2 + 4 + code_len as u32 + 4
+        );
+        let mut expected = vec![0b00000100];
+        expected.extend(r#final.versioning_data.0.to_be_bytes());
+        expected.push(0b00000001); // nonce: add, initial == final == 0
+        expected.push(0b00001010); // balance: sub 0xff
+        expected.push(0xff);
+        expected.extend((code_len as u32).to_be_bytes());
+        expected.extend_from_slice(&full_bytecode[..code_len]); // only raw code bytes
+        expected.extend((code_len as u32).to_be_bytes()); // observable
         assert_eq!(compression, expected);
     }
 }

--- a/bench_scripts/bench.sh
+++ b/bench_scripts/bench.sh
@@ -47,7 +47,7 @@ run_block() {
     cargo run --manifest-path "$ETH_RUNNER_MANIFEST" \
         --release -j 3 \
         --features "$FEATURES" \
-        -- single-run --block-dir "$block_dir" \
+        -- single-run --block-dir "$block_dir" --opcode-stats \
         > "$output_dir/block_${blk}.out" 2>&1
 }
 

--- a/bench_scripts/compare_opcode_stats.py
+++ b/bench_scripts/compare_opcode_stats.py
@@ -1,0 +1,178 @@
+"""Compare per-opcode EVM stats (gas, native, ratios) between base and head benchmark runs.
+
+Usage:
+    python compare_opcode_stats.py base_block.out head_block.out [label]
+
+Exits 0 with no output if nothing changed or base has no stats.
+Prints a compact markdown table only when differences exist.
+"""
+
+import sys
+import re
+
+
+def parse_opcode_stats(filename):
+    """Parse the '=== EVM Opcode Stats:' table from a benchmark .out file."""
+    stats = {}
+    try:
+        with open(filename) as f:
+            text = f.read()
+    except FileNotFoundError:
+        return stats
+
+    match = re.search(
+        r"=== EVM Opcode Stats:\n(.+?)\n={5,}",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        return stats
+
+    for line in match.group(1).strip().splitlines()[1:]:  # skip header
+        parts = line.split()
+        if len(parts) < 10:
+            continue
+        name = parts[0]
+        # Skip CALL-like opcodes that show "-"
+        if parts[1] == "-":
+            stats[name] = {"count": int(parts[1]) if parts[1] != "-" else 0}
+            continue
+        try:
+            stats[name] = {
+                "count": int(parts[1]),
+                "avg_gas": float(parts[2]),
+                "med_gas": int(parts[3]),
+                "min_gas": int(parts[4]),
+                "max_gas": int(parts[5]),
+                "avg_native": float(parts[6]),
+                "med_native": int(parts[7]),
+                "min_native": int(parts[8]),
+                "max_native": int(parts[9]),
+            }
+        except (ValueError, IndexError):
+            continue
+    return stats
+
+
+def pct(old, new):
+    if old == 0:
+        return 0.0 if new == 0 else float("inf")
+    return (new - old) / old * 100
+
+
+def fmt_pct(val):
+    if abs(val) < 0.005:
+        return ""
+    return f" ({val:+.1f}%)"
+
+
+def compare(base_stats, head_stats):
+    """Return list of rows for opcodes with changed avg_gas or avg_native."""
+    all_opcodes = sorted(set(base_stats) | set(head_stats))
+    rows = []
+    for op in all_opcodes:
+        b = base_stats.get(op, {})
+        h = head_stats.get(op, {})
+
+        # Skip if either side has no gas data (CALL-like or missing)
+        if "avg_gas" not in b and "avg_gas" not in h:
+            continue
+
+        b_avg_gas = b.get("avg_gas", 0)
+        h_avg_gas = h.get("avg_gas", 0)
+        b_med_gas = b.get("med_gas", 0)
+        h_med_gas = h.get("med_gas", 0)
+        b_avg_native = b.get("avg_native", 0)
+        h_avg_native = h.get("avg_native", 0)
+        b_med_native = b.get("med_native", 0)
+        h_med_native = h.get("med_native", 0)
+        b_count = b.get("count", 0)
+        h_count = h.get("count", 0)
+
+        # Compute native/gas ratio (using medians for stability)
+        b_ratio = b_med_native / b_med_gas if b_med_gas > 0 else 0
+        h_ratio = h_med_native / h_med_gas if h_med_gas > 0 else 0
+
+        # Check if anything meaningful changed
+        gas_changed = b_med_gas != h_med_gas
+        native_changed = b_med_native != h_med_native
+        count_changed = b_count != h_count
+
+        if not (gas_changed or native_changed or count_changed):
+            continue
+
+        rows.append({
+            "op": op,
+            "b_count": b_count,
+            "h_count": h_count,
+            "b_med_gas": b_med_gas,
+            "h_med_gas": h_med_gas,
+            "b_med_native": b_med_native,
+            "h_med_native": h_med_native,
+            "b_ratio": b_ratio,
+            "h_ratio": h_ratio,
+        })
+    return rows
+
+
+def format_table(rows, label=""):
+    """Format comparison rows as a compact markdown table."""
+    if not rows:
+        return ""
+
+    lines = []
+    title = f"#### Opcode stats diff"
+    if label:
+        title += f" ({label})"
+    lines.append(title)
+    lines.append("")
+    lines.append(
+        "| Opcode | Count | Med Gas | Med Native | Native/Gas |"
+    )
+    lines.append(
+        "|--------|-------|---------|------------|------------|"
+    )
+    for r in rows:
+        count_s = f"{r['h_count']}"
+        if r['b_count'] != r['h_count']:
+            count_s += fmt_pct(pct(r['b_count'], r['h_count']))
+
+        gas_s = f"{r['h_med_gas']}"
+        gas_s += fmt_pct(pct(r['b_med_gas'], r['h_med_gas']))
+
+        native_s = f"{r['h_med_native']}"
+        native_s += fmt_pct(pct(r['b_med_native'], r['h_med_native']))
+
+        ratio_s = f"{r['h_ratio']:.1f}"
+        ratio_s += fmt_pct(pct(r['b_ratio'], r['h_ratio']))
+
+        lines.append(f"| `{r['op']}` | {count_s} | {gas_s} | {native_s} | {ratio_s} |")
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python compare_opcode_stats.py <base.out> <head.out> [label]", file=sys.stderr)
+        sys.exit(1)
+
+    base_file = sys.argv[1]
+    head_file = sys.argv[2]
+    label = sys.argv[3] if len(sys.argv) > 3 else ""
+
+    base_stats = parse_opcode_stats(base_file)
+    head_stats = parse_opcode_stats(head_file)
+
+    # If base has no stats (old branch), silently exit
+    if not base_stats:
+        sys.exit(0)
+
+    rows = compare(base_stats, head_stats)
+    if not rows:
+        sys.exit(0)
+
+    print(format_table(rows, label))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/compare_opcode_stats.py
+++ b/bench_scripts/compare_opcode_stats.py
@@ -33,9 +33,9 @@ def parse_opcode_stats(filename):
         if len(parts) < 10:
             continue
         name = parts[0]
-        # Skip CALL-like opcodes that show "-"
-        if parts[1] == "-":
-            stats[name] = {"count": int(parts[1]) if parts[1] != "-" else 0}
+        # Skip CALL-like opcodes that show "-" for gas/native columns
+        if parts[2] == "-":
+            stats[name] = {"count": int(parts[1])}
             continue
         try:
             stats[name] = {

--- a/bench_scripts/join_opcode_stats.py
+++ b/bench_scripts/join_opcode_stats.py
@@ -1,0 +1,161 @@
+"""Join per-opcode tracer stats (gas/native) with cycle stats to produce combined ratios.
+
+Reads:
+  - .out file: EVM Opcode Stats table (gas, native with min/max/median)
+  - .bench file: Per-opcode cycle stats (cycles with min/max/median)
+
+Outputs a combined table with cycles/gas and native/gas ratios,
+including worst-case bounds (max_cycles/min_gas).
+
+Usage:
+    python join_opcode_stats.py <block.out> <block.bench> [--csv output.csv]
+"""
+
+import sys
+import re
+import argparse
+
+
+def parse_tracer_stats(filename):
+    """Parse '=== EVM Opcode Stats:' from .out file."""
+    stats = {}
+    try:
+        with open(filename) as f:
+            text = f.read()
+    except FileNotFoundError:
+        return stats
+
+    match = re.search(r"=== EVM Opcode Stats:\n(.+?)\n={5,}", text, re.DOTALL)
+    if not match:
+        return stats
+
+    for line in match.group(1).strip().splitlines()[1:]:
+        parts = line.split()
+        if len(parts) < 10 or parts[1] == "-":
+            continue
+        try:
+            stats[parts[0]] = {
+                "count": int(parts[1]),
+                "avg_gas": float(parts[2]),
+                "med_gas": int(parts[3]),
+                "min_gas": int(parts[4]),
+                "max_gas": int(parts[5]),
+                "avg_native": float(parts[6]),
+                "med_native": int(parts[7]),
+                "min_native": int(parts[8]),
+                "max_native": int(parts[9]),
+            }
+        except (ValueError, IndexError):
+            continue
+    return stats
+
+
+def parse_cycle_stats(filename):
+    """Parse '=== Per-opcode cycle stats:' from .bench file."""
+    stats = {}
+    try:
+        with open(filename) as f:
+            text = f.read()
+    except FileNotFoundError:
+        return stats
+
+    match = re.search(r"=== Per-opcode cycle stats:\n(.+?)\n={5,}", text, re.DOTALL)
+    if not match:
+        return stats
+
+    for line in match.group(1).strip().splitlines()[1:]:
+        parts = line.split()
+        if len(parts) < 7:
+            continue
+        try:
+            stats[parts[0]] = {
+                "count": int(parts[1]),
+                "total_cycles": int(parts[2]),
+                "avg_cycles": float(parts[3]),
+                "med_cycles": int(parts[4]),
+                "min_cycles": int(parts[5]),
+                "max_cycles": int(parts[6]),
+            }
+        except (ValueError, IndexError):
+            continue
+    return stats
+
+
+def ratio(num, den):
+    return num / den if den > 0 else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Join opcode tracer and cycle stats")
+    parser.add_argument("out_file", help=".out file with tracer stats")
+    parser.add_argument("bench_file", help=".bench file with cycle stats")
+    parser.add_argument("--csv", help="Write CSV output to file")
+    args = parser.parse_args()
+
+    tracer = parse_tracer_stats(args.out_file)
+    cycles = parse_cycle_stats(args.bench_file)
+
+    if not tracer or not cycles:
+        print("No data to join.", file=sys.stderr)
+        sys.exit(1)
+
+    opcodes = sorted(set(tracer) & set(cycles))
+
+    rows = []
+    for op in opcodes:
+        t = tracer[op]
+        c = cycles[op]
+        rows.append({
+            "op": op,
+            "count": t["count"],
+            # Median ratios (typical case)
+            "med_cycles_per_gas": ratio(c["med_cycles"], t["med_gas"]),
+            "med_native_per_gas": ratio(t["med_native"], t["med_gas"]),
+            "med_cycles_per_native": ratio(c["med_cycles"], t["med_native"]),
+            # Worst-case ratios (upper bounds)
+            "worst_cycles_per_gas": ratio(c["max_cycles"], t["min_gas"]) if t["min_gas"] > 0 else 0,
+            "worst_native_per_gas": ratio(t["max_native"], t["min_gas"]) if t["min_gas"] > 0 else 0,
+            # Raw values for reference
+            "med_gas": t["med_gas"],
+            "med_native": t["med_native"],
+            "med_cycles": c["med_cycles"],
+            "max_cycles": c["max_cycles"],
+            "min_gas": t["min_gas"],
+            "max_native": t["max_native"],
+        })
+
+    # Sort by worst cycles/gas descending (most expensive first)
+    rows.sort(key=lambda r: r["worst_cycles_per_gas"], reverse=True)
+
+    # Print table
+    print(f"{'opcode':<16} {'count':>8} {'med_gas':>8} {'med_nat':>8} {'med_cyc':>8}"
+          f" {'cyc/gas':>8} {'nat/gas':>8} {'cyc/nat':>8}"
+          f" {'W cyc/gas':>10} {'W nat/gas':>10}")
+    print("-" * 114)
+    for r in rows:
+        print(f"{r['op']:<16} {r['count']:>8} {r['med_gas']:>8} {r['med_native']:>8} {r['med_cycles']:>8}"
+              f" {r['med_cycles_per_gas']:>8.1f} {r['med_native_per_gas']:>8.1f} {r['med_cycles_per_native']:>8.2f}"
+              f" {r['worst_cycles_per_gas']:>10.1f} {r['worst_native_per_gas']:>10.1f}")
+
+    if args.csv:
+        with open(args.csv, "w") as f:
+            f.write("opcode,count,"
+                    "med_gas,med_native,med_cycles,"
+                    "min_gas,max_gas,min_native,max_native,min_cycles,max_cycles,"
+                    "med_cycles_per_gas,med_native_per_gas,med_cycles_per_native,"
+                    "worst_cycles_per_gas,worst_native_per_gas\n")
+            for r in rows:
+                t = tracer[r["op"]]
+                c = cycles[r["op"]]
+                f.write(f"{r['op']},{r['count']},"
+                        f"{t['med_gas']},{t['med_native']},{c['med_cycles']},"
+                        f"{t['min_gas']},{t['max_gas']},{t['min_native']},{t['max_native']},"
+                        f"{c['min_cycles']},{c['max_cycles']},"
+                        f"{r['med_cycles_per_gas']:.2f},{r['med_native_per_gas']:.2f},"
+                        f"{r['med_cycles_per_native']:.4f},"
+                        f"{r['worst_cycles_per_gas']:.2f},{r['worst_native_per_gas']:.2f}\n")
+        print(f"\nCSV written to {args.csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/join_samples.py
+++ b/bench_scripts/join_samples.py
@@ -1,0 +1,155 @@
+"""Join per-execution opcode samples (gas/native from tracer, cycles from RISC-V).
+
+Reads:
+  - <tracer_dir>/<OPCODE>.samples: "gas,native" per line (execution order)
+  - <cycles_dir>/<OPCODE>.cycles: "cycles" per line (execution order)
+
+Since both runs are deterministic, line K in both files corresponds to
+the Kth execution of that opcode.
+
+Outputs per-opcode CSV with (gas, native, cycles, cycles/gas, native/gas)
+per execution, and a summary with worst-case ratios.
+
+Usage:
+    python join_samples.py <tracer_dir> <cycles_dir> [--out-dir <output_dir>] [--summary]
+"""
+
+import os
+import sys
+import argparse
+
+
+def load_tracer_samples(path):
+    """Load gas,native pairs from .samples file."""
+    samples = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(",")
+            samples.append((int(parts[0]), int(parts[1])))
+    return samples
+
+
+def load_cycle_samples(path):
+    """Load cycle values from .cycles file."""
+    samples = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                samples.append(int(line))
+    return samples
+
+
+def ratio(num, den):
+    return num / den if den > 0 else 0.0
+
+
+def process_opcode(name, tracer_samples, cycle_samples, out_dir):
+    """Join samples and write per-execution CSV. Return summary stats."""
+    n = min(len(tracer_samples), len(cycle_samples))
+    if n == 0:
+        return None
+
+    if len(tracer_samples) != len(cycle_samples):
+        print(f"  WARNING: {name} count mismatch: tracer={len(tracer_samples)} cycles={len(cycle_samples)}, using first {n}",
+              file=sys.stderr)
+
+    rows = []
+    for i in range(n):
+        gas, native = tracer_samples[i]
+        cycles = cycle_samples[i]
+        rows.append((gas, native, cycles))
+
+    # Write per-execution CSV
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(out_dir, f"{name}.csv")
+        with open(path, "w") as f:
+            f.write("gas,native,cycles,cycles_per_gas,native_per_gas\n")
+            for gas, native, cycles in rows:
+                cpg = ratio(cycles, gas)
+                npg = ratio(native, gas)
+                f.write(f"{gas},{native},{cycles},{cpg:.2f},{npg:.2f}\n")
+
+    # Compute summary
+    cycles_per_gas_values = [ratio(c, g) for g, _, c in rows if g > 0]
+    native_per_gas_values = [ratio(n, g) for g, n, _ in rows if g > 0]
+
+    if not cycles_per_gas_values:
+        return None
+
+    cycles_per_gas_values.sort()
+    native_per_gas_values.sort()
+
+    def percentile(sorted_vals, p):
+        idx = int(len(sorted_vals) * p / 100)
+        idx = min(idx, len(sorted_vals) - 1)
+        return sorted_vals[idx]
+
+    return {
+        "name": name,
+        "count": n,
+        "med_cpg": percentile(cycles_per_gas_values, 50),
+        "p95_cpg": percentile(cycles_per_gas_values, 95),
+        "p99_cpg": percentile(cycles_per_gas_values, 99),
+        "max_cpg": cycles_per_gas_values[-1],
+        "med_npg": percentile(native_per_gas_values, 50),
+        "p95_npg": percentile(native_per_gas_values, 95),
+        "p99_npg": percentile(native_per_gas_values, 99),
+        "max_npg": native_per_gas_values[-1],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Join per-execution opcode samples")
+    parser.add_argument("tracer_dir", help="Directory with .samples files (gas,native)")
+    parser.add_argument("cycles_dir", help="Directory with .cycles files")
+    parser.add_argument("--out-dir", help="Write per-execution CSVs to this directory")
+    parser.add_argument("--summary", action="store_true", help="Print summary table")
+    args = parser.parse_args()
+
+    # Find opcodes present in both directories
+    tracer_opcodes = {f.replace(".samples", "") for f in os.listdir(args.tracer_dir) if f.endswith(".samples")}
+    cycle_opcodes = {f.replace(".cycles", "") for f in os.listdir(args.cycles_dir) if f.endswith(".cycles")}
+    common = sorted(tracer_opcodes & cycle_opcodes)
+
+    if not common:
+        print("No matching opcodes found between tracer and cycle directories.", file=sys.stderr)
+        sys.exit(1)
+
+    summaries = []
+    for name in common:
+        tracer_path = os.path.join(args.tracer_dir, f"{name}.samples")
+        cycles_path = os.path.join(args.cycles_dir, f"{name}.cycles")
+
+        tracer_samples = load_tracer_samples(tracer_path)
+        cycle_samples = load_cycle_samples(cycles_path)
+
+        summary = process_opcode(name, tracer_samples, cycle_samples, args.out_dir)
+        if summary:
+            summaries.append(summary)
+
+    if not args.summary and not args.out_dir:
+        args.summary = True
+
+    if args.summary and summaries:
+        # Sort by worst-case cycles/gas
+        summaries.sort(key=lambda s: s["max_cpg"], reverse=True)
+        print(f"{'opcode':<16} {'count':>8}"
+              f" {'med c/g':>8} {'p95 c/g':>8} {'p99 c/g':>8} {'max c/g':>8}"
+              f" {'med n/g':>8} {'p95 n/g':>8} {'p99 n/g':>8} {'max n/g':>8}")
+        print("-" * 104)
+        for s in summaries:
+            print(f"{s['name']:<16} {s['count']:>8}"
+                  f" {s['med_cpg']:>8.1f} {s['p95_cpg']:>8.1f} {s['p99_cpg']:>8.1f} {s['max_cpg']:>8.1f}"
+                  f" {s['med_npg']:>8.1f} {s['p95_npg']:>8.1f} {s['p99_npg']:>8.1f} {s['max_npg']:>8.1f}")
+
+    if args.out_dir:
+        print(f"\nPer-execution CSVs written to {args.out_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/join_samples.py
+++ b/bench_scripts/join_samples.py
@@ -85,9 +85,9 @@ def process_opcode(name, tracer_samples, cycle_samples, out_dir):
     native_per_gas_values.sort()
 
     def percentile(sorted_vals, p):
-        idx = int(len(sorted_vals) * p / 100)
-        idx = min(idx, len(sorted_vals) - 1)
-        return sorted_vals[idx]
+        # Nearest-rank method: rank = ceil(p/100 * N), 1-indexed
+        rank = max(1, -(-len(sorted_vals) * p // 100))  # ceiling division
+        return sorted_vals[min(rank, len(sorted_vals)) - 1]
 
     return {
         "name": name,

--- a/bench_scripts/visualize_opcode_stats.py
+++ b/bench_scripts/visualize_opcode_stats.py
@@ -1,0 +1,226 @@
+"""Visualize per-opcode benchmarking stats.
+
+Reads the joined per-execution CSVs and summary data to produce charts:
+  1. Cycles/gas ratio distribution per opcode (box plot)
+  2. Top opcodes by total cycle consumption (bar chart)
+  3. Per-opcode scatter: gas vs cycles for selected opcodes
+
+Usage:
+    python visualize_opcode_stats.py <joined_dir> [--out-dir <output_dir>] [--opcodes OP1,OP2,...]
+    python visualize_opcode_stats.py bench_results/joined --out-dir bench_results/charts
+"""
+
+import os
+import sys
+import argparse
+import csv
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+except ImportError:
+    print("matplotlib is required: pip3 install matplotlib", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_joined_csv(path):
+    rows = []
+    with open(path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append({
+                "gas": int(row["gas"]),
+                "native": int(row["native"]),
+                "cycles": int(row["cycles"]),
+                "cpg": float(row["cycles_per_gas"]),
+                "npg": float(row["native_per_gas"]),
+            })
+    return rows
+
+
+def load_all(joined_dir, filter_opcodes=None):
+    data = {}
+    for fname in sorted(os.listdir(joined_dir)):
+        if not fname.endswith(".csv"):
+            continue
+        name = fname.replace(".csv", "")
+        if filter_opcodes and name not in filter_opcodes:
+            continue
+        rows = load_joined_csv(os.path.join(joined_dir, fname))
+        if rows:
+            data[name] = rows
+    return data
+
+
+def plot_cpg_boxplot(data, out_path):
+    """Box plot of cycles/gas ratio distribution per opcode."""
+    # Sort by median cycles/gas descending
+    items = []
+    for name, rows in data.items():
+        cpg_values = [r["cpg"] for r in rows if r["cpg"] > 0]
+        if cpg_values:
+            med = sorted(cpg_values)[len(cpg_values) // 2]
+            items.append((name, cpg_values, med))
+    items.sort(key=lambda x: x[2], reverse=True)
+
+    # Top 30 for readability
+    items = items[:30]
+
+    if not items:
+        return
+
+    fig, ax = plt.subplots(figsize=(14, 8))
+    labels = [it[0] for it in items]
+    box_data = [it[1] for it in items]
+
+    bp = ax.boxplot(box_data, vert=True, patch_artist=True, showfliers=True,
+                    flierprops=dict(marker=".", markersize=2, alpha=0.3))
+
+    for patch in bp["boxes"]:
+        patch.set_facecolor("#4C72B0")
+        patch.set_alpha(0.7)
+
+    ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel("Cycles / Gas")
+    ax.set_title("Cycles/Gas Ratio Distribution by Opcode (top 30 by median)")
+    ax.grid(axis="y", alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def plot_total_cycles(data, out_path):
+    """Bar chart of total cycles consumed per opcode."""
+    totals = []
+    for name, rows in data.items():
+        total = sum(r["cycles"] for r in rows)
+        count = len(rows)
+        totals.append((name, total, count))
+    totals.sort(key=lambda x: x[1], reverse=True)
+    totals = totals[:30]
+
+    if not totals:
+        return
+
+    fig, ax = plt.subplots(figsize=(14, 6))
+    names = [t[0] for t in totals]
+    values = [t[1] for t in totals]
+
+    bars = ax.bar(names, values, color="#4C72B0", alpha=0.8)
+    ax.set_xticklabels(names, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel("Total Cycles")
+    ax.set_title("Total Cycle Consumption by Opcode (top 30)")
+    ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x/1e6:.1f}M"))
+    ax.grid(axis="y", alpha=0.3)
+
+    for bar, (_, total, count) in zip(bars, totals):
+        ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),
+                f"n={count}", ha="center", va="bottom", fontsize=6)
+
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def plot_scatter(data, opcodes, out_path):
+    """Scatter plot: gas vs cycles for selected opcodes."""
+    fig, ax = plt.subplots(figsize=(10, 8))
+    colors = plt.cm.tab10.colors
+
+    for idx, name in enumerate(opcodes):
+        if name not in data:
+            continue
+        rows = data[name]
+        gas = [r["gas"] for r in rows]
+        cycles = [r["cycles"] for r in rows]
+        color = colors[idx % len(colors)]
+        ax.scatter(gas, cycles, label=name, alpha=0.5, s=15, color=color)
+
+    ax.set_xlabel("Gas")
+    ax.set_ylabel("Cycles")
+    ax.set_title("Gas vs Cycles per Execution")
+    ax.legend(fontsize=8)
+    ax.grid(alpha=0.3)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def plot_cpg_histogram(data, opcodes, out_path):
+    """Histogram of cycles/gas ratio for selected opcodes."""
+    fig, axes = plt.subplots(len(opcodes), 1, figsize=(10, 3 * len(opcodes)))
+    if len(opcodes) == 1:
+        axes = [axes]
+
+    for ax, name in zip(axes, opcodes):
+        if name not in data:
+            ax.set_title(f"{name} — no data")
+            continue
+        rows = data[name]
+        cpg = [r["cpg"] for r in rows if r["cpg"] > 0]
+        if not cpg:
+            continue
+        ax.hist(cpg, bins=50, color="#4C72B0", alpha=0.8, edgecolor="white")
+        ax.set_title(f"{name} — cycles/gas distribution (n={len(cpg)})")
+        ax.set_xlabel("Cycles / Gas")
+        ax.set_ylabel("Count")
+        ax.grid(alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize per-opcode benchmarking stats")
+    parser.add_argument("joined_dir", help="Directory with per-execution .csv files")
+    parser.add_argument("--out-dir", default=".", help="Output directory for charts")
+    parser.add_argument("--opcodes", help="Comma-separated opcodes for scatter/histogram (default: auto-select interesting ones)")
+    args = parser.parse_args()
+
+    data = load_all(args.joined_dir)
+    if not data:
+        print("No data found.", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    # Auto-select interesting opcodes (high variance in cycles/gas)
+    if args.opcodes:
+        selected = args.opcodes.split(",")
+    else:
+        # Pick opcodes with highest max/median cpg ratio (most variance)
+        variance = []
+        for name, rows in data.items():
+            cpg = sorted([r["cpg"] for r in rows if r["cpg"] > 0])
+            if len(cpg) > 10:
+                med = cpg[len(cpg) // 2]
+                mx = cpg[-1]
+                if med > 0:
+                    variance.append((name, mx / med))
+        variance.sort(key=lambda x: x[1], reverse=True)
+        selected = [v[0] for v in variance[:6]]
+
+    print(f"Generating charts for {len(data)} opcodes...")
+    print(f"Selected for detail: {', '.join(selected)}")
+
+    plot_cpg_boxplot(data, os.path.join(args.out_dir, "cpg_boxplot.png"))
+    print(f"  -> {args.out_dir}/cpg_boxplot.png")
+
+    plot_total_cycles(data, os.path.join(args.out_dir, "total_cycles.png"))
+    print(f"  -> {args.out_dir}/total_cycles.png")
+
+    if selected:
+        plot_scatter(data, selected, os.path.join(args.out_dir, "gas_vs_cycles.png"))
+        print(f"  -> {args.out_dir}/gas_vs_cycles.png")
+
+        plot_cpg_histogram(data, selected, os.path.join(args.out_dir, "cpg_histograms.png"))
+        print(f"  -> {args.out_dir}/cpg_histograms.png")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_scripts/visualize_opcode_stats.py
+++ b/bench_scripts/visualize_opcode_stats.py
@@ -1,19 +1,19 @@
 """Visualize per-opcode benchmarking stats.
 
-Reads the joined per-execution CSVs and summary data to produce charts:
-  1. Cycles/gas ratio distribution per opcode (box plot)
-  2. Top opcodes by total cycle consumption (bar chart)
-  3. Per-opcode scatter: gas vs cycles for selected opcodes
+Reads the joined per-execution CSVs to produce:
+  1. Total cycle consumption bar chart (top opcodes)
+  2. Per-opcode scatter plots (gas vs cycles) for top consumers
+  3. Outlier analysis report
 
 Usage:
-    python visualize_opcode_stats.py <joined_dir> [--out-dir <output_dir>] [--opcodes OP1,OP2,...]
-    python visualize_opcode_stats.py bench_results/joined --out-dir bench_results/charts
+    python visualize_opcode_stats.py <joined_dir> [--out-dir <output_dir>] [--top N]
 """
 
 import os
 import sys
 import argparse
 import csv
+import math
 
 try:
     import matplotlib
@@ -40,58 +40,30 @@ def load_joined_csv(path):
     return rows
 
 
-def load_all(joined_dir, filter_opcodes=None):
+def load_all(joined_dir):
     data = {}
     for fname in sorted(os.listdir(joined_dir)):
         if not fname.endswith(".csv"):
             continue
         name = fname.replace(".csv", "")
-        if filter_opcodes and name not in filter_opcodes:
-            continue
         rows = load_joined_csv(os.path.join(joined_dir, fname))
         if rows:
             data[name] = rows
     return data
 
 
-def plot_cpg_boxplot(data, out_path):
-    """Box plot of cycles/gas ratio distribution per opcode."""
-    # Sort by median cycles/gas descending
-    items = []
-    for name, rows in data.items():
-        cpg_values = [r["cpg"] for r in rows if r["cpg"] > 0]
-        if cpg_values:
-            med = sorted(cpg_values)[len(cpg_values) // 2]
-            items.append((name, cpg_values, med))
-    items.sort(key=lambda x: x[2], reverse=True)
-
-    # Top 30 for readability
-    items = items[:30]
-
-    if not items:
-        return
-
-    fig, ax = plt.subplots(figsize=(14, 8))
-    labels = [it[0] for it in items]
-    box_data = [it[1] for it in items]
-
-    bp = ax.boxplot(box_data, vert=True, patch_artist=True, showfliers=True,
-                    flierprops=dict(marker=".", markersize=2, alpha=0.3))
-
-    for patch in bp["boxes"]:
-        patch.set_facecolor("#4C72B0")
-        patch.set_alpha(0.7)
-
-    ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
-    ax.set_ylabel("Cycles / Gas")
-    ax.set_title("Cycles/Gas Ratio Distribution by Opcode (top 30 by median)")
-    ax.grid(axis="y", alpha=0.3)
-    plt.tight_layout()
-    plt.savefig(out_path, dpi=150)
-    plt.close()
+def ratio(num, den):
+    return num / den if den > 0 else 0.0
 
 
-def plot_total_cycles(data, out_path):
+def percentile(sorted_vals, p):
+    if not sorted_vals:
+        return 0
+    idx = min(int(len(sorted_vals) * p / 100), len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def plot_total_cycles(data, out_path, top_n=25):
     """Bar chart of total cycles consumed per opcode."""
     totals = []
     for name, rows in data.items():
@@ -99,20 +71,19 @@ def plot_total_cycles(data, out_path):
         count = len(rows)
         totals.append((name, total, count))
     totals.sort(key=lambda x: x[1], reverse=True)
-    totals = totals[:30]
-
-    if not totals:
-        return
+    totals = totals[:top_n]
 
     fig, ax = plt.subplots(figsize=(14, 6))
     names = [t[0] for t in totals]
     values = [t[1] for t in totals]
+    x = range(len(names))
 
-    bars = ax.bar(names, values, color="#4C72B0", alpha=0.8)
+    bars = ax.bar(x, values, color="#4C72B0", alpha=0.8)
+    ax.set_xticks(x)
     ax.set_xticklabels(names, rotation=45, ha="right", fontsize=8)
     ax.set_ylabel("Total Cycles")
-    ax.set_title("Total Cycle Consumption by Opcode (top 30)")
-    ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x/1e6:.1f}M"))
+    ax.set_title(f"Total Cycle Consumption by Opcode (top {top_n})")
+    ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda v, _: f"{v/1e6:.1f}M"))
     ax.grid(axis="y", alpha=0.3)
 
     for bar, (_, total, count) in zip(bars, totals):
@@ -122,62 +93,131 @@ def plot_total_cycles(data, out_path):
     plt.tight_layout()
     plt.savefig(out_path, dpi=150)
     plt.close()
+    return [t[0] for t in totals]
 
 
-def plot_scatter(data, opcodes, out_path):
-    """Scatter plot: gas vs cycles for selected opcodes."""
-    fig, ax = plt.subplots(figsize=(10, 8))
-    colors = plt.cm.tab10.colors
+def plot_opcode_scatter(name, rows, out_path):
+    """Scatter plot: gas vs cycles for a single opcode, with outlier highlighting."""
+    gas = [r["gas"] for r in rows]
+    cycles = [r["cycles"] for r in rows]
+    cpg = sorted([r["cpg"] for r in rows if r["cpg"] > 0])
 
-    for idx, name in enumerate(opcodes):
-        if name not in data:
-            continue
-        rows = data[name]
-        gas = [r["gas"] for r in rows]
-        cycles = [r["cycles"] for r in rows]
-        color = colors[idx % len(colors)]
-        ax.scatter(gas, cycles, label=name, alpha=0.5, s=15, color=color)
+    if not cpg:
+        return
+
+    p50 = percentile(cpg, 50)
+    p95 = percentile(cpg, 95)
+    p99 = percentile(cpg, 99)
+
+    # Color points by severity
+    colors = []
+    for r in rows:
+        c = r["cpg"] if r["gas"] > 0 else 0
+        if c >= p99:
+            colors.append("#d62728")  # red — p99+
+        elif c >= p95:
+            colors.append("#ff7f0e")  # orange — p95-p99
+        else:
+            colors.append("#1f77b4")  # blue — normal
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.scatter(gas, cycles, c=colors, alpha=0.6, s=20, edgecolors="none")
+
+    # Draw ratio reference lines
+    max_gas = max(gas) if gas else 1
+    for label, val, style in [("p50", p50, "--"), ("p95", p95, ":"), ("p99", p99, "-.")]:
+        if val > 0 and val < 1e6:
+            xs = [0, max_gas]
+            ys = [0, max_gas * val]
+            ax.plot(xs, ys, style, color="gray", alpha=0.5, linewidth=1,
+                    label=f"{label} c/g={val:.1f}")
 
     ax.set_xlabel("Gas")
     ax.set_ylabel("Cycles")
-    ax.set_title("Gas vs Cycles per Execution")
-    ax.legend(fontsize=8)
-    ax.grid(alpha=0.3)
+    ax.set_title(f"{name} — Gas vs Cycles (n={len(rows)})")
+    ax.legend(fontsize=7, loc="upper left")
+    ax.grid(alpha=0.2)
     plt.tight_layout()
     plt.savefig(out_path, dpi=150)
     plt.close()
 
 
-def plot_cpg_histogram(data, opcodes, out_path):
-    """Histogram of cycles/gas ratio for selected opcodes."""
-    fig, axes = plt.subplots(len(opcodes), 1, figsize=(10, 3 * len(opcodes)))
-    if len(opcodes) == 1:
-        axes = [axes]
+def analyze_outliers(data, top_n=15):
+    """Find and report extreme outlier executions across all opcodes."""
+    all_outliers = []
 
-    for ax, name in zip(axes, opcodes):
-        if name not in data:
-            ax.set_title(f"{name} — no data")
+    for name, rows in data.items():
+        cpg = sorted([r["cpg"] for r in rows if r["cpg"] > 0])
+        if len(cpg) < 5:
             continue
-        rows = data[name]
-        cpg = [r["cpg"] for r in rows if r["cpg"] > 0]
-        if not cpg:
-            continue
-        ax.hist(cpg, bins=50, color="#4C72B0", alpha=0.8, edgecolor="white")
-        ax.set_title(f"{name} — cycles/gas distribution (n={len(cpg)})")
-        ax.set_xlabel("Cycles / Gas")
-        ax.set_ylabel("Count")
-        ax.grid(alpha=0.3)
 
-    plt.tight_layout()
-    plt.savefig(out_path, dpi=150)
-    plt.close()
+        p50 = percentile(cpg, 50)
+        p99 = percentile(cpg, 99)
+        max_cpg = cpg[-1]
+
+        if p50 == 0:
+            continue
+
+        # Ratio of worst case to median
+        severity = max_cpg / p50
+
+        # Count of p99+ outliers
+        n_outliers = sum(1 for c in cpg if c >= p99)
+
+        # Find the actual worst execution
+        worst = max((r for r in rows if r["gas"] > 0), key=lambda r: r["cpg"], default=None)
+
+        if worst and severity > 1.5:
+            all_outliers.append({
+                "opcode": name,
+                "count": len(rows),
+                "p50_cpg": p50,
+                "p95_cpg": percentile(cpg, 95),
+                "p99_cpg": p99,
+                "max_cpg": max_cpg,
+                "severity": severity,
+                "n_outliers": n_outliers,
+                "worst_gas": worst["gas"],
+                "worst_native": worst["native"],
+                "worst_cycles": worst["cycles"],
+            })
+
+    all_outliers.sort(key=lambda x: x["severity"], reverse=True)
+    return all_outliers[:top_n]
+
+
+def write_outlier_report(outliers, out_path):
+    """Write outlier analysis as markdown."""
+    with open(out_path, "w") as f:
+        f.write("# Opcode Outlier Analysis\n\n")
+        f.write("Opcodes sorted by worst-case / median cycles/gas ratio (severity).\n")
+        f.write("High severity = the worst execution is disproportionately expensive relative to typical.\n\n")
+
+        f.write(f"| Opcode | Count | p50 c/g | p95 c/g | p99 c/g | max c/g | severity | worst execution |\n")
+        f.write(f"|--------|-------|---------|---------|---------|---------|----------|------------------|\n")
+
+        for o in outliers:
+            worst = f"gas={o['worst_gas']}, cycles={o['worst_cycles']}, native={o['worst_native']}"
+            f.write(f"| `{o['opcode']}` "
+                    f"| {o['count']} "
+                    f"| {o['p50_cpg']:.1f} "
+                    f"| {o['p95_cpg']:.1f} "
+                    f"| {o['p99_cpg']:.1f} "
+                    f"| {o['max_cpg']:.1f} "
+                    f"| **{o['severity']:.1f}x** "
+                    f"| {worst} |\n")
+
+        f.write("\n### Interpretation\n\n")
+        f.write("- **severity** = max(cycles/gas) / median(cycles/gas). Higher = more variable proving cost per gas.\n")
+        f.write("- Opcodes with severity > 10x are candidates for native model tuning.\n")
+        f.write("- Worst execution shows the actual gas/native/cycles for the most expensive invocation.\n")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Visualize per-opcode benchmarking stats")
     parser.add_argument("joined_dir", help="Directory with per-execution .csv files")
     parser.add_argument("--out-dir", default=".", help="Output directory for charts")
-    parser.add_argument("--opcodes", help="Comma-separated opcodes for scatter/histogram (default: auto-select interesting ones)")
+    parser.add_argument("--top", type=int, default=12, help="Number of top opcodes for scatter plots")
     args = parser.parse_args()
 
     data = load_all(args.joined_dir)
@@ -187,39 +227,32 @@ def main():
 
     os.makedirs(args.out_dir, exist_ok=True)
 
-    # Auto-select interesting opcodes (high variance in cycles/gas)
-    if args.opcodes:
-        selected = args.opcodes.split(",")
-    else:
-        # Pick opcodes with highest max/median cpg ratio (most variance)
-        variance = []
-        for name, rows in data.items():
-            cpg = sorted([r["cpg"] for r in rows if r["cpg"] > 0])
-            if len(cpg) > 10:
-                med = cpg[len(cpg) // 2]
-                mx = cpg[-1]
-                if med > 0:
-                    variance.append((name, mx / med))
-        variance.sort(key=lambda x: x[1], reverse=True)
-        selected = [v[0] for v in variance[:6]]
-
-    print(f"Generating charts for {len(data)} opcodes...")
-    print(f"Selected for detail: {', '.join(selected)}")
-
-    plot_cpg_boxplot(data, os.path.join(args.out_dir, "cpg_boxplot.png"))
-    print(f"  -> {args.out_dir}/cpg_boxplot.png")
-
-    plot_total_cycles(data, os.path.join(args.out_dir, "total_cycles.png"))
+    # 1. Total cycles bar chart
+    top_opcodes = plot_total_cycles(data, os.path.join(args.out_dir, "total_cycles.png"))
     print(f"  -> {args.out_dir}/total_cycles.png")
 
-    if selected:
-        plot_scatter(data, selected, os.path.join(args.out_dir, "gas_vs_cycles.png"))
-        print(f"  -> {args.out_dir}/gas_vs_cycles.png")
+    # 2. Per-opcode scatter plots for top consumers
+    scatter_dir = os.path.join(args.out_dir, "scatter")
+    os.makedirs(scatter_dir, exist_ok=True)
+    for name in top_opcodes[:args.top]:
+        if name in data:
+            out = os.path.join(scatter_dir, f"{name}.png")
+            plot_opcode_scatter(name, data[name], out)
+            print(f"  -> {out}")
 
-        plot_cpg_histogram(data, selected, os.path.join(args.out_dir, "cpg_histograms.png"))
-        print(f"  -> {args.out_dir}/cpg_histograms.png")
+    # 3. Outlier analysis
+    outliers = analyze_outliers(data)
+    report_path = os.path.join(args.out_dir, "outlier_report.md")
+    write_outlier_report(outliers, report_path)
+    print(f"  -> {report_path}")
 
-    print("Done.")
+    # Print summary to stdout too
+    if outliers:
+        print(f"\nTop outliers (worst/median severity):")
+        for o in outliers[:10]:
+            print(f"  {o['opcode']:<16} {o['severity']:>6.1f}x  "
+                  f"(p50={o['p50_cpg']:.1f}, max={o['max_cpg']:.1f} c/g, "
+                  f"worst: gas={o['worst_gas']} cycles={o['worst_cycles']})")
 
 
 if __name__ == "__main__":

--- a/bench_scripts/visualize_opcode_stats.py
+++ b/bench_scripts/visualize_opcode_stats.py
@@ -2,7 +2,7 @@
 
 Reads the joined per-execution CSVs to produce:
   1. Total cycle consumption bar chart (top opcodes)
-  2. Per-opcode scatter plots (gas vs cycles) for top consumers
+  2. Sorted cycles/gas ratio curves per opcode (top consumers)
   3. Outlier analysis report
 
 Usage:
@@ -13,7 +13,6 @@ import os
 import sys
 import argparse
 import csv
-import math
 
 try:
     import matplotlib
@@ -50,10 +49,6 @@ def load_all(joined_dir):
         if rows:
             data[name] = rows
     return data
-
-
-def ratio(num, den):
-    return num / den if den > 0 else 0.0
 
 
 def percentile(sorted_vals, p):
@@ -96,47 +91,71 @@ def plot_total_cycles(data, out_path, top_n=25):
     return [t[0] for t in totals]
 
 
-def plot_opcode_scatter(name, rows, out_path):
-    """Scatter plot: gas vs cycles for a single opcode, with outlier highlighting."""
-    gas = [r["gas"] for r in rows]
-    cycles = [r["cycles"] for r in rows]
-    cpg = sorted([r["cpg"] for r in rows if r["cpg"] > 0])
+def plot_sorted_cpg(data, opcodes, out_path):
+    """Plot sorted cycles/gas ratios for each opcode on a single chart.
 
-    if not cpg:
+    X axis: execution index (sorted by cycles/gas ascending)
+    Y axis: cycles/gas ratio
+    Each opcode is a separate line — shows the full distribution shape.
+    """
+    fig, ax = plt.subplots(figsize=(14, 8))
+    colors = plt.cm.tab20.colors
+
+    for idx, name in enumerate(opcodes):
+        if name not in data:
+            continue
+        cpg = sorted([r["cpg"] for r in data[name] if r["gas"] > 0])
+        if not cpg:
+            continue
+        # Normalize x to [0, 1] so opcodes with different counts are comparable
+        n = len(cpg)
+        xs = [i / (n - 1) if n > 1 else 0.5 for i in range(n)]
+        color = colors[idx % len(colors)]
+        p50 = percentile(cpg, 50)
+        ax.plot(xs, cpg, color=color, linewidth=1.5, alpha=0.8,
+                label=f"{name} (n={n}, p50={p50:.0f})")
+
+    ax.set_xlabel("Percentile (fraction of executions)")
+    ax.set_ylabel("Cycles / Gas")
+    ax.set_title("Sorted Cycles/Gas Ratios by Opcode")
+    ax.set_yscale("log")
+    ax.legend(fontsize=7, loc="upper left", ncol=2)
+    ax.grid(alpha=0.3, which="both")
+    ax.set_xlim(0, 1)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def plot_sorted_cpg_detail(name, rows, out_path):
+    """Per-opcode sorted cycles/gas curve with p50/p95/p99 annotations."""
+    cpg = sorted([r["cpg"] for r in rows if r["gas"] > 0])
+    if len(cpg) < 3:
         return
+
+    n = len(cpg)
+    xs = [i / (n - 1) if n > 1 else 0.5 for i in range(n)]
 
     p50 = percentile(cpg, 50)
     p95 = percentile(cpg, 95)
     p99 = percentile(cpg, 99)
+    max_val = cpg[-1]
 
-    # Color points by severity
-    colors = []
-    for r in rows:
-        c = r["cpg"] if r["gas"] > 0 else 0
-        if c >= p99:
-            colors.append("#d62728")  # red — p99+
-        elif c >= p95:
-            colors.append("#ff7f0e")  # orange — p95-p99
-        else:
-            colors.append("#1f77b4")  # blue — normal
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(xs, cpg, color="#4C72B0", linewidth=1.5)
+    ax.fill_between(xs, cpg, alpha=0.15, color="#4C72B0")
 
-    fig, ax = plt.subplots(figsize=(8, 6))
-    ax.scatter(gas, cycles, c=colors, alpha=0.6, s=20, edgecolors="none")
+    # Annotate percentiles
+    for pct, val, color in [(50, p50, "green"), (95, p95, "orange"), (99, p99, "red")]:
+        ax.axhline(val, color=color, linestyle="--", linewidth=0.8, alpha=0.7)
+        ax.text(0.02, val, f"p{pct}={val:.1f}", fontsize=8, color=color,
+                va="bottom")
 
-    # Draw ratio reference lines
-    max_gas = max(gas) if gas else 1
-    for label, val, style in [("p50", p50, "--"), ("p95", p95, ":"), ("p99", p99, "-.")]:
-        if val > 0 and val < 1e6:
-            xs = [0, max_gas]
-            ys = [0, max_gas * val]
-            ax.plot(xs, ys, style, color="gray", alpha=0.5, linewidth=1,
-                    label=f"{label} c/g={val:.1f}")
-
-    ax.set_xlabel("Gas")
-    ax.set_ylabel("Cycles")
-    ax.set_title(f"{name} — Gas vs Cycles (n={len(rows)})")
-    ax.legend(fontsize=7, loc="upper left")
-    ax.grid(alpha=0.2)
+    ax.set_xlabel("Percentile (fraction of executions)")
+    ax.set_ylabel("Cycles / Gas")
+    ax.set_title(f"{name} — Sorted Cycles/Gas (n={n}, max={max_val:.1f})")
+    ax.grid(alpha=0.3)
+    ax.set_xlim(0, 1)
     plt.tight_layout()
     plt.savefig(out_path, dpi=150)
     plt.close()
@@ -158,13 +177,8 @@ def analyze_outliers(data, top_n=15):
         if p50 == 0:
             continue
 
-        # Ratio of worst case to median
         severity = max_cpg / p50
 
-        # Count of p99+ outliers
-        n_outliers = sum(1 for c in cpg if c >= p99)
-
-        # Find the actual worst execution
         worst = max((r for r in rows if r["gas"] > 0), key=lambda r: r["cpg"], default=None)
 
         if worst and severity > 1.5:
@@ -176,7 +190,6 @@ def analyze_outliers(data, top_n=15):
                 "p99_cpg": p99,
                 "max_cpg": max_cpg,
                 "severity": severity,
-                "n_outliers": n_outliers,
                 "worst_gas": worst["gas"],
                 "worst_native": worst["native"],
                 "worst_cycles": worst["cycles"],
@@ -193,8 +206,8 @@ def write_outlier_report(outliers, out_path):
         f.write("Opcodes sorted by worst-case / median cycles/gas ratio (severity).\n")
         f.write("High severity = the worst execution is disproportionately expensive relative to typical.\n\n")
 
-        f.write(f"| Opcode | Count | p50 c/g | p95 c/g | p99 c/g | max c/g | severity | worst execution |\n")
-        f.write(f"|--------|-------|---------|---------|---------|---------|----------|------------------|\n")
+        f.write("| Opcode | Count | p50 c/g | p95 c/g | p99 c/g | max c/g | severity | worst execution |\n")
+        f.write("|--------|-------|---------|---------|---------|---------|----------|------------------|\n")
 
         for o in outliers:
             worst = f"gas={o['worst_gas']}, cycles={o['worst_cycles']}, native={o['worst_native']}"
@@ -217,7 +230,7 @@ def main():
     parser = argparse.ArgumentParser(description="Visualize per-opcode benchmarking stats")
     parser.add_argument("joined_dir", help="Directory with per-execution .csv files")
     parser.add_argument("--out-dir", default=".", help="Output directory for charts")
-    parser.add_argument("--top", type=int, default=12, help="Number of top opcodes for scatter plots")
+    parser.add_argument("--top", type=int, default=12, help="Number of top opcodes for detail plots")
     args = parser.parse_args()
 
     data = load_all(args.joined_dir)
@@ -231,22 +244,25 @@ def main():
     top_opcodes = plot_total_cycles(data, os.path.join(args.out_dir, "total_cycles.png"))
     print(f"  -> {args.out_dir}/total_cycles.png")
 
-    # 2. Per-opcode scatter plots for top consumers
-    scatter_dir = os.path.join(args.out_dir, "scatter")
-    os.makedirs(scatter_dir, exist_ok=True)
+    # 2. Combined sorted cycles/gas curves
+    plot_sorted_cpg(data, top_opcodes[:args.top], os.path.join(args.out_dir, "sorted_cpg.png"))
+    print(f"  -> {args.out_dir}/sorted_cpg.png")
+
+    # 3. Per-opcode detail curves for top consumers
+    detail_dir = os.path.join(args.out_dir, "detail")
+    os.makedirs(detail_dir, exist_ok=True)
     for name in top_opcodes[:args.top]:
         if name in data:
-            out = os.path.join(scatter_dir, f"{name}.png")
-            plot_opcode_scatter(name, data[name], out)
+            out = os.path.join(detail_dir, f"{name}.png")
+            plot_sorted_cpg_detail(name, data[name], out)
             print(f"  -> {out}")
 
-    # 3. Outlier analysis
+    # 4. Outlier analysis
     outliers = analyze_outliers(data)
     report_path = os.path.join(args.out_dir, "outlier_report.md")
     write_outlier_report(outliers, report_path)
     print(f"  -> {report_path}")
 
-    # Print summary to stdout too
     if outliers:
         print(f"\nTop outliers (worst/median severity):")
         for o in outliers[:10]:

--- a/bench_scripts/visualize_opcode_stats.py
+++ b/bench_scripts/visualize_opcode_stats.py
@@ -257,18 +257,7 @@ def main():
             plot_sorted_cpg_detail(name, data[name], out)
             print(f"  -> {out}")
 
-    # 4. Outlier analysis
-    outliers = analyze_outliers(data)
-    report_path = os.path.join(args.out_dir, "outlier_report.md")
-    write_outlier_report(outliers, report_path)
-    print(f"  -> {report_path}")
-
-    if outliers:
-        print(f"\nTop outliers (worst/median severity):")
-        for o in outliers[:10]:
-            print(f"  {o['opcode']:<16} {o['severity']:>6.1f}x  "
-                  f"(p50={o['p50_cpg']:.1f}, max={o['max_cpg']:.1f} c/g, "
-                  f"worst: gas={o['worst_gas']} cycles={o['worst_cycles']})")
+    print("Done.")
 
 
 if __name__ == "__main__":

--- a/callable_oracles/src/blob_kzg_commitment/mod.rs
+++ b/callable_oracles/src/blob_kzg_commitment/mod.rs
@@ -56,7 +56,7 @@ impl<M: MemorySource> OracleQueryProcessor<M> for BlobCommitmentAndProofQuery<M>
         let data = read_memory_as_u8(memory, data_ptr, data_len).unwrap();
         let result = blob_kzg_commitment_and_proof(&data);
 
-        let r = result.iter().collect::<Vec<_>>();
+        let r = UsizeSerializable::iter(&result).collect::<Vec<_>>();
         let r = Vec::into_boxed_slice(r);
         let n = UsizeSliceIteratorOwned::new(r);
         Box::new(n)

--- a/callable_oracles/src/field_hints/impls.rs
+++ b/callable_oracles/src/field_hints/impls.rs
@@ -1,0 +1,46 @@
+use crypto::k256::{Scalar, U256};
+use crypto::secp256k1::FieldElement;
+use zk_ee::utils::Bytes32;
+
+/// Computes the square root candidate for a secp256k1 base field element.
+///
+/// Returns `(candidate, is_quadratic_non_residue)` where:
+/// - `candidate` is `input^((p+1)/4)` (the square root if one exists)
+/// - `is_quadratic_non_residue` is `true` if `input` has no square root in the field
+///
+/// When `is_quadratic_non_residue` is false: `candidate² == input`
+/// When `is_quadratic_non_residue` is true:  `candidate² == -input`
+pub(crate) fn secp256k1_base_field_sqrt(input: Bytes32) -> (Bytes32, bool) {
+    // NOTE: input is in normal form
+    let el = FieldElement::from_bytes(input.as_u8_array_ref()).expect("must be normalized");
+    assert!(el.normalizes_to_zero() == false);
+    let mut candidate = el;
+    // sqrt_in_place_inner returns true if the input is a quadratic residue (has a square root)
+    let is_quadratic_residue = candidate.sqrt_in_place_inner();
+    (
+        Bytes32::from_array(candidate.to_bytes().into()),
+        !is_quadratic_residue,
+    )
+}
+
+pub(crate) fn secp256k1_base_field_inverse(input: Bytes32) -> Bytes32 {
+    // NOTE: input is in normal form
+    let mut el = FieldElement::from_bytes(input.as_u8_array_ref()).expect("must be normalized");
+    assert!(el.normalizes_to_zero() == false);
+    el.invert_in_place_inner();
+    Bytes32::from_array(el.to_bytes().into())
+}
+
+pub(crate) fn secp256k1_scalar_field_inverse(input: Bytes32) -> Bytes32 {
+    use crypto::k256::elliptic_curve::ops::Invert;
+    use crypto::k256::elliptic_curve::scalar::FromUintUnchecked;
+    use crypto::k256::elliptic_curve::Curve;
+
+    // NOTE: input is in normal form
+    let el = U256::from_be_slice(input.as_u8_array_ref());
+    assert!(el < crypto::k256::Secp256k1::ORDER);
+    let scalar: Scalar = Scalar::from_uint_unchecked(el);
+    let inverse = scalar.invert_vartime().unwrap();
+
+    Bytes32::from_array(inverse.to_bytes().into())
+}

--- a/callable_oracles/src/field_hints/mod.rs
+++ b/callable_oracles/src/field_hints/mod.rs
@@ -1,0 +1,166 @@
+//! Oracle query processors for secp256k1 field operations (sqrt, inverse).
+//!
+//! Provides two implementations:
+//! - [`FieldOpsQuery`]: Reads operands from simulated RISC-V memory.
+//! - [`NativeFieldOpsQuery`]: Reads operands directly from native memory (for host execution).
+
+use basic_system::system_functions::field_ops::{FieldHintOp, FieldOpsHint};
+use basic_system::system_functions::field_ops::{FieldOpsHint64, FIELD_OPS_ADVISE_QUERY_ID};
+use oracle_provider::OracleQueryProcessor;
+use risc_v_simulator::abstractions::memory::MemorySource;
+use zk_ee::oracle::usize_serialization::dyn_usize_iterator::DynUsizeIterator;
+use zk_ee::oracle::usize_serialization::UsizeSerializable;
+use zk_ee::utils::Bytes32;
+mod impls;
+
+use crate::read_u64_words;
+use crate::utils::evaluate::{read_memory_as_u64, read_struct};
+
+pub struct FieldOpsQuery<M: MemorySource> {
+    _marker: std::marker::PhantomData<M>,
+}
+
+impl<M: MemorySource> Default for FieldOpsQuery<M> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<M: MemorySource> OracleQueryProcessor<M> for FieldOpsQuery<M> {
+    fn supported_query_ids(&self) -> Vec<u32> {
+        vec![FIELD_OPS_ADVISE_QUERY_ID]
+    }
+
+    fn process_buffered_query(
+        &mut self,
+        query_id: u32,
+        query: Vec<usize>,
+        memory: &M,
+    ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+        debug_assert!(self.supports_query_id(query_id));
+
+        let mut it = query.into_iter();
+
+        let arg_ptr = it.next().expect("A u32 should've been passed in.");
+
+        assert!(
+            it.next().is_none(),
+            "A single RISC-V ptr should've been passed."
+        );
+
+        assert!(arg_ptr.is_multiple_of(4));
+        const { assert!(core::mem::align_of::<FieldOpsHint>() == 4) }
+        const { assert!(core::mem::size_of::<FieldOpsHint>().is_multiple_of(4)) }
+
+        let arg = unsafe { read_struct::<FieldOpsHint, M>(memory, arg_ptr as u32) }.unwrap();
+
+        let Some(op) = FieldHintOp::parse_u32(arg.op) else {
+            panic!("Unknown field hint op {}", arg.op);
+        };
+
+        const { assert!(8 == core::mem::size_of::<usize>()) };
+        assert!(arg.src_ptr > 0);
+        assert_eq!(arg.src_len_u32_words, 8);
+        let n = read_memory_as_u64(memory, arg.src_ptr as u32, arg.src_len_u32_words / 2).unwrap();
+
+        let n = Bytes32::from_array(
+            n.into_iter()
+                .flat_map(|el| el.to_le_bytes())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        );
+
+        match op {
+            FieldHintOp::Secp256k1BaseFieldSqrt => {
+                let t = impls::secp256k1_base_field_sqrt(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            FieldHintOp::Secp256k1BaseFieldInverse => {
+                let t = impls::secp256k1_base_field_inverse(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            FieldHintOp::Secp256k1ScalarFieldInverse => {
+                let t = impls::secp256k1_scalar_field_inverse(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            _ => {
+                panic!("Unknown field hint op {}", arg.op);
+            }
+        }
+    }
+}
+
+pub struct NativeFieldOpsQuery<M: MemorySource> {
+    _marker: std::marker::PhantomData<M>,
+}
+
+impl<M: MemorySource> Default for NativeFieldOpsQuery<M> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<M: MemorySource> OracleQueryProcessor<M> for NativeFieldOpsQuery<M> {
+    fn supported_query_ids(&self) -> Vec<u32> {
+        vec![FIELD_OPS_ADVISE_QUERY_ID]
+    }
+
+    fn process_buffered_query(
+        &mut self,
+        query_id: u32,
+        query: Vec<usize>,
+        _memory: &M,
+    ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+        debug_assert!(self.supports_query_id(query_id));
+
+        let mut it = query.into_iter();
+
+        let arg_ptr = it.next().expect("A u64 should've been passed in.");
+
+        assert!(it.next().is_none(), "A single ptr should've been passed.");
+
+        let arg = unsafe {
+            let p = arg_ptr as *const FieldOpsHint64;
+            core::ptr::read_unaligned(p)
+        };
+
+        let Some(op) = FieldHintOp::parse_u32(arg.op) else {
+            panic!("Unknown field hint op {}", arg.op);
+        };
+
+        const { assert!(8 == core::mem::size_of::<usize>()) };
+        assert!(arg.src_ptr > 0);
+        assert_eq!(arg.src_len_u32_words, 8);
+        let n: Vec<u64> = unsafe { read_u64_words(arg.src_ptr, arg.src_len_u32_words as u64 / 2) };
+        let n = Bytes32::from_array(
+            n.into_iter()
+                .flat_map(|el| el.to_le_bytes())
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        );
+
+        match op {
+            FieldHintOp::Secp256k1BaseFieldSqrt => {
+                let t = impls::secp256k1_base_field_sqrt(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            FieldHintOp::Secp256k1BaseFieldInverse => {
+                let t = impls::secp256k1_base_field_inverse(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            FieldHintOp::Secp256k1ScalarFieldInverse => {
+                let t = impls::secp256k1_scalar_field_inverse(n);
+                DynUsizeIterator::from_constructor(t, UsizeSerializable::iter)
+            }
+            _ => {
+                panic!("Unknown field hint op {}", arg.op);
+            }
+        }
+    }
+}

--- a/callable_oracles/src/lib.rs
+++ b/callable_oracles/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod arithmetic;
 pub mod blob_kzg_commitment;
+pub mod field_hints;
 pub mod utils;
 
 use zk_ee::{
@@ -57,4 +58,14 @@ impl UsizeDeserializable for MemoryRegionDescriptionParams {
 
         Ok(new)
     }
+}
+
+#[inline(always)]
+unsafe fn read_u64_words(ptr_u64: u64, len_words_u64: u64) -> Vec<u64> {
+    if ptr_u64 == 0 || len_words_u64 == 0 {
+        return vec![];
+    }
+    let addr = ptr_u64 as usize;
+    let len_words = len_words_u64 as usize;
+    core::slice::from_raw_parts(addr as *const u64, len_words).to_vec()
 }

--- a/callable_oracles/src/utils/evaluate.rs
+++ b/callable_oracles/src/utils/evaluate.rs
@@ -72,7 +72,7 @@ pub fn read_memory_as_u64<M: MemorySource>(
         return Err(());
     }
 
-    let mut result = Vec::with_capacity(len_u32_words as usize * 2);
+    let mut result = Vec::with_capacity(len_u64_words as usize);
 
     let mut trap = TrapReason::NoTrap;
 

--- a/crypto/src/secp256k1/field/mod.rs
+++ b/crypto/src/secp256k1/field/mod.rs
@@ -120,7 +120,7 @@ pub struct FieldElement(pub(crate) FieldElementImpl);
 
 impl FieldElement {
     pub(crate) const ZERO: Self = Self(FieldElementImpl::ZERO);
-    pub(crate) const ONE: Self = Self(FieldElementImpl::ONE);
+    pub const ONE: Self = Self(FieldElementImpl::ONE);
     // 0x7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee
     pub(crate) const BETA: Self = Self(FieldElementImpl::BETA);
 
@@ -129,7 +129,7 @@ impl FieldElement {
         Self(FieldElementImpl::from_bytes_unchecked(bytes))
     }
 
-    pub(crate) fn from_bytes(bytes: &[u8; 32]) -> Option<Self> {
+    pub fn from_bytes(bytes: &[u8; 32]) -> Option<Self> {
         FieldElementImpl::from_bytes(bytes).map(Self)
     }
 
@@ -141,11 +141,11 @@ impl FieldElement {
         self.0.mul_int_in_place(rhs);
     }
 
-    pub(crate) fn square_in_place(&mut self) {
+    pub fn square_in_place(&mut self) {
         self.0.square_in_place();
     }
 
-    pub(crate) fn add_in_place(&mut self, rhs: &Self) {
+    pub fn add_in_place(&mut self, rhs: &Self) {
         self.0.add_in_place(&rhs.0);
     }
 
@@ -153,7 +153,7 @@ impl FieldElement {
         self.0.double_in_place();
     }
 
-    pub(crate) fn sub_in_place(&mut self, rhs: &Self) {
+    pub fn sub_in_place(&mut self, rhs: &Self) {
         self.0.sub_in_place(&rhs.0);
     }
 
@@ -161,7 +161,8 @@ impl FieldElement {
         self.0.add_int_in_place(rhs);
     }
 
-    pub(crate) fn invert_in_place(&mut self) {
+    // Note: try to use the hook version whenever possible
+    pub fn invert_in_place_inner(&mut self) {
         self.0.invert_in_place()
     }
 
@@ -214,7 +215,8 @@ impl FieldElement {
         self.pow2k_in_place(2);
     }
 
-    pub(crate) fn sqrt_in_place(&mut self) -> bool {
+    // Note: try to use the hook version whenever possible
+    pub fn sqrt_in_place_inner(&mut self) -> bool {
         let original = *self;
         self.sqrt_in_place_unchecked();
 
@@ -225,19 +227,20 @@ impl FieldElement {
 
         is_root.normalizes_to_zero()
     }
-    pub(crate) fn negate_in_place(&mut self, magnitude: u32) {
+
+    pub fn negate_in_place(&mut self, magnitude: u32) {
         self.0.negate_in_place(magnitude);
     }
 
-    pub(crate) fn normalize_in_place(&mut self) {
+    pub fn normalize_in_place(&mut self) {
         self.0.normalize_in_place();
     }
 
-    pub(crate) fn is_odd(&self) -> bool {
+    pub fn is_odd(&self) -> bool {
         self.0.is_odd()
     }
 
-    pub(crate) fn normalizes_to_zero(&self) -> bool {
+    pub fn normalizes_to_zero(&self) -> bool {
         self.0.normalizes_to_zero()
     }
 
@@ -248,7 +251,7 @@ impl FieldElement {
         }
     }
 
-    pub(crate) fn to_bytes(mut self) -> FieldBytes {
+    pub fn to_bytes(mut self) -> FieldBytes {
         self.normalize_in_place();
         self.0.to_bytes()
     }
@@ -432,11 +435,11 @@ mod tests {
     fn test_invert() {
         proptest!(|(x: FieldElement)| {
             let mut a = x;
-            a.invert_in_place();
-            a.invert_in_place();
+            a.invert_in_place_inner();
+            a.invert_in_place_inner();
             prop_assert_eq!(a, x);
 
-            a.invert_in_place();
+            a.invert_in_place_inner();
             a.mul_in_place(&x);
             if x.normalizes_to_zero() {
                 prop_assert_eq!(a, FieldElement::ZERO);
@@ -514,12 +517,12 @@ mod tests {
 
             a = x;
             a.square_in_place();
-            a.sqrt_in_place();
+            a.sqrt_in_place_inner();
 
             prop_assert!(a == x || a == x_neg);
 
             a = x;
-            a.sqrt_in_place();
+            a.sqrt_in_place_inner();
             a.square_in_place();
 
             prop_assert!(a == x || a == x_neg)

--- a/crypto/src/secp256k1/hooks.rs
+++ b/crypto/src/secp256k1/hooks.rs
@@ -1,0 +1,34 @@
+//! This module defines hooks for Secp256k1 field operations that can be
+//! overridden to provide custom implementations, such as using an oracle for
+//! square root and inversion operations.
+
+pub trait Secp256k1Hooks {
+    /// Computes the square root of a Secp256k1 field element and assigns it to the input.
+    /// Returns true if the square root exists, false otherwise.
+    fn fe_sqrt_and_assign(&mut self, fe: &mut crate::secp256k1::field::FieldElement) -> bool;
+
+    /// Computes the multiplicative inverse of a Secp256k1 field element and assigns it to the input.
+    fn fe_invert_and_assign(&mut self, fe: &mut crate::secp256k1::field::FieldElement);
+
+    /// Computes the multiplicative inverse of a Secp256k1 scalar and assigns it to the input.
+    fn scalar_invert_and_assign(&mut self, scalar: &mut crate::secp256k1::scalars::Scalar);
+}
+
+pub struct DefaultSecp256k1Hooks;
+
+impl Secp256k1Hooks for DefaultSecp256k1Hooks {
+    #[inline(always)]
+    fn fe_sqrt_and_assign(&mut self, fe: &mut crate::secp256k1::field::FieldElement) -> bool {
+        fe.sqrt_in_place_inner()
+    }
+
+    #[inline(always)]
+    fn fe_invert_and_assign(&mut self, fe: &mut crate::secp256k1::field::FieldElement) {
+        fe.invert_in_place_inner()
+    }
+
+    #[inline(always)]
+    fn scalar_invert_and_assign(&mut self, scalar: &mut crate::secp256k1::scalars::Scalar) {
+        scalar.invert_in_place_inner()
+    }
+}

--- a/crypto/src/secp256k1/mod.rs
+++ b/crypto/src/secp256k1/mod.rs
@@ -3,6 +3,7 @@
 
 mod context;
 mod field;
+pub mod hooks;
 mod points;
 mod recover;
 mod scalars;
@@ -14,7 +15,11 @@ use core::fmt::Debug;
 use core::fmt::Display;
 
 pub use context::ECMultContext;
+pub use field::FieldElement;
+pub use points::Affine;
+pub use recover::ecmult;
 pub use recover::recover_with_context;
+pub use scalars::Scalar;
 
 #[cfg(feature = "secp256k1-static-context")]
 pub use recover::recover;
@@ -53,6 +58,8 @@ impl Display for Secp256k1Err {
 
 #[cfg(feature = "secp256k1-static-context")]
 pub fn ecrecover_test() {
+    use hooks::DefaultSecp256k1Hooks;
+
     use crate::k256::{
         ecdsa::{hazmat::bits2field, SigningKey},
         elliptic_curve::{group::GroupEncoding, ops::Reduce},
@@ -87,7 +94,8 @@ pub fn ecrecover_test() {
             .unwrap(),
     );
 
-    let recovered_key = recover(&msg, &signature, &recovery_id).unwrap();
+    let recovered_key =
+        recover(&msg, &signature, &recovery_id, &mut DefaultSecp256k1Hooks).unwrap();
 
     assert_eq!(recovered_key.to_bytes(), public_key.to_bytes());
 }

--- a/crypto/src/secp256k1/points/affine.rs
+++ b/crypto/src/secp256k1/points/affine.rs
@@ -1,6 +1,7 @@
 use crate::k256::{elliptic_curve::subtle::Choice, CompressedPoint, EncodedPoint, FieldBytes};
 
 use crate::secp256k1::field::{FieldElement, FieldElementConst};
+use crate::secp256k1::hooks::Secp256k1Hooks;
 
 use super::{jacobian::JacobianConst, AffineStorage, Jacobian};
 
@@ -132,7 +133,11 @@ impl Affine {
         self.infinity || (self.x.normalizes_to_zero() && self.y.normalizes_to_zero())
     }
 
-    pub(crate) fn decompress(x_bytes: &FieldBytes, y_is_odd: bool) -> Option<Self> {
+    pub(crate) fn decompress<H: Secp256k1Hooks>(
+        x_bytes: &FieldBytes,
+        y_is_odd: bool,
+        hooks: &mut H,
+    ) -> Option<Self> {
         #[allow(deprecated)]
         let len = x_bytes.as_slice().len();
         debug_assert!(len == 32);
@@ -141,7 +146,7 @@ impl Affine {
         x_bytes.as_slice().try_into().ok().and_then(|x| {
             let x = FieldElement::from_bytes(x)?;
             let mut ret = Affine::DEFAULT;
-            if ret.set_xo(&x, y_is_odd) {
+            if ret.set_xo(&x, y_is_odd, hooks) {
                 Some(ret)
             } else {
                 None
@@ -149,13 +154,19 @@ impl Affine {
         })
     }
 
-    fn set_xo(&mut self, x: &FieldElement, y_is_odd: bool) -> bool {
+    #[allow(dead_code)]
+    fn set_xo<H: Secp256k1Hooks>(
+        &mut self,
+        x: &FieldElement,
+        y_is_odd: bool,
+        hooks: &mut H,
+    ) -> bool {
         self.y = *x;
         self.y.square_in_place();
         self.y *= x;
         self.y += 7;
 
-        let ret = self.y.sqrt_in_place();
+        let ret = hooks.fe_sqrt_and_assign(&mut self.y);
         self.y.normalize_in_place();
 
         if self.y.is_odd() != y_is_odd {
@@ -257,7 +268,11 @@ impl proptest::arbitrary::Arbitrary for Affine {
 
         any::<FieldElement>().prop_map(|x| {
             let mut ret = Affine::DEFAULT;
-            ret.set_xo(&x, true);
+            ret.set_xo(
+                &x,
+                true,
+                &mut crate::secp256k1::hooks::DefaultSecp256k1Hooks,
+            );
 
             ret
         })
@@ -269,7 +284,7 @@ impl proptest::arbitrary::Arbitrary for Affine {
 #[cfg(test)]
 mod tests {
     use super::Affine;
-
+    use crate::secp256k1::hooks::DefaultSecp256k1Hooks;
     use proptest::{prop_assert_eq, proptest};
 
     #[test]
@@ -278,14 +293,14 @@ mod tests {
         let x = g.x;
         let y_is_odd = false;
         let mut a = Affine::DEFAULT;
-        a.set_xo(&x, y_is_odd);
+        a.set_xo(&x, y_is_odd, &mut DefaultSecp256k1Hooks);
         assert_eq!(a, g);
     }
 
     #[test]
     fn jacobian_round_trip() {
         proptest!(|(x: Affine)| {
-            prop_assert_eq!(x.to_jacobian().to_affine(), x);
+            prop_assert_eq!(x.to_jacobian().to_affine(&mut DefaultSecp256k1Hooks), x);
         });
     }
 }

--- a/crypto/src/secp256k1/points/jacobian.rs
+++ b/crypto/src/secp256k1/points/jacobian.rs
@@ -1,4 +1,7 @@
-use crate::secp256k1::field::{FieldElement, FieldElementConst};
+use crate::secp256k1::{
+    field::{FieldElement, FieldElementConst},
+    hooks::Secp256k1Hooks,
+};
 
 use super::{affine::AffineConst, Affine, AffineStorage};
 
@@ -174,7 +177,7 @@ impl JacobianConst {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Jacobian {
+pub struct Jacobian {
     pub(crate) x: FieldElement,
     pub(crate) y: FieldElement,
     pub(crate) z: FieldElement,
@@ -206,7 +209,7 @@ impl Jacobian {
         self.z.normalizes_to_zero()
     }
 
-    pub(crate) fn to_affine(self) -> Affine {
+    pub(crate) fn to_affine<H: Secp256k1Hooks>(self, hooks: &mut H) -> Affine {
         self.assert_verify();
 
         if self.is_infinity() {
@@ -214,7 +217,7 @@ impl Jacobian {
         }
 
         let mut zi = self.z;
-        zi.invert_in_place();
+        hooks.fe_invert_and_assign(&mut zi);
 
         let mut ret = Affine {
             x: zi,
@@ -474,6 +477,7 @@ mod tests {
 
     use crate::secp256k1::{
         field::{FieldElement, FieldElementConst},
+        hooks::DefaultSecp256k1Hooks,
         points::{affine::AffineConst, Affine, Jacobian},
         test_vectors::ADD_TEST_VECTORS,
     };
@@ -522,21 +526,24 @@ mod tests {
         let g = Affine::GENERATOR;
         let mut a = Jacobian::INFINITY;
         a.add_ge_in_place(Affine::INFINITY, None);
-        assert_eq!(a.to_affine(), Affine::INFINITY);
+        assert_eq!(a.to_affine(&mut DefaultSecp256k1Hooks), Affine::INFINITY);
 
         a.add_ge_in_place(g, None);
-        assert_eq!(a.to_affine(), g);
+        assert_eq!(a.to_affine(&mut DefaultSecp256k1Hooks), g);
 
         let mut g2 = g.to_jacobian();
         g2.add_ge_in_place(g, None);
         let mut g4 = g2;
-        g4.add_ge_in_place(g2.to_affine(), None);
+        g4.add_ge_in_place(g2.to_affine(&mut DefaultSecp256k1Hooks), None);
 
         let mut g4_double = g.to_jacobian();
         g4_double.double_in_place(None);
         g4_double.double_in_place(None);
 
-        assert_eq!(g4.to_affine(), g4_double.to_affine());
+        assert_eq!(
+            g4.to_affine(&mut DefaultSecp256k1Hooks),
+            g4_double.to_affine(&mut DefaultSecp256k1Hooks)
+        );
     }
 
     #[test]
@@ -562,7 +569,7 @@ mod tests {
         let mut p = g.to_jacobian();
 
         for i in 0..ADD_TEST_VECTORS.len() {
-            let a = p.to_affine();
+            let a = p.to_affine(&mut DefaultSecp256k1Hooks);
 
             let expected = Affine {
                 x: FieldElement::from_bytes(&ADD_TEST_VECTORS[i].0).unwrap(),
@@ -608,13 +615,13 @@ mod tests {
         tt.double_in_place(None);
         tt.double_in_place(None);
 
-        let tt = tt.to_affine();
+        let tt = tt.to_affine(&mut DefaultSecp256k1Hooks);
 
         // t = 5G + 3G
         let mut t = ECRECOVER_CONTEXT.pre_g[2].to_affine().to_jacobian();
         t.add_ge_in_place(ECRECOVER_CONTEXT.pre_g[1].to_affine(), None);
 
-        let t = t.to_affine();
+        let t = t.to_affine(&mut DefaultSecp256k1Hooks);
         assert_eq!(t, tt);
     }
 
@@ -625,14 +632,14 @@ mod tests {
             t.add_zinv_in_place(Affine { x: b.x, y: b.y, infinity: false}, &b.z);
 
             let mut tt = a;
-            tt.add_ge_in_place(b.to_affine(), None);
+            tt.add_ge_in_place(b.to_affine(&mut DefaultSecp256k1Hooks), None);
 
-            prop_assert_eq!(t.to_affine(), tt.to_affine());
+            prop_assert_eq!(t.to_affine(&mut DefaultSecp256k1Hooks), tt.to_affine(&mut DefaultSecp256k1Hooks));
 
             let mut t = Jacobian::INFINITY;
-            let a = a.to_affine();
+            let a = a.to_affine(&mut DefaultSecp256k1Hooks);
             t.add_zinv_in_place(a, &FieldElement::ONE);
-            assert_eq!(t.to_affine(), a);
+            assert_eq!(t.to_affine(&mut DefaultSecp256k1Hooks), a);
         })
     }
 }

--- a/crypto/src/secp256k1/recover.rs
+++ b/crypto/src/secp256k1/recover.rs
@@ -11,27 +11,30 @@ use super::{
         ECMultContext, ECMULT_TABLE_SIZE_A, ECMULT_TABLE_SIZE_G, WINDOW_A, WINDOW_G, WNAF_BITS,
     },
     field::FieldElement,
+    hooks::Secp256k1Hooks,
     points::{Affine, AffineStorage, Jacobian},
     scalars::Scalar,
     Secp256k1Err,
 };
 
 #[cfg(feature = "secp256k1-static-context")]
-pub fn recover(
+pub fn recover<H: Secp256k1Hooks>(
     message: &crate::k256::Scalar,
     signature: &crate::k256::ecdsa::Signature,
     recovery_id: &crate::k256::ecdsa::RecoveryId,
+    hooks: &mut H,
 ) -> Result<Affine, Secp256k1Err> {
     use super::context::ECRECOVER_CONTEXT;
 
-    recover_with_context(message, signature, recovery_id, &ECRECOVER_CONTEXT)
+    recover_with_context(message, signature, recovery_id, &ECRECOVER_CONTEXT, hooks)
 }
 
-pub fn recover_with_context(
+pub fn recover_with_context<H: Secp256k1Hooks>(
     message: &crate::k256::Scalar,
     signature: &crate::k256::ecdsa::Signature,
     recovery_id: &crate::k256::ecdsa::RecoveryId,
     context: &ECMultContext,
+    hooks: &mut H,
 ) -> Result<Affine, Secp256k1Err> {
     let (mut sigr, mut sigs) = Scalar::from_signature(signature);
     let message = Scalar::from_k256_scalar(*message);
@@ -52,17 +55,17 @@ pub fn recover_with_context(
     }
 
     let is_odd = recovery_id.is_y_odd();
-    let x = Affine::decompress(&brx, is_odd).ok_or(Secp256k1Err::InvalidParams)?;
+    let x = Affine::decompress(&brx, is_odd, hooks).ok_or(Secp256k1Err::InvalidParams)?;
 
     let xj = x.to_jacobian();
 
-    sigr.invert_in_place();
+    hooks.scalar_invert_and_assign(&mut sigr);
     sigs *= sigr;
 
     sigr *= message;
     sigr.negate_in_place();
 
-    let mut pk = ecmult(&xj, &sigs, &sigr, context).to_affine();
+    let mut pk = ecmult(&xj, &sigs, &sigr, context).to_affine(hooks);
     pk.normalize_in_place();
 
     if pk.is_infinity() {
@@ -74,7 +77,7 @@ pub fn recover_with_context(
 
 /// Compute na*a+ng*g where g is the generator.
 /// Algorithm adapted from https://github.com/bitcoin-core/secp256k1/blob/master/src/ecmult_impl.h#L237
-fn ecmult(a: &Jacobian, na: &Scalar, ng: &Scalar, context: &ECMultContext) -> Jacobian {
+pub fn ecmult(a: &Jacobian, na: &Scalar, ng: &Scalar, context: &ECMultContext) -> Jacobian {
     let mut z = FieldElement::ONE;
 
     let mut prea: [Affine; ECMULT_TABLE_SIZE_A] = [Affine::DEFAULT; ECMULT_TABLE_SIZE_A];
@@ -377,6 +380,7 @@ fn table_verify(n: i32, w: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::ecmult;
+    use crate::secp256k1::hooks::DefaultSecp256k1Hooks;
     use crate::secp256k1::scalars::Scalar;
     use crate::secp256k1::{context::ECRECOVER_CONTEXT, test_vectors::MUL_TEST_VECTORS};
     use crate::secp256k1::{
@@ -398,7 +402,7 @@ mod tests {
             &Scalar::ZERO,
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert!(res.is_infinity());
     }
@@ -413,7 +417,7 @@ mod tests {
             &Scalar::ONE,
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         res.normalize_in_place();
 
@@ -430,7 +434,7 @@ mod tests {
             &Scalar::from_u128(3),
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert_eq!(res, ECRECOVER_CONTEXT.pre_g[1].to_affine())
     }
@@ -444,7 +448,7 @@ mod tests {
             &Scalar::from_u128(5),
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert_eq!(res, ECRECOVER_CONTEXT.pre_g[2].to_affine());
     }
@@ -456,7 +460,7 @@ mod tests {
         let mut t = ECRECOVER_CONTEXT.pre_g[2].to_affine().to_jacobian();
         t.add_ge_in_place(ECRECOVER_CONTEXT.pre_g[1].to_affine(), None);
 
-        let t = t.to_affine();
+        let t = t.to_affine(&mut DefaultSecp256k1Hooks);
 
         // 0*infinity + 8*G = 8*G
         let res = ecmult(
@@ -465,7 +469,7 @@ mod tests {
             &Scalar::from_u128(8),
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert_eq!(res, t);
     }
@@ -479,7 +483,7 @@ mod tests {
             &Scalar::ZERO,
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert_eq!(res, Affine::GENERATOR);
     }
@@ -493,12 +497,12 @@ mod tests {
             &Scalar::ONE,
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         let mut expected = Affine::GENERATOR.to_jacobian();
         expected.double_in_place(None);
 
-        assert_eq!(res, expected.to_affine())
+        assert_eq!(res, expected.to_affine(&mut DefaultSecp256k1Hooks))
     }
 
     #[cfg(feature = "secp256k1-static-context")]
@@ -510,7 +514,7 @@ mod tests {
             &Scalar::from_u128(2),
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         assert_eq!(res, ECRECOVER_CONTEXT.pre_g[1].to_affine());
     }
@@ -524,7 +528,7 @@ mod tests {
             &Scalar::ONE,
             &ECRECOVER_CONTEXT,
         )
-        .to_affine();
+        .to_affine(&mut DefaultSecp256k1Hooks);
 
         res.normalize_in_place();
 
@@ -540,14 +544,14 @@ mod tests {
                 &Scalar::ZERO,
                 &k,
                 &ECRECOVER_CONTEXT
-            ).to_affine();
+            ).to_affine(&mut DefaultSecp256k1Hooks);
 
             let res2 = ecmult(
                 &Affine::GENERATOR.to_jacobian(),
                 &k,
                 &Scalar::ZERO,
                 &ECRECOVER_CONTEXT
-            ).to_affine();
+            ).to_affine(&mut DefaultSecp256k1Hooks);
 
             prop_assert_eq!(res1, res2);
         })
@@ -559,8 +563,8 @@ mod tests {
         for (k, x, y) in MUL_TEST_VECTORS {
             let k = Scalar::from_repr(k.clone().into());
 
-            let computed_ctx =
-                ecmult(&Jacobian::INFINITY, &Scalar::ZERO, &k, &ECRECOVER_CONTEXT).to_affine();
+            let computed_ctx = ecmult(&Jacobian::INFINITY, &Scalar::ZERO, &k, &ECRECOVER_CONTEXT)
+                .to_affine(&mut DefaultSecp256k1Hooks);
 
             let computed = ecmult(
                 &Affine::GENERATOR.to_jacobian(),
@@ -568,7 +572,7 @@ mod tests {
                 &Scalar::ZERO,
                 &ECRECOVER_CONTEXT,
             )
-            .to_affine();
+            .to_affine(&mut DefaultSecp256k1Hooks);
 
             let expected = Affine {
                 x: FieldElement::from_bytes_unchecked(x),
@@ -643,7 +647,9 @@ mod tests {
         s: [u8; 32],
         rec_id: u8,
     ) -> Result<Affine, super::Secp256k1Err> {
+        use crate::secp256k1::hooks::DefaultSecp256k1Hooks;
         use k256::ecdsa::{RecoveryId, Signature};
+
         use {
             k256::elliptic_curve::ops::Reduce,
             k256::{ecdsa::hazmat::bits2field, Scalar},
@@ -656,6 +662,11 @@ mod tests {
             &bits2field::<k256::Secp256k1>(&digest).unwrap(),
         );
 
-        super::recover(&message, &signature, &recovery_id)
+        super::recover(
+            &message,
+            &signature,
+            &recovery_id,
+            &mut DefaultSecp256k1Hooks,
+        )
     }
 }

--- a/crypto/src/secp256k1/scalars/invert.rs
+++ b/crypto/src/secp256k1/scalars/invert.rs
@@ -1,9 +1,10 @@
 use super::Scalar;
 
 impl Scalar {
+    // Note: try to use the hook version whenever possible
     // using addition chain from
     // https://briansmith.org/ecc-inversion-addition-chains-01#secp256k1_scalar_inversion
-    pub(crate) fn invert_in_place(&mut self) {
+    pub(crate) fn invert_in_place_inner(&mut self) {
         let x_1 = *self;
         self.pow2k_in_place(1);
         let x_10 = *self;
@@ -104,12 +105,12 @@ mod tests {
     fn test_invert() {
         proptest!(|(x: Scalar)| {
             let mut a = x;
-            a.invert_in_place();
-            a.invert_in_place();
+            a.invert_in_place_inner();
+            a.invert_in_place_inner();
             prop_assert_eq!(a, x);
 
             a = x;
-            a.invert_in_place();
+            a.invert_in_place_inner();
             a *= x;
 
             if x.is_zero() {

--- a/crypto/src/secp256k1/scalars/mod.rs
+++ b/crypto/src/secp256k1/scalars/mod.rs
@@ -34,10 +34,8 @@ const ORDER_HEX: &str = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8
 pub struct Scalar(pub(crate) ScalarInner);
 
 impl Scalar {
-    #[cfg(test)]
-    pub(crate) const ZERO: Self = Self(ScalarInner::ZERO);
-    #[cfg(test)]
-    pub(crate) const ONE: Self = Self(ScalarInner::ONE);
+    pub const ZERO: Self = Self(ScalarInner::ZERO);
+    pub const ONE: Self = Self(ScalarInner::ONE);
     #[cfg(test)]
     const ORDER: Self = Self(ScalarInner::ORDER);
     #[cfg(test)]
@@ -63,7 +61,7 @@ impl Scalar {
         (Self::from_k256_scalar(*r), Self::from_k256_scalar(*s))
     }
 
-    pub(crate) fn to_repr(self) -> FieldBytes {
+    pub fn to_repr(self) -> FieldBytes {
         self.0.to_be_bytes().into()
     }
 
@@ -74,7 +72,7 @@ impl Scalar {
     }
 
     #[inline(always)]
-    pub(crate) fn from_k256_scalar(s: crate::k256::Scalar) -> Self {
+    pub fn from_k256_scalar(s: crate::k256::Scalar) -> Self {
         Self(ScalarInner::from_k256_scalar(s))
     }
 
@@ -96,7 +94,7 @@ impl Scalar {
         self.0.bits_var(offset, count)
     }
 
-    pub(crate) fn is_zero(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         self.0.is_zero()
     }
 
@@ -156,7 +154,6 @@ impl PartialOrd for Scalar {
     }
 }
 
-#[cfg(test)]
 impl core::ops::Neg for Scalar {
     type Output = Self;
 
@@ -167,7 +164,6 @@ impl core::ops::Neg for Scalar {
     }
 }
 
-#[cfg(test)]
 impl core::ops::Mul for Scalar {
     type Output = Self;
 
@@ -178,7 +174,6 @@ impl core::ops::Mul for Scalar {
     }
 }
 
-#[cfg(test)]
 impl core::ops::Add for Scalar {
     type Output = Self;
 
@@ -189,7 +184,6 @@ impl core::ops::Add for Scalar {
     }
 }
 
-#[cfg(test)]
 impl core::ops::Sub for Scalar {
     type Output = Self;
 

--- a/crypto/tests/secp256k1.rs
+++ b/crypto/tests/secp256k1.rs
@@ -1,3 +1,4 @@
+use crypto::secp256k1::hooks::DefaultSecp256k1Hooks;
 use crypto::secp256k1::recover;
 use crypto::{
     k256::elliptic_curve::{ops::Reduce, rand_core::OsRng},
@@ -64,7 +65,7 @@ fn selftest() {
                 .unwrap(),
         );
 
-        let recovered_key = recover(&msg, &signature, &recovery_id).unwrap();
+        let recovered_key = recover(&msg, &signature, &recovery_id, &mut DefaultSecp256k1Hooks).unwrap();
 
         prop_assert_eq!(recovered_key.to_bytes(), public_key.to_bytes());
     })

--- a/cycle_marker/src/lib.rs
+++ b/cycle_marker/src/lib.rs
@@ -239,6 +239,9 @@ pub struct OpcodeCycleStats {
     pub name: &'static str,
     pub total_cycles: u64,
     pub count: u64,
+    pub min_cycles: u64,
+    pub max_cycles: u64,
+    pub median_cycles: u64,
 }
 
 /// Results from processing cycle markers.
@@ -269,7 +272,44 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
 
     // Opcode-level markers: aggregate by label name.
     // OpcodeStart/OpcodeEnd pairs are always adjacent (leaf-level, no nesting).
-    let mut opcode_aggregated: HashMap<&'static str, (u64, u64)> = HashMap::new();
+    struct OpcodeAcc {
+        total: u64,
+        count: u64,
+        min: u64,
+        max: u64,
+        samples: Vec<u64>,
+    }
+    impl OpcodeAcc {
+        fn new() -> Self {
+            Self {
+                total: 0,
+                count: 0,
+                min: u64::MAX,
+                max: 0,
+                samples: Vec::new(),
+            }
+        }
+        fn record(&mut self, cycles: u64) {
+            self.total += cycles;
+            self.count += 1;
+            self.min = self.min.min(cycles);
+            self.max = self.max.max(cycles);
+            self.samples.push(cycles);
+        }
+        fn median(&mut self) -> u64 {
+            if self.samples.is_empty() {
+                return 0;
+            }
+            self.samples.sort_unstable();
+            let mid = self.samples.len() / 2;
+            if self.samples.len() % 2 == 0 {
+                (self.samples[mid - 1] + self.samples[mid]) / 2
+            } else {
+                self.samples[mid]
+            }
+        }
+    }
+    let mut opcode_aggregated: HashMap<&'static str, OpcodeAcc> = HashMap::new();
     let mut pending_opcode_start: Option<Mark> = None;
 
     log_marker("\n=== Cycle markers:");
@@ -281,9 +321,10 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
             Label::OpcodeEnd(name) => {
                 if let Some(start_mark) = pending_opcode_start.take() {
                     let diff = mark.diff(&start_mark);
-                    let entry = opcode_aggregated.entry(name).or_insert((0, 0));
-                    entry.0 += diff.cycles;
-                    entry.1 += 1;
+                    opcode_aggregated
+                        .entry(name)
+                        .or_insert_with(OpcodeAcc::new)
+                        .record(diff.cycles);
                 }
             }
             Label::Start(name) => {
@@ -347,10 +388,16 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
     // Collect and sort opcode stats
     let mut opcode_cycle_stats: Vec<OpcodeCycleStats> = opcode_aggregated
         .into_iter()
-        .map(|(name, (total_cycles, count))| OpcodeCycleStats {
-            name,
-            total_cycles,
-            count,
+        .map(|(name, mut acc)| {
+            let median = acc.median();
+            OpcodeCycleStats {
+                name,
+                total_cycles: acc.total,
+                count: acc.count,
+                min_cycles: if acc.count > 0 { acc.min } else { 0 },
+                max_cycles: acc.max,
+                median_cycles: median,
+            }
         })
         .collect();
     opcode_cycle_stats.sort_by(|a, b| b.total_cycles.cmp(&a.total_cycles));
@@ -358,14 +405,20 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
     if !opcode_cycle_stats.is_empty() {
         log_marker("\n=== Per-opcode cycle stats:");
         log_marker(&format!(
-            "{:<20} {:>12} {:>14} {:>10}",
-            "opcode", "count", "total_cycles", "avg_cycles"
+            "{:<20} {:>12} {:>14} {:>10} {:>10} {:>10} {:>10}",
+            "opcode", "count", "total_cycles", "avg", "median", "min", "max"
         ));
         for stat in &opcode_cycle_stats {
             let avg = stat.total_cycles as f64 / stat.count as f64;
             log_marker(&format!(
-                "{:<20} {:>12} {:>14} {:>10.1}",
-                stat.name, stat.count, stat.total_cycles, avg
+                "{:<20} {:>12} {:>14} {:>10.1} {:>10} {:>10} {:>10}",
+                stat.name,
+                stat.count,
+                stat.total_cycles,
+                avg,
+                stat.median_cycles,
+                stat.min_cycles,
+                stat.max_cycles
             ));
         }
         log_marker("==================");

--- a/cycle_marker/src/lib.rs
+++ b/cycle_marker/src/lib.rs
@@ -16,12 +16,28 @@
 //!
 //! Traces are dumped to a file, the path can be set using the
 //! MARKER_PATH environment variable.
+//!
+//! ## Per-opcode cycle tracking
+//!
+//! For EVM opcode benchmarking, use the opcode-specific macros:
+//!
+//! cycle_marker::opcode_start!();
+//! // ... opcode execution ...
+//! cycle_marker::opcode_end!(label);
+//!
+//! These are separated from block-level markers and aggregated by label
+//! in `print_cycle_markers`. On RISC-V they use the same CSR mechanism.
 
-/// Labels can be at the start or end of a code block
+/// Labels can be at the start or end of a code block.
+/// OpcodeStart/OpcodeEnd are for per-EVM-opcode cycle tracking —
+/// they use the same CSR mechanism on RISC-V but are aggregated
+/// (summed by label) rather than matched individually.
 #[allow(dead_code)]
 enum Label {
     Start(&'static str),
     End(&'static str),
+    OpcodeStart,
+    OpcodeEnd(&'static str),
 }
 
 #[cfg(not(target_arch = "riscv32"))]
@@ -92,6 +108,44 @@ pub fn end(_label: &'static str) {
     LABELS.with_borrow_mut(|v| v.push(Label::End(_label)))
 }
 
+/// Start an opcode-level cycle marker. Uses the same CSR mechanism as `start()`
+/// on RISC-V. On the host side, recorded as `OpcodeStart` for aggregation.
+pub fn start_opcode() {
+    #[cfg(target_arch = "riscv32")]
+    {
+        unsafe {
+            let word = 0;
+            core::arch::asm!(
+                "csrrw x0, 0x7ff, {rd}",
+                rd = in(reg) word,
+                options(nomem, nostack, preserves_flags)
+            )
+        }
+    }
+
+    #[cfg(not(target_arch = "riscv32"))]
+    LABELS.with_borrow_mut(|v| v.push(Label::OpcodeStart))
+}
+
+/// End an opcode-level cycle marker. Uses the same CSR mechanism as `end()`
+/// on RISC-V. On the host side, recorded as `OpcodeEnd` with label for aggregation.
+pub fn end_opcode(_label: &'static str) {
+    #[cfg(target_arch = "riscv32")]
+    {
+        unsafe {
+            let word = 0;
+            core::arch::asm!(
+                "csrrw x0, 0x7ff, {rd}",
+                rd = in(reg) word,
+                options(nomem, nostack, preserves_flags)
+            )
+        }
+    }
+
+    #[cfg(not(target_arch = "riscv32"))]
+    LABELS.with_borrow_mut(|v| v.push(Label::OpcodeEnd(_label)))
+}
+
 #[macro_export]
 macro_rules! start {
     ($label:expr) => {
@@ -108,6 +162,26 @@ macro_rules! end {
         #[cfg(feature = "cycle_marker")]
         {
             $crate::end($label);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! opcode_start {
+    () => {
+        #[cfg(feature = "cycle_marker")]
+        {
+            $crate::start_opcode();
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! opcode_end {
+    ($label:expr) => {
+        #[cfg(feature = "cycle_marker")]
+        {
+            $crate::end_opcode($label);
         }
     };
 }
@@ -158,8 +232,24 @@ macro_rules! wrap_with_resources {
     }};
 }
 
+/// Per-opcode aggregated cycle statistics.
 #[cfg(all(feature = "use_risc_v_simulator", not(target_arch = "riscv32")))]
-pub fn print_cycle_markers() -> Option<u64> {
+#[derive(Debug, Clone)]
+pub struct OpcodeCycleStats {
+    pub name: &'static str,
+    pub total_cycles: u64,
+    pub count: u64,
+}
+
+/// Results from processing cycle markers.
+#[cfg(all(feature = "use_risc_v_simulator", not(target_arch = "riscv32")))]
+pub struct CycleMarkerResults {
+    pub block_effective: Option<u64>,
+    pub opcode_cycle_stats: Vec<OpcodeCycleStats>,
+}
+
+#[cfg(all(feature = "use_risc_v_simulator", not(target_arch = "riscv32")))]
+pub fn print_cycle_markers() -> CycleMarkerResults {
     const BLAKE_DELEGATION_ID: u32 = 1991;
     const BIGINT_DELEGATION_ID: u32 = 1994;
     const BLAKE_DELEGATION_COEFF: u64 = 16;
@@ -172,13 +262,30 @@ pub fn print_cycle_markers() -> Option<u64> {
 
     assert_eq!(cm.markers.len(), labels.len());
 
+    // Block-level markers: use existing nonce-based matching
     let mut label_nonces: HashMap<&'static str, u64> = HashMap::new();
     let mut marker_map: HashMap<(&'static str, u64), (Mark, Mark)> = HashMap::new();
     let mut start_counts: HashMap<(&'static str, u64), Mark> = HashMap::new();
 
+    // Opcode-level markers: aggregate by label name.
+    // OpcodeStart/OpcodeEnd pairs are always adjacent (leaf-level, no nesting).
+    let mut opcode_aggregated: HashMap<&'static str, (u64, u64)> = HashMap::new();
+    let mut pending_opcode_start: Option<Mark> = None;
+
     log_marker("\n=== Cycle markers:");
     for (label, mark) in labels.into_iter().zip(cm.markers.into_iter()) {
         match label {
+            Label::OpcodeStart => {
+                pending_opcode_start = Some(mark);
+            }
+            Label::OpcodeEnd(name) => {
+                if let Some(start_mark) = pending_opcode_start.take() {
+                    let diff = mark.diff(&start_mark);
+                    let entry = opcode_aggregated.entry(name).or_insert((0, 0));
+                    entry.0 += diff.cycles;
+                    entry.1 += 1;
+                }
+            }
             Label::Start(name) => {
                 let nonce = label_nonces
                     .entry(name)
@@ -197,7 +304,7 @@ pub fn print_cycle_markers() -> Option<u64> {
             }
         }
     }
-    for ((name, _), _) in start_counts {
+    for ((name, _), _) in &start_counts {
         eprintln!("Warning: start label '{}' has no end", name);
     }
     let mut markers: Vec<(&'static str, (Mark, Mark))> = marker_map
@@ -215,10 +322,6 @@ pub fn print_cycle_markers() -> Option<u64> {
             label, diff.cycles, diff.delegations
         ));
         if label == BLOCK_WIDE_LABEL {
-            // We compute effective cycles for the block execution.
-            // That is: raw cycles plus the delegation counts, weighted by
-            // the delegation coefficients (derived from the circuits
-            // geometry)
             block_effective = Some(
                 diff.cycles
                     + BLAKE_DELEGATION_COEFF
@@ -240,5 +343,36 @@ pub fn print_cycle_markers() -> Option<u64> {
         "Total delegations: {:?}\n==================",
         cm.delegation_counter
     ));
-    block_effective
+
+    // Collect and sort opcode stats
+    let mut opcode_cycle_stats: Vec<OpcodeCycleStats> = opcode_aggregated
+        .into_iter()
+        .map(|(name, (total_cycles, count))| OpcodeCycleStats {
+            name,
+            total_cycles,
+            count,
+        })
+        .collect();
+    opcode_cycle_stats.sort_by(|a, b| b.total_cycles.cmp(&a.total_cycles));
+
+    if !opcode_cycle_stats.is_empty() {
+        log_marker("\n=== Per-opcode cycle stats:");
+        log_marker(&format!(
+            "{:<20} {:>12} {:>14} {:>10}",
+            "opcode", "count", "total_cycles", "avg_cycles"
+        ));
+        for stat in &opcode_cycle_stats {
+            let avg = stat.total_cycles as f64 / stat.count as f64;
+            log_marker(&format!(
+                "{:<20} {:>12} {:>14} {:>10.1}",
+                stat.name, stat.count, stat.total_cycles, avg
+            ));
+        }
+        log_marker("==================");
+    }
+
+    CycleMarkerResults {
+        block_effective,
+        opcode_cycle_stats,
+    }
 }

--- a/cycle_marker/src/lib.rs
+++ b/cycle_marker/src/lib.rs
@@ -303,7 +303,7 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
             self.samples.sort_unstable();
             let mid = self.samples.len() / 2;
             if self.samples.len() % 2 == 0 {
-                (self.samples[mid - 1] + self.samples[mid]) / 2
+                ((self.samples[mid - 1] as u128 + self.samples[mid] as u128) / 2) as u64
             } else {
                 self.samples[mid]
             }

--- a/cycle_marker/src/lib.rs
+++ b/cycle_marker/src/lib.rs
@@ -113,6 +113,8 @@ pub fn end(_label: &'static str) {
 pub fn start_opcode() {
     #[cfg(target_arch = "riscv32")]
     {
+        // SAFETY: CSR write to simulator-intercepted register 0x7ff. No memory access,
+        // no stack effect, flags preserved. Mirrors the pattern in `start()`/`end()`.
         unsafe {
             let word = 0;
             core::arch::asm!(
@@ -132,6 +134,8 @@ pub fn start_opcode() {
 pub fn end_opcode(_label: &'static str) {
     #[cfg(target_arch = "riscv32")]
     {
+        // SAFETY: CSR write to simulator-intercepted register 0x7ff. No memory access,
+        // no stack effect, flags preserved. Mirrors the pattern in `start()`/`end()`.
         unsafe {
             let word = 0;
             core::arch::asm!(
@@ -316,6 +320,10 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
     for (label, mark) in labels.into_iter().zip(cm.markers.into_iter()) {
         match label {
             Label::OpcodeStart => {
+                debug_assert!(
+                    pending_opcode_start.is_none(),
+                    "Consecutive OpcodeStart without OpcodeEnd — previous start marker lost"
+                );
                 pending_opcode_start = Some(mark);
             }
             Label::OpcodeEnd(name) => {

--- a/cycle_marker/src/lib.rs
+++ b/cycle_marker/src/lib.rs
@@ -385,6 +385,23 @@ pub fn print_cycle_markers() -> CycleMarkerResults {
         cm.delegation_counter
     ));
 
+    // Dump per-execution cycle samples if requested via env var
+    if let Ok(dir) = std::env::var("OPCODE_CYCLE_SAMPLES_DIR") {
+        let dir = std::path::Path::new(&dir);
+        std::fs::create_dir_all(dir).expect("Failed to create cycle samples dir");
+        for (name, acc) in &opcode_aggregated {
+            if acc.samples.is_empty() {
+                continue;
+            }
+            let path = dir.join(format!("{}.cycles", name));
+            let mut f = std::fs::File::create(path).expect("Failed to create cycle samples file");
+            use std::io::Write;
+            for &c in &acc.samples {
+                writeln!(f, "{}", c).expect("Failed to write cycle sample");
+            }
+        }
+    }
+
     // Collect and sort opcode stats
     let mut opcode_cycle_stats: Vec<OpcodeCycleStats> = opcode_aggregated
         .into_iter()

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -136,8 +136,11 @@ cargo run --manifest-path tests/instances/eth_runner/Cargo.toml \
   --release -j 3 \
   --features rig/no_print,rig/cycle_marker,rig/unlimited_native \
   -- single-run --block-dir tests/instances/eth_runner/blocks/19299001 \
+  --opcode-stats \
   > result.out
 ```
+
+Omit `--opcode-stats` when only block-level cycle benchmarks are needed — it adds per-opcode tracing overhead.
 
 Available blocks: `19299001`, `22244135`, `23292836` (in `tests/instances/eth_runner/blocks/`).
 
@@ -180,7 +183,7 @@ python3 bench_scripts/parse_opcodes.py result.out opcodes.csv opcodes.png
 
 ### Per-Opcode Benchmarking
 
-The benchmark flow collects per-opcode gas, native resource, and RISC-V cycle stats. The forward-mode run uses `EvmOpcodeStatsTracer` to record gas/native per opcode execution (with min/max/median). The RISC-V run records per-opcode cycles via `cycle_marker` opcode markers.
+The benchmark flow collects per-opcode gas, native resource, and RISC-V cycle stats. The forward-mode run uses `EvmOpcodeStatsTracer` (enabled via `--opcode-stats`) to record gas/native per opcode execution (with min/max/median). The RISC-V run records per-opcode cycles via `cycle_marker` opcode markers.
 
 **Quick run with all data:**
 ```bash

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -178,13 +178,48 @@ python3 bench_scripts/parse_flamegraph.py block_19299001.svg block_19299001.txt
 python3 bench_scripts/parse_opcodes.py result.out opcodes.csv opcodes.png
 ```
 
+### Per-Opcode Benchmarking
+
+The benchmark flow collects per-opcode gas, native resource, and RISC-V cycle stats. The forward-mode run uses `EvmOpcodeStatsTracer` to record gas/native per opcode execution (with min/max/median). The RISC-V run records per-opcode cycles via `cycle_marker` opcode markers.
+
+**Quick run with all data:**
+```bash
+OPCODE_SAMPLES_DIR=$(pwd)/samples \
+OPCODE_CYCLE_SAMPLES_DIR=$(pwd)/cycle_samples \
+OPCODE_STATS_PATH=$(pwd)/opcode_stats.csv \
+bash bench_scripts/bench.sh quick
+```
+
+The `.out` file contains the per-opcode stats table (gas/native with min/max/median). The `.bench` file contains per-opcode cycle stats. Setting the env vars also dumps per-execution sample files for detailed analysis.
+
+**Join per-execution samples to get actual cycles/gas ratios:**
+```bash
+python3 bench_scripts/join_samples.py samples/ cycle_samples/ --summary --out-dir joined/
+```
+
+Produces per-execution `(gas, native, cycles, cycles/gas, native/gas)` CSVs per opcode and a summary table with p50/p95/p99/max ratios.
+
+**Visualize:**
+```bash
+python3 bench_scripts/visualize_opcode_stats.py joined/ --out-dir charts/
+```
+
+Produces: total cycle consumption bar chart, sorted cycles/gas ratio curves per opcode, and per-opcode detail plots with percentile annotations.
+
+**Compare per-opcode stats between base and head:**
+```bash
+python3 bench_scripts/compare_opcode_stats.py base_block.out head_block.out "label"
+```
+
+Outputs a compact diff table only when gas/native stats change. Used by CI to add opcode stats diffs to PR comments.
+
 ## CI Integration
 
 The CI workflow (`.github/workflows/bench.yml`) runs the full comparison automatically on every PR. It:
 1. Checks out the merge-base of the PR
 2. Builds RISC-V binaries and runs all block + precompile benchmarks
 3. Checks out the PR branch and repeats
-4. Posts a comparison table as a PR comment
+4. Posts a comparison table as a PR comment (cycle benchmarks + per-opcode stats diff if changed)
 
 ## Important Notes
 
@@ -207,4 +242,8 @@ The CI workflow (`.github/workflows/bench.yml`) runs the full comparison automat
 | `bench_scripts/compare_bench.py` | Compares base vs head `.bench` files |
 | `bench_scripts/parse_flamegraph.py` | Converts flamegraph SVG to text summary with self-cost and call stacks |
 | `bench_scripts/parse_opcodes.py` | Parses opcode frequency from simulator output |
+| `bench_scripts/compare_opcode_stats.py` | Compares per-opcode gas/native stats between base and head |
+| `bench_scripts/join_samples.py` | Joins per-execution tracer + cycle samples, computes ratios |
+| `bench_scripts/visualize_opcode_stats.py` | Generates charts from joined per-execution data |
+| `forward_system/src/system/tracers/evm_opcode_stats.rs` | Per-opcode gas/native stats tracer |
 | `.github/workflows/bench.yml` | CI benchmarking pipeline |

--- a/evm_interpreter/src/interpreter.rs
+++ b/evm_interpreter/src/interpreter.rs
@@ -140,6 +140,7 @@ impl<'ee, S: EthereumLikeTypes> Interpreter<'ee, S> {
             );
 
             self.instruction_pointer += 1;
+            cycle_marker::opcode_start!();
             let result = self
                 .gas
                 .spend_gas_and_native(0, STEP_NATIVE_COST)
@@ -297,6 +298,9 @@ impl<'ee, S: EthereumLikeTypes> Interpreter<'ee, S> {
                     opcodes::BLOBBASEFEE => self.blobbasefee(system),
                     x => Err(EvmError::InvalidOpcode(x).into()),
                 });
+            cycle_marker::opcode_end!(
+                crate::opcodes::OPCODE_JUMPMAP[opcode as usize].unwrap_or("UNKNOWN")
+            );
 
             tracer.evm_tracer().after_evm_interpreter_execution_step(
                 opcode,

--- a/forward_system/src/run/mod.rs
+++ b/forward_system/src/run/mod.rs
@@ -163,6 +163,7 @@ pub fn generate_proof_input_from_bytes<T: ReadStorageTree, PS: PreimageSource, T
     oracle.add_external_processor(
         callable_oracles::blob_kzg_commitment::BlobCommitmentAndProofQuery::default(),
     );
+    oracle.add_external_processor(callable_oracles::field_hints::FieldOpsQuery::default());
     oracle.add_external_processor(UARTPrintResponder);
 
     // We'll wrap the source, to collect all the reads.
@@ -308,6 +309,7 @@ pub fn make_oracle_for_proofs_and_dumps_for_init_data<
     oracle.add_external_processor(
         callable_oracles::blob_kzg_commitment::BlobCommitmentAndProofQuery::default(),
     );
+    oracle.add_external_processor(callable_oracles::field_hints::FieldOpsQuery::default());
 
     if add_uart {
         let uart_responder = UARTPrintResponder;
@@ -405,6 +407,7 @@ pub fn run_block_with_oracle_dump_ext<
     oracle.add_external_processor(
         callable_oracles::blob_kzg_commitment::BlobCommitmentAndProofQuery::default(),
     );
+    oracle.add_external_processor(callable_oracles::field_hints::FieldOpsQuery::default());
     oracle.add_external_processor(UARTPrintResponder);
 
     let mut result_keeper = ForwardRunningResultKeeper::new(tx_result_callback);
@@ -454,6 +457,7 @@ pub fn run_block_from_oracle_dump<
     oracle.add_external_processor(
         callable_oracles::blob_kzg_commitment::BlobCommitmentAndProofQuery::default(),
     );
+    oracle.add_external_processor(callable_oracles::field_hints::FieldOpsQuery::default());
 
     let mut result_keeper = ForwardRunningResultKeeper::new(NoopTxCallback);
 

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -14,15 +14,71 @@ use zk_ee::{
     types_config::SystemIOTypesConfig,
 };
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct OpcodeStats {
     pub count: u64,
     pub total_gas: u64,
     pub total_native: u64,
+    /// Per-execution gas values for min/max/median computation.
+    /// Empty for CALL-like opcodes where gas delta is unreliable.
+    pub gas_samples: Vec<u64>,
+    /// Per-execution native values for min/max/median computation.
+    pub native_samples: Vec<u64>,
+}
+
+impl OpcodeStats {
+    fn median(samples: &mut [u64]) -> u64 {
+        if samples.is_empty() {
+            return 0;
+        }
+        samples.sort_unstable();
+        let mid = samples.len() / 2;
+        if samples.len() % 2 == 0 {
+            (samples[mid - 1] + samples[mid]) / 2
+        } else {
+            samples[mid]
+        }
+    }
+
+    pub fn gas_median(&mut self) -> u64 {
+        Self::median(&mut self.gas_samples)
+    }
+
+    pub fn native_median(&mut self) -> u64 {
+        Self::median(&mut self.native_samples)
+    }
+
+    pub fn gas_min(&self) -> u64 {
+        self.gas_samples.iter().copied().min().unwrap_or(0)
+    }
+
+    pub fn gas_max(&self) -> u64 {
+        self.gas_samples.iter().copied().max().unwrap_or(0)
+    }
+
+    pub fn native_min(&self) -> u64 {
+        self.native_samples.iter().copied().min().unwrap_or(0)
+    }
+
+    pub fn native_max(&self) -> u64 {
+        self.native_samples.iter().copied().max().unwrap_or(0)
+    }
+}
+
+fn is_call_like(opcode: u8) -> bool {
+    matches!(
+        opcode,
+        opcodes::CALL
+            | opcodes::STATICCALL
+            | opcodes::DELEGATECALL
+            | opcodes::CALLCODE
+            | opcodes::CREATE
+            | opcodes::CREATE2
+    )
 }
 
 pub struct EvmOpcodeStatsTracer<S: SystemTypes> {
-    pub stats: [OpcodeStats; 256],
+    pub stats: Vec<OpcodeStats>,
     gas_before: u64,
     native_before: u64,
     _marker: PhantomData<S>,
@@ -30,8 +86,10 @@ pub struct EvmOpcodeStatsTracer<S: SystemTypes> {
 
 impl<S: SystemTypes> Default for EvmOpcodeStatsTracer<S> {
     fn default() -> Self {
+        let mut stats = Vec::with_capacity(256);
+        stats.resize_with(256, OpcodeStats::default);
         Self {
-            stats: [OpcodeStats::default(); 256],
+            stats,
             gas_before: 0,
             native_before: 0,
             _marker: PhantomData,
@@ -40,35 +98,65 @@ impl<S: SystemTypes> Default for EvmOpcodeStatsTracer<S> {
 }
 
 impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
-    pub fn print_stats(&self) {
+    pub fn print_stats(&mut self) {
         println!("=== EVM Opcode Stats:");
         println!(
-            "{:<20} {:>12} {:>14} {:>14} {:>10} {:>10}",
-            "opcode", "count", "total_gas", "total_native", "avg_gas", "avg_native"
+            "{:<16} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+            "opcode",
+            "count",
+            "avg_gas",
+            "med_gas",
+            "min_gas",
+            "max_gas",
+            "avg_native",
+            "med_native",
+            "min_native",
+            "max_native",
         );
-        for (i, stat) in self.stats.iter().enumerate() {
+        for (i, stat) in self.stats.iter_mut().enumerate() {
             if stat.count == 0 {
                 continue;
             }
             let name = OPCODE_JUMPMAP[i].unwrap_or("UNKNOWN");
+            if is_call_like(i as u8) {
+                println!(
+                    "{:<16} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
+                    name, stat.count, "-", "-", "-", "-", "-", "-", "-", "-",
+                );
+                continue;
+            }
             let avg_gas = stat.total_gas as f64 / stat.count as f64;
             let avg_native = stat.total_native as f64 / stat.count as f64;
+            let gas_med = stat.gas_median();
+            let native_med = stat.native_median();
             println!(
-                "{:<20} {:>12} {:>14} {:>14} {:>10.1} {:>10.1}",
-                name, stat.count, stat.total_gas, stat.total_native, avg_gas, avg_native
+                "{:<16} {:>10} {:>10.1} {:>10} {:>10} {:>10} {:>10.1} {:>10} {:>10} {:>10}",
+                name,
+                stat.count,
+                avg_gas,
+                gas_med,
+                stat.gas_min(),
+                stat.gas_max(),
+                avg_native,
+                native_med,
+                stat.native_min(),
+                stat.native_max(),
             );
         }
         println!("==================");
     }
 
-    pub fn write_csv(&self, path: &Path) -> std::io::Result<()> {
+    pub fn write_csv(&mut self, path: &Path) -> std::io::Result<()> {
         let mut f = std::fs::File::create(path)?;
         writeln!(
             f,
-            "opcode,opcode_hex,count,total_gas,total_native,avg_gas,avg_native,native_per_gas"
+            "opcode,opcode_hex,count,\
+             avg_gas,median_gas,min_gas,max_gas,\
+             avg_native,median_native,min_native,max_native,\
+             native_per_gas"
         )?;
-        for (i, stat) in self.stats.iter().enumerate() {
-            if stat.count == 0 {
+        for (i, stat) in self.stats.iter_mut().enumerate() {
+            if stat.count == 0 || is_call_like(i as u8) {
                 continue;
             }
             let name = OPCODE_JUMPMAP[i].unwrap_or("UNKNOWN");
@@ -79,16 +167,26 @@ impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
             } else {
                 0.0
             };
+            let gas_med = stat.gas_median();
+            let gas_min = stat.gas_min();
+            let gas_max = stat.gas_max();
+            let native_med = stat.native_median();
+            let native_min = stat.native_min();
+            let native_max = stat.native_max();
             writeln!(
                 f,
-                "{},{:#04x},{},{},{},{:.2},{:.2},{:.2}",
+                "{},{:#04x},{},{:.2},{},{},{},{:.2},{},{},{},{:.2}",
                 name,
                 i,
                 stat.count,
-                stat.total_gas,
-                stat.total_native,
                 avg_gas,
+                gas_med,
+                gas_min,
+                gas_max,
                 avg_native,
+                native_med,
+                native_min,
+                native_max,
                 native_per_gas,
             )?;
         }
@@ -117,14 +215,8 @@ impl<S: EthereumLikeTypes> EvmTracer<S> for EvmOpcodeStatsTracer<S> {
         // CALL-like and CREATE opcodes move all resources to the call request
         // via take_resources(), so the after-step resources are 0 and the delta
         // would be meaningless. Only record count for these opcodes.
-        match opcode {
-            opcodes::CALL
-            | opcodes::STATICCALL
-            | opcodes::DELEGATECALL
-            | opcodes::CALLCODE
-            | opcodes::CREATE
-            | opcodes::CREATE2 => return,
-            _ => {}
+        if is_call_like(opcode) {
+            return;
         }
 
         let gas_after = frame_state.resources().ergs().0 / ERGS_PER_GAS;
@@ -135,6 +227,8 @@ impl<S: EthereumLikeTypes> EvmTracer<S> for EvmOpcodeStatsTracer<S> {
 
         stat.total_gas += gas_used;
         stat.total_native += native_used;
+        stat.gas_samples.push(gas_used);
+        stat.native_samples.push(native_used);
     }
 
     #[inline(always)]

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -34,7 +34,7 @@ impl OpcodeStats {
         samples.sort_unstable();
         let mid = samples.len() / 2;
         if samples.len().is_multiple_of(2) {
-            (samples[mid - 1] + samples[mid]) / 2
+            ((samples[mid - 1] as u128 + samples[mid] as u128) / 2) as u64
         } else {
             samples[mid]
         }

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -27,25 +27,26 @@ pub struct OpcodeStats {
 }
 
 impl OpcodeStats {
-    fn median(samples: &mut [u64]) -> u64 {
+    fn median(samples: &[u64]) -> u64 {
         if samples.is_empty() {
             return 0;
         }
-        samples.sort_unstable();
-        let mid = samples.len() / 2;
-        if samples.len().is_multiple_of(2) {
-            ((samples[mid - 1] as u128 + samples[mid] as u128) / 2) as u64
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        let mid = sorted.len() / 2;
+        if sorted.len().is_multiple_of(2) {
+            ((sorted[mid - 1] as u128 + sorted[mid] as u128) / 2) as u64
         } else {
-            samples[mid]
+            sorted[mid]
         }
     }
 
-    pub fn gas_median(&mut self) -> u64 {
-        Self::median(&mut self.gas_samples)
+    pub fn gas_median(&self) -> u64 {
+        Self::median(&self.gas_samples)
     }
 
-    pub fn native_median(&mut self) -> u64 {
-        Self::median(&mut self.native_samples)
+    pub fn native_median(&self) -> u64 {
+        Self::median(&self.native_samples)
     }
 
     pub fn gas_min(&self) -> u64 {
@@ -109,7 +110,7 @@ impl<S: SystemTypes> Default for EvmOpcodeStatsTracer<S> {
 }
 
 impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
-    pub fn print_stats(&mut self) {
+    pub fn print_stats(&self) {
         println!("=== EVM Opcode Stats:");
         println!(
             "{:<16} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10}",
@@ -124,7 +125,7 @@ impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
             "min_native",
             "max_native",
         );
-        for (i, stat) in self.stats.iter_mut().enumerate() {
+        for (i, stat) in self.stats.iter().enumerate() {
             if stat.count == 0 {
                 continue;
             }
@@ -157,7 +158,7 @@ impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
         println!("==================");
     }
 
-    pub fn write_csv(&mut self, path: &Path) -> std::io::Result<()> {
+    pub fn write_csv(&self, path: &Path) -> std::io::Result<()> {
         let mut f = std::fs::File::create(path)?;
         writeln!(
             f,
@@ -166,7 +167,7 @@ impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
              avg_native,median_native,min_native,max_native,\
              native_per_gas"
         )?;
-        for (i, stat) in self.stats.iter_mut().enumerate() {
+        for (i, stat) in self.stats.iter().enumerate() {
             if stat.count == 0 || is_call_like(i as u8) {
                 continue;
             }

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -65,6 +65,17 @@ impl OpcodeStats {
     }
 }
 
+impl OpcodeStats {
+    /// Dump per-execution samples to a file: one line per execution with "gas,native".
+    /// Samples are in execution order — the Kth line is the Kth execution.
+    pub fn dump_samples(&self, writer: &mut impl Write) -> std::io::Result<()> {
+        for (g, n) in self.gas_samples.iter().zip(self.native_samples.iter()) {
+            writeln!(writer, "{},{}", g, n)?;
+        }
+        Ok(())
+    }
+}
+
 fn is_call_like(opcode: u8) -> bool {
     matches!(
         opcode,
@@ -189,6 +200,23 @@ impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
                 native_max,
                 native_per_gas,
             )?;
+        }
+        Ok(())
+    }
+
+    /// Dump per-execution samples to a directory.
+    /// Creates one file per opcode: `<dir>/<OPCODE>.samples` with "gas,native" per line.
+    /// Files are in execution order so line K = Kth execution.
+    pub fn dump_samples(&self, dir: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        for (i, stat) in self.stats.iter().enumerate() {
+            if stat.gas_samples.is_empty() {
+                continue;
+            }
+            let name = OPCODE_JUMPMAP[i].unwrap_or("UNKNOWN");
+            let path = dir.join(format!("{}.samples", name));
+            let mut f = std::fs::File::create(path)?;
+            stat.dump_samples(&mut f)?;
         }
         Ok(())
     }

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -33,7 +33,7 @@ impl OpcodeStats {
         }
         samples.sort_unstable();
         let mid = samples.len() / 2;
-        if samples.len() % 2 == 0 {
+        if samples.len().is_multiple_of(2) {
             (samples[mid - 1] + samples[mid]) / 2
         } else {
             samples[mid]

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -1,0 +1,209 @@
+use std::io::Write;
+use std::marker::PhantomData;
+use std::path::Path;
+
+use evm_interpreter::{opcodes::OPCODE_JUMPMAP, ERGS_PER_GAS};
+use zk_ee::{
+    execution_environment_type::ExecutionEnvironmentType,
+    system::{
+        evm::{EvmError, EvmFrameInterface},
+        tracer::{evm_tracer::EvmTracer, Tracer},
+        CallResult, Computational, EthereumLikeTypes, ExecutionEnvironmentLaunchParams, Resources,
+        SystemTypes,
+    },
+    types_config::SystemIOTypesConfig,
+};
+
+#[derive(Clone, Copy, Default)]
+pub struct OpcodeStats {
+    pub count: u64,
+    pub total_gas: u64,
+    pub total_native: u64,
+}
+
+pub struct EvmOpcodeStatsTracer<S: SystemTypes> {
+    pub stats: [OpcodeStats; 256],
+    gas_before: u64,
+    native_before: u64,
+    _marker: PhantomData<S>,
+}
+
+impl<S: SystemTypes> Default for EvmOpcodeStatsTracer<S> {
+    fn default() -> Self {
+        Self {
+            stats: [OpcodeStats::default(); 256],
+            gas_before: 0,
+            native_before: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S: SystemTypes> EvmOpcodeStatsTracer<S> {
+    pub fn print_stats(&self) {
+        println!("=== EVM Opcode Stats:");
+        println!(
+            "{:<20} {:>12} {:>14} {:>14} {:>10} {:>10}",
+            "opcode", "count", "total_gas", "total_native", "avg_gas", "avg_native"
+        );
+        for (i, stat) in self.stats.iter().enumerate() {
+            if stat.count == 0 {
+                continue;
+            }
+            let name = OPCODE_JUMPMAP[i].unwrap_or("UNKNOWN");
+            let avg_gas = stat.total_gas as f64 / stat.count as f64;
+            let avg_native = stat.total_native as f64 / stat.count as f64;
+            println!(
+                "{:<20} {:>12} {:>14} {:>14} {:>10.1} {:>10.1}",
+                name, stat.count, stat.total_gas, stat.total_native, avg_gas, avg_native
+            );
+        }
+        println!("==================");
+    }
+
+    pub fn write_csv(&self, path: &Path) -> std::io::Result<()> {
+        let mut f = std::fs::File::create(path)?;
+        writeln!(
+            f,
+            "opcode,opcode_hex,count,total_gas,total_native,avg_gas,avg_native,native_per_gas"
+        )?;
+        for (i, stat) in self.stats.iter().enumerate() {
+            if stat.count == 0 {
+                continue;
+            }
+            let name = OPCODE_JUMPMAP[i].unwrap_or("UNKNOWN");
+            let avg_gas = stat.total_gas as f64 / stat.count as f64;
+            let avg_native = stat.total_native as f64 / stat.count as f64;
+            let native_per_gas = if stat.total_gas > 0 {
+                stat.total_native as f64 / stat.total_gas as f64
+            } else {
+                0.0
+            };
+            writeln!(
+                f,
+                "{},{:#04x},{},{},{},{:.2},{:.2},{:.2}",
+                name,
+                i,
+                stat.count,
+                stat.total_gas,
+                stat.total_native,
+                avg_gas,
+                avg_native,
+                native_per_gas,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<S: EthereumLikeTypes> EvmTracer<S> for EvmOpcodeStatsTracer<S> {
+    fn before_evm_interpreter_execution_step(
+        &mut self,
+        _opcode: u8,
+        frame_state: &impl EvmFrameInterface<S>,
+    ) {
+        self.gas_before = frame_state.resources().ergs().0 / ERGS_PER_GAS;
+        self.native_before = frame_state.resources().native().as_u64();
+    }
+
+    fn after_evm_interpreter_execution_step(
+        &mut self,
+        opcode: u8,
+        frame_state: &impl EvmFrameInterface<S>,
+    ) {
+        let gas_after = frame_state.resources().ergs().0 / ERGS_PER_GAS;
+        let native_after = frame_state.resources().native().as_u64();
+
+        let gas_used = self.gas_before.saturating_sub(gas_after);
+        let native_used = self.native_before.saturating_sub(native_after);
+
+        let stat = &mut self.stats[opcode as usize];
+        stat.count += 1;
+        stat.total_gas += gas_used;
+        stat.total_native += native_used;
+    }
+
+    #[inline(always)]
+    fn on_opcode_error(&mut self, _error: &EvmError, _frame_state: &impl EvmFrameInterface<S>) {}
+
+    #[inline(always)]
+    fn on_call_error(&mut self, _error: &EvmError) {}
+
+    #[inline(always)]
+    fn on_selfdestruct(
+        &mut self,
+        _beneficiary: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::Address,
+        _token_value: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::NominalTokenValue,
+        _frame_state: &impl EvmFrameInterface<S>,
+    ) {
+    }
+
+    #[inline(always)]
+    fn on_create_request(&mut self, _is_create2: bool) {}
+}
+
+impl<S: EthereumLikeTypes> Tracer<S> for EvmOpcodeStatsTracer<S> {
+    #[inline(always)]
+    fn on_new_execution_frame(&mut self, _request: &ExecutionEnvironmentLaunchParams<S>) {}
+
+    #[inline(always)]
+    fn after_execution_frame_completed(
+        &mut self,
+        _result: Option<(&S::Resources, &CallResult<S>)>,
+    ) {
+    }
+
+    #[inline(always)]
+    fn begin_tx(&mut self, _calldata: &[u8]) {}
+
+    #[inline(always)]
+    fn finish_tx(&mut self) {}
+
+    #[inline(always)]
+    fn on_storage_read(
+        &mut self,
+        _ee_type: ExecutionEnvironmentType,
+        _is_transient: bool,
+        _address: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::Address,
+        _key: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::StorageKey,
+        _value: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::StorageValue,
+    ) {
+    }
+
+    #[inline(always)]
+    fn on_storage_write(
+        &mut self,
+        _ee_type: ExecutionEnvironmentType,
+        _is_transient: bool,
+        _address: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::Address,
+        _key: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::StorageKey,
+        _value: <<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::StorageValue,
+    ) {
+    }
+
+    #[inline(always)]
+    fn on_bytecode_change(
+        &mut self,
+        _ee_type: ExecutionEnvironmentType,
+        _address: <S::IOTypes as SystemIOTypesConfig>::Address,
+        _new_bytecode: Option<&[u8]>,
+        _new_bytecode_hash: <S::IOTypes as SystemIOTypesConfig>::BytecodeHashValue,
+        _new_observable_bytecode_length: u32,
+    ) {
+    }
+
+    #[inline(always)]
+    fn on_event(
+        &mut self,
+        _ee_type: ExecutionEnvironmentType,
+        _address: &<<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::Address,
+        _topics: &[<<S as SystemTypes>::IOTypes as SystemIOTypesConfig>::EventKey],
+        _data: &[u8],
+    ) {
+    }
+
+    #[inline(always)]
+    fn evm_tracer(&mut self) -> &mut impl EvmTracer<S> {
+        self
+    }
+}

--- a/forward_system/src/system/tracers/evm_opcode_stats.rs
+++ b/forward_system/src/system/tracers/evm_opcode_stats.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::marker::PhantomData;
 use std::path::Path;
 
-use evm_interpreter::{opcodes::OPCODE_JUMPMAP, ERGS_PER_GAS};
+use evm_interpreter::{opcodes, opcodes::OPCODE_JUMPMAP, ERGS_PER_GAS};
 use zk_ee::{
     execution_environment_type::ExecutionEnvironmentType,
     system::{
@@ -111,14 +111,28 @@ impl<S: EthereumLikeTypes> EvmTracer<S> for EvmOpcodeStatsTracer<S> {
         opcode: u8,
         frame_state: &impl EvmFrameInterface<S>,
     ) {
+        let stat = &mut self.stats[opcode as usize];
+        stat.count += 1;
+
+        // CALL-like and CREATE opcodes move all resources to the call request
+        // via take_resources(), so the after-step resources are 0 and the delta
+        // would be meaningless. Only record count for these opcodes.
+        match opcode {
+            opcodes::CALL
+            | opcodes::STATICCALL
+            | opcodes::DELEGATECALL
+            | opcodes::CALLCODE
+            | opcodes::CREATE
+            | opcodes::CREATE2 => return,
+            _ => {}
+        }
+
         let gas_after = frame_state.resources().ergs().0 / ERGS_PER_GAS;
         let native_after = frame_state.resources().native().as_u64();
 
         let gas_used = self.gas_before.saturating_sub(gas_after);
         let native_used = self.native_before.saturating_sub(native_after);
 
-        let stat = &mut self.stats[opcode as usize];
-        stat.count += 1;
         stat.total_gas += gas_used;
         stat.total_native += native_used;
     }

--- a/forward_system/src/system/tracers/mod.rs
+++ b/forward_system/src/system/tracers/mod.rs
@@ -1,2 +1,3 @@
 pub mod call_tracer;
+pub mod evm_opcode_stats;
 pub mod evm_opcodes_logger;

--- a/system_hooks/src/lib.rs
+++ b/system_hooks/src/lib.rs
@@ -128,10 +128,10 @@ pub fn add_precompiles<S: EthereumLikeTypes, A: Allocator + Clone>(
 where
     S::IO: IOSubsystemExt,
 {
-    add_precompile::<
+    add_precompile_ext::<
         _,
         _,
-        <S::SystemFunctions as SystemFunctions<_>>::Secp256k1ECRecover,
+        <S::SystemFunctionsExt as SystemFunctionsExt<_>>::Secp256k1ECRecover,
         Secp256k1ECRecoverErrors,
     >(hooks, ECRECOVER_HOOK_ADDRESS_LOW)?;
     add_precompile::<_, _, <S::SystemFunctions as SystemFunctions<_>>::Sha256, Sha256Errors>(

--- a/tests/fuzzer/Cargo.lock
+++ b/tests/fuzzer/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.14"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf01dd83a1ca5e4807d0ca0223c9615e211ce5db0a9fd1443c2778cacf89b546"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -108,7 +108,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -117,7 +117,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -154,14 +154,14 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca96214615ec8cf3fa2a54b32f486eb49100ca7fe7eb0b8c1137cd316e7250a"
+checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -172,15 +172,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdff496dd4e98a81f4861e66f7eaf5f2488971848bb42d9c892f871730245c8"
+checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "itoa",
  "serde",
  "serde_json",
@@ -197,7 +197,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -224,7 +224,7 @@ dependencies = [
  "k256",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -255,14 +255,14 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -279,12 +279,12 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "revm 29.0.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5513d5e6bd1cba6bdcf5373470f559f320c05c8c59493b6e98912fbe6733943f"
+checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -335,10 +335,10 @@ checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.3.1",
+ "http 1.4.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -361,11 +361,11 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -392,10 +392,10 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.0.1",
- "foldhash",
- "hashbrown 0.16.0",
- "indexmap 2.12.0",
+ "derive_more 2.1.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -445,11 +445,11 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "parking_lot",
- "pin-project 1.1.10",
- "reqwest 0.12.24",
+ "pin-project 1.1.11",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -514,8 +514,8 @@ dependencies = [
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
- "pin-project 1.1.10",
- "reqwest 0.12.24",
+ "pin-project 1.1.11",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -573,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
 dependencies = [
  "alloy-primitives",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
 ]
@@ -589,7 +589,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "rand 0.8.5",
@@ -615,7 +615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -629,7 +629,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -705,7 +705,7 @@ dependencies = [
  "gcloud-sdk",
  "k256",
  "spki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -725,7 +725,7 @@ dependencies = [
  "coins-ledger",
  "futures-util",
  "semver 1.0.27",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -742,7 +742,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -756,16 +756,16 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "turnkey_client",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -777,28 +777,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
+ "sha3",
  "syn 2.0.117",
  "syn-solidity",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
+checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
  "winnow",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -843,13 +843,13 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -866,7 +866,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.24",
+ "reqwest 0.12.28",
  "serde_json",
  "tower",
  "tracing",
@@ -885,7 +885,7 @@ dependencies = [
  "bytes",
  "futures",
  "interprocess",
- "pin-project 1.1.10",
+ "pin-project 1.1.11",
  "serde",
  "serde_json",
  "tokio",
@@ -902,7 +902,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -918,11 +918,11 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -954,7 +954,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -964,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -978,30 +993,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle-query"
-version = "1.1.4"
+name = "anstyle-parse"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
- "windows-sys 0.60.2",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -1380,13 +1404,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.32"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -1470,9 +1493,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.8"
+version = "1.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cf2b6af2a95a20e266782b4f76f1a5e12bf412a9db2de9c1e9123b9d8c0ad8"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1486,7 +1509,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.3.1",
+ "http 1.4.0",
  "time",
  "tokio",
  "tracing",
@@ -1495,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.8"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf26925f4a5b59eb76722b63c2892b1d70d06fa053c72e4a100ec308c1d47bc"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1506,10 +1529,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.5.12"
+name = "aws-lc-rs"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa006bb32360ed90ac51203feafb9d02e3d21046e1fd3a450a404b90ea73e5d"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1520,9 +1565,10 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -1531,15 +1577,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.90.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08a2b564e660ad69be524f569fea985380b15eea28694b8fd9f6206a437702b"
+checksum = "8e6bfd8dfb5a562f9a605bbd5c3aef09db9231c826a1e0488ce3f4338c70dbbb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1547,21 +1594,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.88.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30990923f4f675523c51eb1c0dec9b752fb267b36a61e83cbc219c9d86da715"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1570,15 +1619,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.5"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffc03068fbb9c8dd5ce1c6fb240678a5cffb86fb2b7b1985c999c4b83c8df68"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1589,7 +1639,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -1598,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.6"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127fcfad33b7dfc531141fda7e1c402ac65f88aca5511a4d31e2e3d2cd01ce9c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1609,18 +1659,19 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.4"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3feafd437c763db26aa04e0cc7591185d0961e64c61885bece0fb9d50ceac671"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.12",
- "http 1.3.1",
- "http-body 0.4.6",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -1629,27 +1680,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.6"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff418fc8ec5cadf8173b10125f05c2e7e1d46771406187b2c878557d4503390"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1881b1ea6d313f9890710d65c158bdab6fb08c91ea825f74c1c8c357baf4cc"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.8"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28a63441360c477465f80c7abac3b9c4d075ca638f982e605b7dc2a2c7156c9"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -1657,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.3"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ab99739082da5347660c556689256438defae3bcefd66c52b095905730e404"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1669,9 +1720,10 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -1680,15 +1732,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.9.1"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683c5b152d2ad753607179ed71988e8cfd52964443b4f74fd8e552d0bbfeb46"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1697,15 +1749,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.3"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5b3a7486f6690ba25952cabf1e7d75e34d69eaff5081904a47bc79074d6457"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1720,18 +1772,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.11"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c34127e8c624bc2999f3b657e749c1393bedc9cd97b92a804db8ced4d2e163"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.9"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fd329bf0e901ff3f60425691410c69094dc2a1f34b331f37bfc4e9ac1565a1"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1743,14 +1795,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -1768,13 +1820,13 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -1786,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "az"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "base16ct"
@@ -1820,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic_bootloader"
@@ -1842,6 +1894,26 @@ dependencies = [
  "strum_macros",
  "system_hooks",
  "zk_ee",
+]
+
+[[package]]
+name = "basic_bootloader_forward"
+version = "0.1.0"
+dependencies = [
+ "arrayvec",
+ "basic_system_forward",
+ "cfg-if",
+ "crypto_forward",
+ "cycle_marker",
+ "evm_interpreter_forward",
+ "hex",
+ "paste",
+ "ruint",
+ "serde",
+ "serde-big-array",
+ "strum_macros",
+ "system_hooks_forward",
+ "zk_ee_forward",
 ]
 
 [[package]]
@@ -1890,7 +1962,7 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.9.2",
- "reqwest 0.12.24",
+ "reqwest 0.13.2",
  "reth-trie-common",
  "reth-trie-sparse",
  "ruint",
@@ -1924,7 +1996,7 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.9.2",
- "reqwest 0.12.24",
+ "reqwest 0.13.2",
  "reth-trie-common",
  "reth-trie-sparse",
  "ruint",
@@ -1978,15 +2050,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -2000,9 +2072,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -2043,6 +2115,14 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+dependencies = [
+ "unroll",
+]
+
+[[package]]
+name = "blake2s_u32"
+version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "unroll",
@@ -2051,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 dependencies = [
  "unroll",
 ]
@@ -2111,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2123,9 +2203,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -2135,9 +2215,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -2182,10 +2262,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "callable_oracles_forward"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "basic_bootloader_forward",
+ "basic_system_forward",
+ "c-kzg",
+ "crypto_forward",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "oracle_provider_forward",
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "ruint",
+ "zk_ee_forward",
+]
+
+[[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2196,6 +2294,12 @@ dependencies = [
 [[package]]
 name = "cc-traits"
 version = "0.1.0"
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -2211,14 +2315,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2233,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2243,11 +2347,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -2255,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2267,9 +2371,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "coins-ledger"
@@ -2281,7 +2394,7 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "const-hex",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hidapi-rusb",
  "js-sys",
  "log",
@@ -2296,15 +2409,25 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.31"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "compression-core",
  "flate2",
@@ -2313,15 +2436,15 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2350,7 +2473,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2389,9 +2512,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2442,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -2629,6 +2752,16 @@ dependencies = [
 [[package]]
 name = "cs"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+dependencies = [
+ "arrayvec",
+ "field 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "serde",
+]
+
+[[package]]
+name = "cs"
+version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "arrayvec",
@@ -2654,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "cs"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 dependencies = [
  "arrayvec",
  "field 0.1.0 (git+https://github.com/matter-labs/zksync-airbender)",
@@ -2683,6 +2816,16 @@ checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
  "darling_core 0.21.3",
  "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2715,6 +2858,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2893,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -2769,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -2790,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2825,22 +2992,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.7.1",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -2885,9 +3053,9 @@ checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "dunce"
@@ -2969,18 +3137,18 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2989,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -2999,11 +3167,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -3228,6 +3396,16 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+dependencies = [
+ "rand 0.9.2",
+ "seq-macro",
+ "serde",
+]
+
+[[package]]
+name = "field"
+version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "rand 0.9.2",
@@ -3238,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "field"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 dependencies = [
  "rand 0.9.2",
  "seq-macro",
@@ -3259,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -3277,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3293,24 +3471,15 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3346,6 +3515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,9 +3528,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3368,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3378,15 +3553,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3395,15 +3570,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3412,15 +3587,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -3430,9 +3605,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3442,7 +3617,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3457,6 +3631,8 @@ name = "fuzz_precompiles_forward"
 version = "0.1.0"
 dependencies = [
  "basic_system_forward",
+ "callable_oracles_forward",
+ "oracle_provider_forward",
  "zk_ee_forward",
 ]
 
@@ -3521,12 +3697,12 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.24",
+ "reqwest 0.12.28",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -3552,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3572,9 +3748,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3626,7 +3815,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3635,17 +3824,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3680,18 +3869,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3738,9 +3929,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
@@ -3785,12 +3976,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -3812,7 +4002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -3823,7 +4013,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3866,16 +4056,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3907,16 +4097,16 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.7.0",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3925,49 +4115,32 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "socket2 0.6.3",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3976,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -4000,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -4013,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4026,11 +4199,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -4041,48 +4213,50 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -4172,22 +4346,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "inferno"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96d2465363ed2d81857759fc864cf6bb7997f79327aec028d65bd7989393685"
+checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
 dependencies = [
  "ahash",
  "clap",
@@ -4195,7 +4369,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "itoa",
  "log",
  "num-format",
@@ -4206,19 +4380,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "interprocess"
-version = "2.2.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4231,15 +4396,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -4247,15 +4412,24 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4280,33 +4454,55 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -4320,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4374,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -4392,10 +4588,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lib-rv32-asm"
@@ -4413,15 +4609,15 @@ source = "git+https://github.com/shamatar/lib-rv32.git#869f82795f82314f17014a04f
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
@@ -4429,9 +4625,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsecp256k1"
@@ -4493,15 +4689,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -4514,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -4524,7 +4720,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4564,15 +4760,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -4588,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -4598,13 +4794,12 @@ dependencies = [
 
 [[package]]
 name = "metrics-derive"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
+checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "regex",
  "syn 2.0.117",
 ]
 
@@ -4636,9 +4831,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -4648,23 +4843,6 @@ dependencies = [
 [[package]]
 name = "modexp"
 version = "0.1.0"
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "nix"
@@ -4682,12 +4860,17 @@ dependencies = [
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+
+[[package]]
+name = "non_determinism_source"
+version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 
 [[package]]
 name = "non_determinism_source"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 
 [[package]]
 name = "num"
@@ -4724,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-format"
@@ -4791,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -4801,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4844,14 +5027,25 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "flate2",
  "memchr",
- "ruzstd 0.8.1",
+ "ruzstd 0.8.2",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd 0.8.2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -4859,9 +5053,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "op-alloy-consensus"
@@ -4873,8 +5067,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
- "thiserror 2.0.17",
+ "derive_more 2.1.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4888,12 +5082,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "op-alloy-consensus",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4914,48 +5108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "oracle_provider"
@@ -4963,6 +5119,14 @@ version = "0.1.0"
 dependencies = [
  "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2)",
  "zk_ee",
+]
+
+[[package]]
+name = "oracle_provider_forward"
+version = "0.1.0"
+dependencies = [
+ "risc_v_simulator 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "zk_ee_forward",
 ]
 
 [[package]]
@@ -5031,7 +5195,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5067,9 +5231,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5182,11 +5346,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
- "pin-project-internal 1.1.10",
+ "pin-project-internal 1.1.11",
 ]
 
 [[package]]
@@ -5202,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5213,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -5241,17 +5405,28 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "poseidon2"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+dependencies = [
+ "field 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "non_determinism_source 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "rand 0.9.2",
+ "unroll",
 ]
 
 [[package]]
@@ -5268,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 dependencies = [
  "field 0.1.0 (git+https://github.com/matter-labs/zksync-airbender)",
  "non_determinism_source 0.1.0 (git+https://github.com/matter-labs/zksync-airbender)",
@@ -5278,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -5298,6 +5473,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5324,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -5355,23 +5540,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
- "lazy_static",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -5415,12 +5599,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -5430,7 +5614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5451,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -5482,11 +5666,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.1",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -5541,9 +5725,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -5560,9 +5744,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.33",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5570,20 +5754,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5598,16 +5783,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5617,6 +5802,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -5643,7 +5834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "serde",
 ]
 
@@ -5664,7 +5855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5673,14 +5864,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
@@ -5692,7 +5883,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5736,7 +5927,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5785,9 +5976,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5797,9 +5988,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5808,15 +5999,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -5861,34 +6052,28 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.27.7",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -5896,7 +6081,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -5907,7 +6091,49 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5920,7 +6146,7 @@ dependencies = [
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5946,7 +6172,7 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "once_cell",
  "op-alloy-consensus",
  "revm-bytecode 6.2.2",
@@ -5955,7 +6181,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5964,10 +6190,10 @@ version = "1.8.4"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "serde",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5976,7 +6202,7 @@ version = "1.8.4"
 source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.8.4#bde6574bcac266f9858c1a78f8d0da9fd1e5d262"
 dependencies = [
  "alloy-primitives",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "serde",
  "strum",
 ]
@@ -5989,12 +6215,12 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface 7.0.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6009,7 +6235,7 @@ dependencies = [
  "alloy-serde",
  "alloy-trie",
  "bytes",
- "derive_more 2.0.1",
+ "derive_more 2.1.1",
  "itertools 0.14.0",
  "nybbles",
  "reth-primitives-traits",
@@ -6268,7 +6494,7 @@ dependencies = [
  "revm-primitives 22.1.0",
  "revm-state 9.0.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6397,7 +6623,7 @@ dependencies = [
  "revm 34.0.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6580,7 +6806,7 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "revm-bytecode 6.2.2",
  "revm-primitives 20.2.1",
  "serde",
@@ -6593,7 +6819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "revm-bytecode 8.0.0",
  "revm-primitives 22.1.0",
  "serde",
@@ -6611,28 +6837,28 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "rhai"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527390cc333a8d2cd8237890e15c36518c26f8b54c903d86fc59f42f08d25594"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
 dependencies = [
  "ahash",
- "bitflags 2.10.0",
- "instant",
+ "bitflags 2.11.0",
  "num-traits",
  "once_cell",
  "rhai_codegen",
  "smallvec",
  "smartstring",
  "thin-vec",
+ "web-time",
 ]
 
 [[package]]
@@ -6683,7 +6909,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -6719,6 +6945,25 @@ dependencies = [
 [[package]]
 name = "risc_v_simulator"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3#c23fd0085ee87872e25ff83f780d2d0ee102a166"
+dependencies = [
+ "addr2line",
+ "blake2s_u32 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "cs 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "field 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "inferno",
+ "memmap2",
+ "object 0.38.1",
+ "poseidon2 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?tag=v0.4.3)",
+ "rand 0.9.2",
+ "ringbuffer",
+ "ruint",
+ "serde",
+]
+
+[[package]]
+name = "risc_v_simulator"
+version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
 dependencies = [
  "addr2line",
@@ -6738,7 +6983,7 @@ dependencies = [
 [[package]]
 name = "risc_v_simulator"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender#60e2958514884b3a56fd9e9b738f412341bef746"
+source = "git+https://github.com/matter-labs/zksync-airbender#8bfda65461c16ff824832856138990e5bc7ae94f"
 dependencies = [
  "addr2line",
  "blake2s_u32 0.1.0 (git+https://github.com/matter-labs/zksync-airbender)",
@@ -6766,9 +7011,9 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -6822,9 +7067,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -6858,11 +7103,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6883,29 +7128,30 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.33"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.7",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -6919,13 +7165,40 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6939,10 +7212,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6979,24 +7253,33 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash 2.1.2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -7015,9 +7298,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7121,8 +7404,8 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "662c7f8e99d46c9d3a87561d771a970c29efaccbab4bbdc6ab65d099d2358077"
 dependencies = [
- "prost 0.14.1",
- "prost-types 0.14.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "serde",
  "serde_json",
  "zeroize",
@@ -7130,24 +7413,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7156,9 +7426,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7241,16 +7511,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -7267,17 +7537,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.0.4",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7286,11 +7556,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7400,33 +7670,33 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -7466,12 +7736,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7597,9 +7867,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.4.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7646,11 +7916,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -7689,6 +7959,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system_hooks_forward"
+version = "0.1.0"
+dependencies = [
+ "arrayvec",
+ "cycle_marker",
+ "evm_interpreter_forward",
+ "paste",
+ "ruint",
+ "strum_macros",
+ "zk_ee_forward",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7696,12 +7979,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7724,11 +8007,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7744,9 +8027,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7764,30 +8047,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7804,9 +8087,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7814,9 +8097,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7829,38 +8112,28 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -7879,15 +8152,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7903,7 +8176,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -7913,9 +8186,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7926,20 +8199,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -7947,9 +8220,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -7964,15 +8237,15 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
- "pin-project 1.1.10",
+ "pin-project 1.1.11",
  "prost 0.13.5",
  "rustls-native-certs",
  "socket2 0.5.10",
@@ -7987,13 +8260,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.0",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -8006,17 +8279,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "async-compression",
+ "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8069,9 +8347,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -8080,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8091,9 +8369,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -8142,14 +8420,14 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.33",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -8166,7 +8444,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8178,11 +8456,11 @@ dependencies = [
  "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "reqwest 0.12.24",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "turnkey_api_key_stamper",
 ]
@@ -8244,9 +8522,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -8256,15 +8534,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -8299,14 +8577,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna 1.1.0",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8335,9 +8614,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8407,6 +8686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8423,18 +8712,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8444,26 +8742,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -8472,9 +8757,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8482,24 +8767,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -8513,6 +8820,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -8531,9 +8850,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8570,7 +8889,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "pin-project 1.1.10",
+ "pin-project 1.1.11",
  "reqwest 0.11.27",
  "rlp",
  "secp256k1 0.27.0",
@@ -8578,6 +8897,15 @@ dependencies = [
  "serde_json",
  "tiny-keccak",
  "url",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8592,14 +8920,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8611,6 +8939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8618,9 +8955,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -8647,34 +8984,19 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -8683,16 +9005,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -8701,7 +9014,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -8737,7 +9059,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8777,7 +9114,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -8787,6 +9124,12 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8808,6 +9151,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8823,6 +9172,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8856,6 +9211,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8871,6 +9232,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8892,6 +9259,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8907,6 +9280,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8928,9 +9307,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -8947,9 +9326,91 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "worker"
@@ -8962,9 +9423,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -8979,7 +9440,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -9002,11 +9463,10 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -9014,9 +9474,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9026,18 +9486,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9076,9 +9536,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9087,9 +9547,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9098,9 +9558,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9109,9 +9569,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9123,7 +9583,7 @@ name = "zk_ee"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "crypto",
  "cycle_marker",
@@ -9138,7 +9598,7 @@ name = "zk_ee_forward"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "crypto_forward",
  "cycle_marker",
@@ -9154,7 +9614,7 @@ name = "zk_ee_proving"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "crypto_proving",
  "cycle_marker",
@@ -9168,6 +9628,7 @@ dependencies = [
 [[package]]
 name = "zksync-os-revm"
 version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-os-revm?rev=237fd5a#237fd5a5a97468443a47d658298efd420d3e63d8"
 dependencies = [
  "auto_impl",
  "revm 34.0.0",
@@ -9253,3 +9714,9 @@ dependencies = [
  "alloy",
  "zksync_os_interface",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tests/fuzzer/fuzz/fuzz_targets/precompiles_diff/ecrecover.rs
+++ b/tests/fuzzer/fuzz/fuzz_targets/precompiles_diff/ecrecover.rs
@@ -1,30 +1,26 @@
 #![no_main]
 #![feature(allocator_api)]
 
-use arbitrary::{Arbitrary,Unstructured};
+use crate::common::{be_dec_inplace, be_inc_inplace};
+use arbitrary::{Arbitrary, Unstructured};
+use fuzz_precompiles_forward::precompiles::ecrecover as ecrecover_forward;
+use fuzz_precompiles_forward::precompiles::ecrecover_with_oracle;
 use libfuzzer_sys::fuzz_target;
 use revm_precompile::secp256k1::ec_recover_run;
-use fuzz_precompiles_forward::precompiles::ecrecover as ecrecover_forward;
-use fuzz_precompiles_proving::precompiles::ecrecover as ecrecover_proving;
-use secp256k1::{ecdsa::RecoverableSignature,Message,Secp256k1,SecretKey};
-use crate::common::{be_inc_inplace,be_dec_inplace};
+use secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1, SecretKey};
 
 mod common;
 
 const IN_LEN: usize = 128;
 
 const N_SECP256K1: [u8; 32] = [
-    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE,
-    0xBA,0xAE,0xDC,0xE6,0xAF,0x48,0xA0,0x3B,
-    0xBF,0xD2,0x5E,0x8C,0xD0,0x36,0x41,0x41,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+    0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41,
 ];
 
 const N_SECP256K1_HALF: [u8; 32] = [
-    0x7F,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-    0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-    0x5D,0x57,0x6E,0x73,0x57,0xA4,0x50,0x1D,
-    0xDF,0xE9,0x2F,0x46,0x68,0x1B,0x20,0xA0,
+    0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0x5D, 0x57, 0x6E, 0x73, 0x57, 0xA4, 0x50, 0x1D, 0xDF, 0xE9, 0x2F, 0x46, 0x68, 0x1B, 0x20, 0xA0,
 ];
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
@@ -36,25 +32,25 @@ enum Case {
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
 enum Mutation {
-    Msg,    // Bit flip mutate msg
-    V,      // Bit flip mutate v part of signature
-    R,      // Bit flip mutate r part of signature
-    S,      // Bit flip mutate s part of signature
+    Msg, // Bit flip mutate msg
+    V,   // Bit flip mutate v part of signature
+    R,   // Bit flip mutate r part of signature
+    S,   // Bit flip mutate s part of signature
 
-    V_0,      // v = 0
-    V_1,      // v = 1
-    V_29,     // v = 29
-    V_27,     // force 27
-    V_28,     // force 28
+    V_0,  // v = 0
+    V_1,  // v = 1
+    V_29, // v = 29
+    V_27, // force 27
+    V_28, // force 28
 
-    ZeroR,    // r = 0
-    ZeroS,    // s = 0
-    R_EqN,    // r = n
-    S_EqN,    // s = n
-    R_GeN,    // r = n+1
-    S_GeN,    // s = n+1
-    HighS,    // s = n-1
-    LowS,     // s = floor(n/2)
+    ZeroR, // r = 0
+    ZeroS, // s = 0
+    R_EqN, // r = n
+    S_EqN, // s = n
+    R_GeN, // r = n+1
+    S_GeN, // s = n+1
+    HighS, // s = n-1
+    LowS,  // s = floor(n/2)
 }
 
 #[derive(Arbitrary, Debug, Clone)]
@@ -70,9 +66,8 @@ struct Input {
 fn valid_tuple(seed: [u8; 32], msg32: [u8; 32]) -> ([u8; 32], [u8; 32], [u8; 32], [u8; 32]) {
     let secp = Secp256k1::signing_only();
 
-    let sk = SecretKey::from_slice(&seed).unwrap_or_else(|_| {
-        SecretKey::from_slice(&[1u8; 32]).expect("non-zero sk")
-    });
+    let sk = SecretKey::from_slice(&seed)
+        .unwrap_or_else(|_| SecretKey::from_slice(&[1u8; 32]).expect("non-zero sk"));
 
     let msg = Message::from_slice(&msg32).expect("prehash");
     let recsig: RecoverableSignature = secp.sign_ecdsa_recoverable(&msg, &sk);
@@ -99,7 +94,9 @@ fn build_input(u: &mut Unstructured<'_>, i: &Input) -> Vec<u8> {
 
             if let Some(t) = i.trunc {
                 let t = t as usize;
-                if t < v.len() { v.truncate(t); }
+                if t < v.len() {
+                    v.truncate(t);
+                }
             }
             v
         }
@@ -117,39 +114,81 @@ fn build_input(u: &mut Unstructured<'_>, i: &Input) -> Vec<u8> {
 
             if let Some(t) = i.trunc {
                 let t = t as usize;
-                if t < out.len() { out.truncate(t); }
+                if t < out.len() {
+                    out.truncate(t);
+                }
             }
             out
         }
     }
 }
 
-fn apply_mut(mutation: Mutation, msg: &mut [u8;32], v: &mut [u8;32], r: &mut [u8;32], s: &mut [u8;32], flip_idx: u8) {
-    let flip = |b: &mut [u8;32], at: u8| {
+fn apply_mut(
+    mutation: Mutation,
+    msg: &mut [u8; 32],
+    v: &mut [u8; 32],
+    r: &mut [u8; 32],
+    s: &mut [u8; 32],
+    flip_idx: u8,
+) {
+    let flip = |b: &mut [u8; 32], at: u8| {
         let i = (at as usize) & 31;
         b[i] ^= 1;
     };
     match mutation {
         Mutation::Msg => flip(msg, flip_idx),
-        Mutation::V   => flip(v, flip_idx),
-        Mutation::R   => flip(r, flip_idx),
-        Mutation::S   => flip(s, flip_idx),
+        Mutation::V => flip(v, flip_idx),
+        Mutation::R => flip(r, flip_idx),
+        Mutation::S => flip(s, flip_idx),
 
-        Mutation::V_0  => { *v = [0u8;32]; }
-        Mutation::V_1  => { *v = [0u8;32]; v[31] = 1; }
-        Mutation::V_29 => { *v = [0u8;32]; v[31] = 29; }
-        Mutation::V_27 => { *v = [0u8;32]; v[31] = 27; }
-        Mutation::V_28 => { *v = [0u8;32]; v[31] = 28; }
+        Mutation::V_0 => {
+            *v = [0u8; 32];
+        }
+        Mutation::V_1 => {
+            *v = [0u8; 32];
+            v[31] = 1;
+        }
+        Mutation::V_29 => {
+            *v = [0u8; 32];
+            v[31] = 29;
+        }
+        Mutation::V_27 => {
+            *v = [0u8; 32];
+            v[31] = 27;
+        }
+        Mutation::V_28 => {
+            *v = [0u8; 32];
+            v[31] = 28;
+        }
 
-        Mutation::ZeroR => { *r = [0u8;32]; }
-        Mutation::ZeroS => { *s = [0u8;32]; }
-        Mutation::R_EqN => { *r = N_SECP256K1; }
-        Mutation::S_EqN => { *s = N_SECP256K1; }
-        Mutation::R_GeN => { *r = N_SECP256K1; be_inc_inplace(r); }
-        Mutation::S_GeN => { *s = N_SECP256K1; be_inc_inplace(s); }
+        Mutation::ZeroR => {
+            *r = [0u8; 32];
+        }
+        Mutation::ZeroS => {
+            *s = [0u8; 32];
+        }
+        Mutation::R_EqN => {
+            *r = N_SECP256K1;
+        }
+        Mutation::S_EqN => {
+            *s = N_SECP256K1;
+        }
+        Mutation::R_GeN => {
+            *r = N_SECP256K1;
+            be_inc_inplace(r);
+        }
+        Mutation::S_GeN => {
+            *s = N_SECP256K1;
+            be_inc_inplace(s);
+        }
 
-        Mutation::HighS => { *s = N_SECP256K1; be_dec_inplace(s); }
-        Mutation::LowS  => { *s = N_SECP256K1_HALF; },
+        Mutation::HighS => {
+            *s = N_SECP256K1;
+            be_dec_inplace(s);
+        }
+        Mutation::LowS => {
+            *s = N_SECP256K1_HALF;
+        }
     }
 }
 
@@ -171,16 +210,16 @@ fn fuzz(data: &[u8]) {
     let r1 = ecrecover_forward(in_bytes.as_slice(), &mut out_forward);
     let fwd_ok = r1.is_ok();
 
-    let r2 = ecrecover_proving(in_bytes.as_slice(), &mut out_proving);
+    let r2 = ecrecover_with_oracle(in_bytes.as_slice(), &mut out_proving);
     let prv_ok = r2.is_ok();
 
     match (reth_ok, fwd_ok, prv_ok) {
         (true, true, true) => {
             let reth_bytes = r_reth.unwrap().bytes.to_vec();
             assert_eq!(out_forward, reth_bytes, "forward <> reth bytes mismatch");
-            assert_eq!(out_proving, reth_bytes, "proving <> reth bytes mismatch");
+            assert_eq!(out_proving, reth_bytes, "oracle <> reth bytes mismatch");
         }
-        (false, false, false) => { }
+        (false, false, false) => {}
         _ => {
             panic!(
                 "status mismatch: reth_ok={reth_ok} fwd_ok={fwd_ok} prv_ok={prv_ok}, in_len={}",

--- a/tests/fuzzer/fuzz/fuzz_targets/system_functions/ecrecover.rs
+++ b/tests/fuzzer/fuzz/fuzz_targets/system_functions/ecrecover.rs
@@ -5,11 +5,30 @@ use arbitrary::Unstructured;
 use basic_system::system_functions::ecrecover::EcRecoverImpl;
 use libfuzzer_sys::fuzz_target;
 use zk_ee::reference_implementations::BaseResources;
-use zk_ee::system::SystemFunction;
-use zk_ee::system::Resource;
 use zk_ee::reference_implementations::DecreasingNative;
+use zk_ee::system::logger::NullLogger;
+use zk_ee::system::Resource;
+use zk_ee::system::SystemFunctionExt;
 
 const ECRECOVER_SRC_REQUIRED_LENGTH: usize = 128;
+
+struct DummyOracle;
+
+impl zk_ee::oracle::IOOracle for DummyOracle {
+    type RawIterator<'a> = Box<dyn ExactSizeIterator<Item = usize> + 'static>;
+
+    fn raw_query<
+        'a,
+        I: zk_ee::oracle::usize_serialization::UsizeSerializable
+            + zk_ee::oracle::usize_serialization::UsizeDeserializable,
+    >(
+        &'a mut self,
+        _query_type: u32,
+        _input: &I,
+    ) -> Result<Self::RawIterator<'a>, zk_ee::system::errors::internal::InternalError> {
+        unreachable!("oracle should not be consulted on native targets");
+    }
+}
 
 fn fuzz(data: &[u8]) {
     let u = &mut Unstructured::new(data);
@@ -32,7 +51,14 @@ fn fuzz(data: &[u8]) {
 
     let mut dst = dst.clone();
 
-    let _ = EcRecoverImpl::execute(&src.as_slice()[0..n], &mut dst, &mut resource, allocator);
+    let _ = EcRecoverImpl::<false>::execute(
+        &src.as_slice()[0..n],
+        &mut dst,
+        &mut resource,
+        &mut DummyOracle,
+        &mut NullLogger,
+        allocator,
+    );
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/tests/fuzzer/fuzz/wrappers/basic_bootloader_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_bootloader_forward/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "basic_bootloader_forward"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "../../../../../basic_bootloader/src/lib.rs"
+
+[dependencies]
+zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward", default-features = false }
+cycle_marker = { path = "../../../../../cycle_marker" }
+evm_interpreter = { package = "evm_interpreter_forward", path = "../evm_interpreter_forward", default-features = false }
+system_hooks = { package = "system_hooks_forward", path = "../system_hooks_forward", default-features = false }
+basic_system = { package = "basic_system_forward", path = "../basic_system_forward", default-features = false }
+ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
+arrayvec = { version = "0.7.4", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+crypto = { package = "crypto_forward", path = "../crypto_forward", default-features = false }
+hex = {version = "*", optional = true}
+strum_macros = "0.27.1"
+paste = "1.0.15"
+cfg-if = "*"
+serde-big-array = "0.5"
+
+[features]
+serde = ["dep:serde", "ruint/serde"]
+testing = ["zk_ee/testing", "evm_interpreter/testing", "hex", "serde"]
+default = ["testing"]
+eip-7702 = []
+eip_7623 = []
+eip-4844 = ["system_hooks/point_eval_precompile"]
+burn_base_fee = []
+cycle_marker = ["system_hooks/cycle_marker", "cycle_marker/log_to_file"]
+resources_for_tester = []
+unlimited_native = []
+disable_system_contracts = []
+error_origins = ["zk_ee/error_origins"]

--- a/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "callable_oracles_forward"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "../../../../../callable_oracles/src/lib.rs"
+
+[dependencies]
+zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
+ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
+crypto = { package = "crypto_forward", path = "../crypto_forward", default-features = false }
+oracle_provider = { package = "oracle_provider_forward", path = "../oracle_provider_forward" }
+basic_system = { package = "basic_system_forward", path = "../basic_system_forward" }
+basic_bootloader = { package = "basic_bootloader_forward", path = "../basic_bootloader_forward", default-features = false }
+
+
+risc_v_simulator = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.4.3", optional = true }
+num-bigint = { version = "*", optional = true }
+num-traits = { version = "*", optional = true }
+
+alloy-consensus = "1.0.41"
+c-kzg = "2.1.5"
+
+[dev-dependencies]
+hex = "*"
+
+[features]
+default = ["evaluate"]
+evaluate = ["risc_v_simulator", "num-bigint", "num-traits"]

--- a/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_forward/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 [dependencies]
 basic_system = { package = "basic_system_forward", path = "../basic_system_forward"}
 zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
+callable_oracles = { package = "callable_oracles_forward", path = "../callable_oracles_forward" }
+oracle_provider = { package = "oracle_provider_forward", path = "../oracle_provider_forward" }

--- a/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_forward/src/precompiles.rs
+++ b/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_forward/src/precompiles.rs
@@ -14,6 +14,21 @@ use zk_ee::reference_implementations::DecreasingNative;
 use zk_ee::system::errors::subsystem::SubsystemError;
 use zk_ee::system::base_system_functions::{Bn254AddErrors,Sha256Errors,RipeMd160Errors,Keccak256Errors,
 Bn254MulErrors,P256VerifyErrors,Secp256k1ECRecoverErrors,Bn254PairingCheckErrors,PointEvaluationErrors};
+use zk_ee::system::logger::NullLogger;
+
+struct DummyOracle;
+
+impl zk_ee::oracle::IOOracle for DummyOracle {
+    type RawIterator<'a> = Box<dyn ExactSizeIterator<Item = usize> + 'static>;
+
+    fn raw_query<'a, I: zk_ee::oracle::usize_serialization::UsizeSerializable + zk_ee::oracle::usize_serialization::UsizeDeserializable>(
+        &'a mut self,
+        _query_type: u32,
+        _input: &I,
+    ) -> Result<Self::RawIterator<'a>, zk_ee::system::errors::internal::InternalError> {
+        unreachable!("oracle should not be consulted on native targets");
+    }
+}
 
 pub fn ecadd(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Bn254AddErrors>> {
     let allocator = std::alloc::Global;
@@ -54,7 +69,19 @@ pub fn p256_verify(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<P
 pub fn ecrecover(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
     let allocator = std::alloc::Global;
     let mut resource = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
-    EcRecoverImpl::execute(&src, dst, &mut resource, allocator)
+    EcRecoverImpl::<false>::execute(&src, dst, &mut resource, &mut DummyOracle, &mut NullLogger, allocator)
+}
+
+/// ecrecover using native field operations oracle (for comparing oracle vs non-oracle paths)
+pub fn ecrecover_with_oracle(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
+    use callable_oracles::field_hints::NativeFieldOpsQuery;
+    use oracle_provider::{DummyMemorySource, ZkEENonDeterminismSource};
+    
+    let allocator = std::alloc::Global;
+    let mut resource = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
+    let mut oracle = ZkEENonDeterminismSource::<DummyMemorySource>::default();
+    oracle.add_external_processor(NativeFieldOpsQuery::<DummyMemorySource>::default());
+    EcRecoverImpl::<true>::execute(&src, dst, &mut resource, &mut oracle, &mut NullLogger, allocator)
 }
 
 pub fn pairing(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Bn254PairingCheckErrors>> {

--- a/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_proving/src/precompiles.rs
+++ b/tests/fuzzer/fuzz/wrappers/fuzz_precompiles_proving/src/precompiles.rs
@@ -1,19 +1,21 @@
 use basic_system::system_functions::bn254_ecadd::Bn254AddImpl;
-use basic_system::system_functions::sha256::Sha256Impl;
-use basic_system::system_functions::keccak256::Keccak256Impl;
-use basic_system::system_functions::ripemd160::RipeMd160Impl;
 use basic_system::system_functions::bn254_ecmul::Bn254MulImpl;
-use basic_system::system_functions::p256_verify::P256VerifyImpl;
-use basic_system::system_functions::ecrecover::EcRecoverImpl;
 use basic_system::system_functions::bn254_pairing_check::Bn254PairingCheckImpl;
+use basic_system::system_functions::ecrecover::EcRecoverImpl;
+use basic_system::system_functions::keccak256::Keccak256Impl;
+use basic_system::system_functions::p256_verify::P256VerifyImpl;
 use basic_system::system_functions::point_evaluation::PointEvaluationImpl;
+use basic_system::system_functions::ripemd160::RipeMd160Impl;
+use basic_system::system_functions::sha256::Sha256Impl;
 use zk_ee::reference_implementations::BaseResources;
-use zk_ee::system::{SystemFunction,SystemFunctionExt};
-use zk_ee::system::Resource;
 use zk_ee::reference_implementations::DecreasingNative;
+use zk_ee::system::base_system_functions::{
+    Bn254AddErrors, Bn254MulErrors, Bn254PairingCheckErrors, Keccak256Errors, P256VerifyErrors,
+    PointEvaluationErrors, RipeMd160Errors, Secp256k1ECRecoverErrors, Sha256Errors,
+};
 use zk_ee::system::errors::subsystem::SubsystemError;
-use zk_ee::system::base_system_functions::{Bn254AddErrors,Sha256Errors,RipeMd160Errors,Keccak256Errors,
-Bn254MulErrors,P256VerifyErrors,Secp256k1ECRecoverErrors,Bn254PairingCheckErrors,PointEvaluationErrors};
+use zk_ee::system::Resource;
+use zk_ee::system::{SystemFunction, SystemFunctionExt};
 
 pub fn ecadd(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Bn254AddErrors>> {
     let allocator = std::alloc::Global;
@@ -51,13 +53,10 @@ pub fn p256_verify(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<P
     P256VerifyImpl::execute(&src, dst, &mut resource, allocator)
 }
 
-pub fn ecrecover(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
-    let allocator = std::alloc::Global;
-    let mut resource = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
-    EcRecoverImpl::execute(&src, dst, &mut resource, allocator)
-}
-
-pub fn pairing(src: &[u8], dst: &mut Vec<u8>) -> Result<(), SubsystemError<Bn254PairingCheckErrors>> {
+pub fn pairing(
+    src: &[u8],
+    dst: &mut Vec<u8>,
+) -> Result<(), SubsystemError<Bn254PairingCheckErrors>> {
     let allocator = std::alloc::Global;
     let mut resource = <BaseResources<DecreasingNative> as Resource>::FORMAL_INFINITE;
     Bn254PairingCheckImpl::execute(&src, dst, &mut resource, allocator)

--- a/tests/fuzzer/fuzz/wrappers/oracle_provider_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/oracle_provider_forward/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "oracle_provider_forward"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "../../../../../oracle_provider/src/lib.rs"
+
+[dependencies]
+zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
+risc_v_simulator = { git = "https://github.com/matter-labs/zksync-airbender", tag = "v0.4.3"}

--- a/tests/instances/eth_runner/src/main.rs
+++ b/tests/instances/eth_runner/src/main.rs
@@ -73,6 +73,10 @@ enum Command {
         /// Cannot be used together with --witness-output-dir.
         #[arg(long, conflicts_with = "witness_output_dir")]
         flamegraph: Option<String>,
+        /// Enable per-opcode EVM statistics collection.
+        /// Adds overhead; omit when only block-level benchmarks are needed.
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        opcode_stats: bool,
     },
     // Export block ratios from DB
     ExportRatios {
@@ -106,6 +110,7 @@ fn main() -> anyhow::Result<()> {
             chain_id,
             single_tx,
             flamegraph,
+            opcode_stats,
         } => crate::single_run::single_run(
             block_dir,
             block_hashes,
@@ -114,6 +119,7 @@ fn main() -> anyhow::Result<()> {
             chain_id,
             single_tx,
             flamegraph,
+            opcode_stats,
         ),
         Command::LiveRun {
             start_block,

--- a/tests/instances/eth_runner/src/single_run.rs
+++ b/tests/instances/eth_runner/src/single_run.rs
@@ -5,11 +5,12 @@ use crate::native_model::compute_ratio;
 use crate::post_check::post_check;
 use crate::prestate::{populate_prestate, DiffTrace, PrestateTrace};
 use crate::receipts::{BlockReceipts, TransactionReceipt};
+use rig::forward_system::system::system_types::ForwardRunningSystem;
+use rig::forward_system::system::tracers::evm_opcode_stats::EvmOpcodeStatsTracer;
 use rig::log::info;
 use rig::*;
 use std::fs::{self, File};
 use std::io::BufReader;
-use zk_ee::system::tracer::NopTracer;
 use zk_ee::system::validator::NopTxValidator;
 use zksync_os_interface::traits::EncodedTx;
 
@@ -54,18 +55,28 @@ fn run<const RANDOMIZED: bool>(
         check_storage_diff_hashes: true,
         ..Default::default()
     };
+    let mut tracer = EvmOpcodeStatsTracer::<ForwardRunningSystem>::default();
     let (output, stats, _) = chain
         .run_block_with_extra_stats(
             transactions,
             Some(block_context),
             None,
             Some(run_config),
-            &mut NopTracer::default(),
+            &mut tracer,
             &mut NopTxValidator::default(),
         )
         .unwrap();
 
     let _ratio = compute_ratio(stats);
+
+    tracer.print_stats();
+
+    if let Ok(path) = std::env::var("OPCODE_STATS_PATH") {
+        tracer
+            .write_csv(std::path::Path::new(&path))
+            .expect("Failed to write opcode stats CSV");
+        info!("Opcode stats written to {path}");
+    }
 
     post_check(output, receipts, diff_trace, prestate_cache).unwrap();
 

--- a/tests/instances/eth_runner/src/single_run.rs
+++ b/tests/instances/eth_runner/src/single_run.rs
@@ -78,6 +78,13 @@ fn run<const RANDOMIZED: bool>(
         info!("Opcode stats written to {path}");
     }
 
+    if let Ok(dir) = std::env::var("OPCODE_SAMPLES_DIR") {
+        tracer
+            .dump_samples(std::path::Path::new(&dir))
+            .expect("Failed to dump opcode samples");
+        info!("Opcode samples dumped to {dir}");
+    }
+
     post_check(output, receipts, diff_trace, prestate_cache).unwrap();
 
     Ok(())

--- a/tests/instances/eth_runner/src/single_run.rs
+++ b/tests/instances/eth_runner/src/single_run.rs
@@ -5,14 +5,17 @@ use crate::native_model::compute_ratio;
 use crate::post_check::post_check;
 use crate::prestate::{populate_prestate, DiffTrace, PrestateTrace};
 use crate::receipts::{BlockReceipts, TransactionReceipt};
+use rig::chain::BlockExtraStats;
 use rig::forward_system::system::system_types::ForwardRunningSystem;
 use rig::forward_system::system::tracers::evm_opcode_stats::EvmOpcodeStatsTracer;
 use rig::log::info;
 use rig::*;
 use std::fs::{self, File};
 use std::io::BufReader;
+use zk_ee::system::tracer::{NopTracer, Tracer};
 use zk_ee::system::validator::NopTxValidator;
 use zksync_os_interface::traits::EncodedTx;
+use zksync_os_interface::types::BlockOutput;
 
 #[allow(clippy::too_many_arguments)]
 fn run<const RANDOMIZED: bool>(
@@ -28,6 +31,7 @@ fn run<const RANDOMIZED: bool>(
     block_hashes: Option<BlockHashes>,
     witness_output_dir: Option<String>,
     flamegraph: Option<String>,
+    opcode_stats: bool,
 ) -> anyhow::Result<()> {
     chain.set_last_block_number(block_number - 1);
 
@@ -55,41 +59,73 @@ fn run<const RANDOMIZED: bool>(
         check_storage_diff_hashes: true,
         ..Default::default()
     };
-    let mut tracer = EvmOpcodeStatsTracer::<ForwardRunningSystem>::default();
-    let (output, stats, _) = chain
-        .run_block_with_extra_stats(
+
+    let (output, stats) = if opcode_stats {
+        let mut tracer = EvmOpcodeStatsTracer::<ForwardRunningSystem>::default();
+        let result = run_with_tracer(
+            &mut chain,
             transactions,
-            Some(block_context),
-            None,
-            Some(run_config),
+            block_context,
+            run_config,
             &mut tracer,
-            &mut NopTxValidator::default(),
+        );
+
+        tracer.print_stats();
+
+        if let Ok(path) = std::env::var("OPCODE_STATS_PATH") {
+            tracer
+                .write_csv(std::path::Path::new(&path))
+                .expect("Failed to write opcode stats CSV");
+            info!("Opcode stats written to {path}");
+        }
+
+        if let Ok(dir) = std::env::var("OPCODE_SAMPLES_DIR") {
+            tracer
+                .dump_samples(std::path::Path::new(&dir))
+                .expect("Failed to dump opcode samples");
+            info!("Opcode samples dumped to {dir}");
+        }
+
+        result
+    } else {
+        run_with_tracer(
+            &mut chain,
+            transactions,
+            block_context,
+            run_config,
+            &mut NopTracer::default(),
         )
-        .unwrap();
+    };
 
     let _ratio = compute_ratio(stats);
-
-    tracer.print_stats();
-
-    if let Ok(path) = std::env::var("OPCODE_STATS_PATH") {
-        tracer
-            .write_csv(std::path::Path::new(&path))
-            .expect("Failed to write opcode stats CSV");
-        info!("Opcode stats written to {path}");
-    }
-
-    if let Ok(dir) = std::env::var("OPCODE_SAMPLES_DIR") {
-        tracer
-            .dump_samples(std::path::Path::new(&dir))
-            .expect("Failed to dump opcode samples");
-        info!("Opcode samples dumped to {dir}");
-    }
 
     post_check(output, receipts, diff_trace, prestate_cache).unwrap();
 
     Ok(())
 }
 
+fn run_with_tracer<const RANDOMIZED: bool>(
+    chain: &mut Chain<RANDOMIZED>,
+    transactions: Vec<EncodedTx>,
+    block_context: BlockContext,
+    run_config: rig::chain::RunConfig,
+    tracer: &mut impl Tracer<ForwardRunningSystem>,
+) -> (BlockOutput, BlockExtraStats) {
+    let (output, stats, _) = chain
+        .run_block_with_extra_stats(
+            transactions,
+            Some(block_context),
+            None,
+            Some(run_config),
+            tracer,
+            &mut NopTxValidator::default(),
+        )
+        .unwrap();
+
+    (output, stats)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn single_run(
     block_dir: String,
     block_hashes: Option<String>,
@@ -98,6 +134,7 @@ pub fn single_run(
     chain_id: Option<u64>,
     single_tx: Option<u64>,
     flamegraph: Option<String>,
+    opcode_stats: bool,
 ) -> anyhow::Result<()> {
     use std::path::Path;
 
@@ -184,6 +221,7 @@ pub fn single_run(
             block_hashes,
             witness_output_dir,
             flamegraph,
+            opcode_stats,
         )
     } else {
         let chain = Chain::empty(Some(1));
@@ -200,6 +238,7 @@ pub fn single_run(
             block_hashes,
             witness_output_dir,
             flamegraph,
+            opcode_stats,
         )
     }
 }

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -963,6 +963,7 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
             callable_oracles::blob_kzg_commitment::BlobCommitmentAndProofQuery::default(),
         );
         oracle.add_external_processor(callable_oracles::arithmetic::ArithmeticQuery::default());
+        oracle.add_external_processor(callable_oracles::field_hints::FieldOpsQuery::default());
         oracle.add_external_processor(UARTPrintResponder);
 
         oracle

--- a/zk_ee/src/system/base_system_functions.rs
+++ b/zk_ee/src/system/base_system_functions.rs
@@ -166,7 +166,6 @@ impl<R: Resources> SystemFunction<R, Secp256r1MulProjectiveErrors> for MissingSy
 pub trait SystemFunctions<R: Resources> {
     type Keccak256: SystemFunction<R, Keccak256Errors>;
     type Sha256: SystemFunction<R, Sha256Errors>;
-    type Secp256k1ECRecover: SystemFunction<R, Secp256k1ECRecoverErrors>;
     type Secp256k1AddProjective: SystemFunction<R, Secp256k1AddProjectiveErrors>;
     type Secp256k1MulProjective: SystemFunction<R, Secp256k1MulProjectiveErrors>;
     type Secp256r1AddProjective: SystemFunction<R, Secp256r1AddProjectiveErrors>;
@@ -194,15 +193,6 @@ pub trait SystemFunctions<R: Resources> {
         allocator: A,
     ) -> Result<(), SubsystemError<Sha256Errors>> {
         Self::Sha256::execute(input, output, resources, allocator)
-    }
-
-    fn secp256k1_ec_recover<D: TryExtend<u8> + ?Sized, A: core::alloc::Allocator + Clone>(
-        input: &[u8],
-        output: &mut D,
-        resources: &mut R,
-        allocator: A,
-    ) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
-        Self::Secp256k1ECRecover::execute(input, output, resources, allocator)
     }
 
     fn secp256k1_add_projective<D: TryExtend<u8> + ?Sized, A: core::alloc::Allocator + Clone>(
@@ -297,7 +287,24 @@ pub trait SystemFunctions<R: Resources> {
 }
 
 pub trait SystemFunctionsExt<R: Resources> {
+    type Secp256k1ECRecover: SystemFunctionExt<R, Secp256k1ECRecoverErrors>;
     type ModExp: SystemFunctionExt<R, ModExpErrors>;
+
+    fn secp256k1_ec_recover<
+        O: IOOracle,
+        L: Logger,
+        D: TryExtend<u8> + ?Sized,
+        A: core::alloc::Allocator + Clone,
+    >(
+        input: &[u8],
+        output: &mut D,
+        resources: &mut R,
+        oracle: &mut O,
+        logger: &mut L,
+        allocator: A,
+    ) -> Result<(), SubsystemError<Secp256k1ECRecoverErrors>> {
+        Self::Secp256k1ECRecover::execute(input, output, resources, oracle, logger, allocator)
+    }
 
     fn mod_exp<
         O: IOOracle,

--- a/zksync_os/Cargo.lock
+++ b/zksync_os/Cargo.lock
@@ -197,10 +197,8 @@ name = "basic_system"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "cc-traits 0.1.0",
- "cfg-if",
+ "cc-traits",
  "const-hex",
- "const_for",
  "crypto",
  "cycle_marker",
  "either",
@@ -210,8 +208,6 @@ dependencies = [
  "ruint",
  "storage_models",
  "strum_macros",
- "system_hooks",
- "zerocopy",
  "zk_ee",
 ]
 
@@ -258,12 +254,6 @@ name = "cc-traits"
 version = "0.1.0"
 
 [[package]]
-name = "cc-traits"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +289,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto"
@@ -431,12 +415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-hal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,7 +446,6 @@ dependencies = [
  "ruint",
  "strum_macros",
  "zk_ee",
- "zksync_os_evm_errors",
 ]
 
 [[package]]
@@ -700,16 +677,12 @@ dependencies = [
 name = "proof_running_system"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "basic_bootloader",
  "basic_system",
- "cc-traits 2.0.0",
  "cfg-if",
  "crypto",
  "evm_interpreter",
- "lock_api",
  "ruint",
- "seq-macro",
  "system_hooks",
  "talc",
  "zk_ee",
@@ -818,16 +791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5c1b8bf41ea746266cdee443d1d1e9125c86ce1447e1a2615abd34330d33a9"
-dependencies = [
- "critical-section",
- "embedded-hal",
-]
-
-[[package]]
 name = "riscv_common"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender.git?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
@@ -871,12 +834,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -957,7 +914,6 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "storage_models"
 version = "0.1.0"
 dependencies = [
- "crypto",
  "zk_ee",
 ]
 
@@ -1115,7 +1071,6 @@ dependencies = [
  "paste",
  "ruint",
  "strum_macros",
- "zksync_os_evm_errors",
 ]
 
 [[package]]
@@ -1125,13 +1080,5 @@ dependencies = [
  "crypto",
  "heapless",
  "proof_running_system",
- "riscv",
  "riscv_common",
- "zerocopy",
 ]
-
-[[package]]
-name = "zksync_os_evm_errors"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fea4915ff8302cbd66403de07518fe4025fbcacd3d3d1760cc03029e710586a"

--- a/zksync_os_runner/src/lib.rs
+++ b/zksync_os_runner/src/lib.rs
@@ -81,7 +81,8 @@ fn run_and_get_effective_cycles_inner(
 
     #[cfg(feature = "cycle_marker")]
     {
-        block_effective = cycle_marker::print_cycle_markers();
+        let results = cycle_marker::print_cycle_markers();
+        block_effective = results.block_effective;
     }
 
     // our convention is to return 32 bytes placed into registers x10-x17


### PR DESCRIPTION
## What ❔

Per-opcode EVM benchmarking infrastructure that collects gas, native resource, and RISC-V cycle stats for every EVM opcode execution. Enables computing cycles/gas and native/gas ratios to guide proving cost optimizations.

**Components:**
- `EvmOpcodeStatsTracer` — forward-mode tracer collecting per-opcode gas, native, count with min/max/median
- Per-opcode cycle markers in the interpreter loop (`opcode_start!/opcode_end!`) — aggregated in `print_cycle_markers()` with min/max/median
- Per-execution sample dump mode — write `(gas, native)` and `cycles` per execution for detailed ratio analysis
- `join_samples.py` — joins tracer + cycle samples, computes per-execution cycles/gas with p50/p95/p99/max
- `compare_opcode_stats.py` — CI integration: compact diff table when per-opcode stats change
- `visualize_opcode_stats.py` — total cycle bar chart + sorted cycles/gas ratio curves
- Integration into `eth_runner` single-run and CI bench workflow

**Usage:**
```bash
# Basic run (prints per-opcode stats table)
bash bench_scripts/bench.sh quick

# Full per-execution analysis
OPCODE_SAMPLES_DIR=samples OPCODE_CYCLE_SAMPLES_DIR=cycle_samples bash bench_scripts/bench.sh quick
python3 bench_scripts/join_samples.py samples/ cycle_samples/ --summary --out-dir joined/
python3 bench_scripts/visualize_opcode_stats.py joined/ --out-dir charts/
```

**Benchmark impact:** +0.34% effective cycles with benchmarking features enabled. Zero overhead in production builds (all behind `#[cfg(feature = "cycle_marker")]`).

## Why ❔

To compute per-opcode `cycles/gas` and `native/gas` ratios for verifying the native resource model against actual RISC-V proving costs.

## Is this a breaking change?
- [ ] Yes
- [x] No

All code is behind feature flags or in benchmarking-only paths. Production proving builds are unaffected — verified by audit of all changed files and benchmark comparison.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.