### PR TITLE
test(unit): add malicious oracle behavior tests

### DIFF
--- a/callable_oracles/Cargo.toml
+++ b/callable_oracles/Cargo.toml
@@ -26,3 +26,4 @@ hex = { workspace = true }
 [features]
 default = ["evaluate"]
 evaluate = ["riscv_transpiler"]
+testing = []

--- a/callable_oracles/src/arithmetic/mod.rs
+++ b/callable_oracles/src/arithmetic/mod.rs
@@ -260,11 +260,7 @@ mod tests {
         memory.insert_u64_words(m_addr, modulus_u64);
 
         let result: Vec<usize> = ArithmeticQuery
-            .process_buffered_query(
-                MODEXP_ADVICE_QUERY_ID,
-                vec![PARAMS_ADDR as usize],
-                &memory,
-            )
+            .process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![PARAMS_ADDR as usize], &memory)
             .collect();
 
         assert!(!result.is_empty(), "Expected at least a header word");
@@ -431,15 +427,19 @@ mod tests {
     #[should_panic(expected = "A single RISC-V ptr should've been passed")]
     fn arithmetic_query_panics_on_extra_args() {
         let memory = TestMemorySource::default();
-        let _ =
-            ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![0x100, 0x200], &memory);
+        let _ = ArithmeticQuery.process_buffered_query(
+            MODEXP_ADVICE_QUERY_ID,
+            vec![0x100, 0x200],
+            &memory,
+        );
     }
 
     #[test]
     #[should_panic]
     fn arithmetic_query_panics_on_misaligned_pointer() {
         let memory = TestMemorySource::default();
-        let _ = ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![0x101], &memory);
+        let _ =
+            ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![0x101], &memory);
     }
 
     #[test]

--- a/callable_oracles/src/arithmetic/mod.rs
+++ b/callable_oracles/src/arithmetic/mod.rs
@@ -162,22 +162,11 @@ impl OracleQueryProcessor for NativeArithmeticQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
+    use crate::test_utils::TestMemorySource;
     use oracle_provider::DummyMemorySource;
-    use oracle_provider::RamPeek;
-
-    #[derive(Default)]
-    struct TestMemorySource {
-        words: BTreeMap<u32, u32>,
-    }
 
     impl TestMemorySource {
-        fn insert_u32(&mut self, address: u32, value: u32) {
-            assert!(address.is_multiple_of(4));
-            self.words.insert(address, value);
-        }
-
         fn insert_u64_words(&mut self, address: u32, values: &[u64]) {
             for (idx, value) in values.iter().copied().enumerate() {
                 let word_address = address + (idx as u32) * 8;
@@ -204,12 +193,6 @@ mod tests {
         }
     }
 
-    impl RamPeek for TestMemorySource {
-        fn peek_word(&self, address: u32) -> u32 {
-            self.words.get(&address).copied().unwrap_or(0)
-        }
-    }
-
     fn patterned_u64_words(len: usize, seed: u64) -> Vec<u64> {
         let mut state = seed;
         let mut words = Vec::with_capacity(len);
@@ -233,8 +216,8 @@ mod tests {
     }
 
     /// Helper: write a ModExpAdviceParams struct and data into TestMemorySource, then run the
-    /// RISC-V oracle query. Returns (quotient_u64_words, remainder_u64_words).
-    fn run_riscv_division(dividend_u64: &[u64], modulus_u64: &[u64]) -> (Vec<u64>, Vec<u64>) {
+    /// oracle query processor. Returns (quotient_u64_words, remainder_u64_words).
+    fn run_division_query(dividend_u64: &[u64], modulus_u64: &[u64]) -> (Vec<u64>, Vec<u64>) {
         let a_digits = dividend_u64.len().div_ceil(4);
         let m_digits = modulus_u64.len().div_ceil(4);
         let a_u64_count = a_digits * 4;
@@ -279,7 +262,7 @@ mod tests {
     #[test]
     fn riscv_arithmetic_query_basic_division() {
         // 10 / 3 = q=3, r=1
-        let (q, r) = run_riscv_division(&[10, 0, 0, 0], &[3, 0, 0, 0]);
+        let (q, r) = run_division_query(&[10, 0, 0, 0], &[3, 0, 0, 0]);
         assert_eq!(q, vec![3]);
         assert_eq!(r, vec![1]);
     }
@@ -287,7 +270,7 @@ mod tests {
     #[test]
     fn riscv_arithmetic_query_exact_division() {
         // 15 / 5 = q=3, r=0
-        let (q, r) = run_riscv_division(&[15, 0, 0, 0], &[5, 0, 0, 0]);
+        let (q, r) = run_division_query(&[15, 0, 0, 0], &[5, 0, 0, 0]);
         assert_eq!(q, vec![3]);
         assert!(r.is_empty(), "remainder should be zero (stripped)");
     }
@@ -295,7 +278,7 @@ mod tests {
     #[test]
     fn riscv_arithmetic_query_dividend_smaller_than_modulus() {
         // 2 / 7 = q=0, r=2
-        let (q, r) = run_riscv_division(&[2, 0, 0, 0], &[7, 0, 0, 0]);
+        let (q, r) = run_division_query(&[2, 0, 0, 0], &[7, 0, 0, 0]);
         assert!(q.is_empty(), "quotient should be zero (stripped)");
         assert_eq!(r, vec![2]);
     }
@@ -304,7 +287,7 @@ mod tests {
     fn riscv_arithmetic_query_dividend_fewer_digits_than_modulus() {
         // a=5 (1 DelegatedU256 digit), m=2^64+3 (2 DelegatedU256 digits)
         // 5 < 2^64+3, so q=0, r=5
-        let (q, r) = run_riscv_division(&[5, 0, 0, 0], &[3, 0, 0, 0, 1, 0, 0, 0]);
+        let (q, r) = run_division_query(&[5, 0, 0, 0], &[3, 0, 0, 0, 1, 0, 0, 0]);
         assert!(q.is_empty(), "quotient should be zero (stripped)");
         assert_eq!(r, vec![5]);
     }
@@ -312,7 +295,7 @@ mod tests {
     #[test]
     fn riscv_arithmetic_query_multi_digit_quotient() {
         // 2^128 / 3 = 0x55555555555555555555555555555555 remainder 1
-        let (q, r) = run_riscv_division(&[0, 0, 1, 0], &[3, 0, 0, 0]);
+        let (q, r) = run_division_query(&[0, 0, 1, 0], &[3, 0, 0, 0]);
         assert_eq!(q, vec![0x5555555555555555, 0x5555555555555555]);
         assert_eq!(r, vec![1]);
     }
@@ -320,7 +303,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn riscv_arithmetic_query_division_by_zero() {
-        let _ = run_riscv_division(&[10, 0, 0, 0], &[0, 0, 0, 0]);
+        let _ = run_division_query(&[10, 0, 0, 0], &[0, 0, 0, 0]);
     }
 
     #[test]

--- a/callable_oracles/src/arithmetic/mod.rs
+++ b/callable_oracles/src/arithmetic/mod.rs
@@ -305,6 +305,29 @@ mod tests {
     }
 
     #[test]
+    fn riscv_arithmetic_query_dividend_fewer_digits_than_modulus() {
+        // a=5 (1 DelegatedU256 digit), m=2^64+3 (2 DelegatedU256 digits)
+        // 5 < 2^64+3, so q=0, r=5
+        let (q, r) = run_riscv_division(&[5, 0, 0, 0], &[3, 0, 0, 0, 1, 0, 0, 0]);
+        assert!(q.is_empty(), "quotient should be zero (stripped)");
+        assert_eq!(r, vec![5]);
+    }
+
+    #[test]
+    fn riscv_arithmetic_query_multi_digit_quotient() {
+        // 2^128 / 3 = 0x55555555555555555555555555555555 remainder 1
+        let (q, r) = run_riscv_division(&[0, 0, 1, 0], &[3, 0, 0, 0]);
+        assert_eq!(q, vec![0x5555555555555555, 0x5555555555555555]);
+        assert_eq!(r, vec![1]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn riscv_arithmetic_query_division_by_zero() {
+        let _ = run_riscv_division(&[10, 0, 0, 0], &[0, 0, 0, 0]);
+    }
+
+    #[test]
     fn native_arithmetic_query_processes_valid_query() {
         let mut dividend = vec![10u64, 0, 0, 0];
         let mut modulus = vec![3u64, 0, 0, 0];

--- a/callable_oracles/src/arithmetic/mod.rs
+++ b/callable_oracles/src/arithmetic/mod.rs
@@ -232,6 +232,78 @@ mod tests {
         words
     }
 
+    /// Helper: write a ModExpAdviceParams struct and data into TestMemorySource, then run the
+    /// RISC-V oracle query. Returns (quotient_u64_words, remainder_u64_words).
+    fn run_riscv_division(dividend_u64: &[u64], modulus_u64: &[u64]) -> (Vec<u64>, Vec<u64>) {
+        let a_digits = dividend_u64.len().div_ceil(4);
+        let m_digits = modulus_u64.len().div_ceil(4);
+        let a_u64_count = a_digits * 4;
+
+        const PARAMS_ADDR: u32 = 0x100;
+        const A_ADDR: u32 = 0x200;
+        let m_addr: u32 = A_ADDR + (a_u64_count as u32) * 8;
+
+        let mut memory = TestMemorySource::default();
+        memory.insert_modexp_params(
+            PARAMS_ADDR,
+            ModExpAdviceParams {
+                op: 0,
+                a_ptr: A_ADDR,
+                a_len: a_digits as u32,
+                b_ptr: 0,
+                b_len: 0,
+                modulus_ptr: m_addr,
+                modulus_len: m_digits as u32,
+            },
+        );
+        memory.insert_u64_words(A_ADDR, dividend_u64);
+        memory.insert_u64_words(m_addr, modulus_u64);
+
+        let result: Vec<usize> = ArithmeticQuery
+            .process_buffered_query(
+                MODEXP_ADVICE_QUERY_ID,
+                vec![PARAMS_ADDR as usize],
+                &memory,
+            )
+            .collect();
+
+        assert!(!result.is_empty(), "Expected at least a header word");
+        let header = result[0] as u64;
+        let q_len_u32 = (header & 0xFFFF_FFFF) as usize;
+        let r_len_u32 = (header >> 32) as usize;
+        let q_len = q_len_u32 / 2;
+        let r_len = r_len_u32 / 2;
+        assert_eq!(result.len(), 1 + q_len + r_len);
+
+        let quotient: Vec<u64> = result[1..1 + q_len].iter().map(|&x| x as u64).collect();
+        let remainder: Vec<u64> = result[1 + q_len..].iter().map(|&x| x as u64).collect();
+        (quotient, remainder)
+    }
+
+    #[test]
+    fn riscv_arithmetic_query_basic_division() {
+        // 10 / 3 = q=3, r=1
+        let (q, r) = run_riscv_division(&[10, 0, 0, 0], &[3, 0, 0, 0]);
+        assert_eq!(q, vec![3]);
+        assert_eq!(r, vec![1]);
+    }
+
+    #[test]
+    fn riscv_arithmetic_query_exact_division() {
+        // 15 / 5 = q=3, r=0
+        let (q, r) = run_riscv_division(&[15, 0, 0, 0], &[5, 0, 0, 0]);
+        assert_eq!(q, vec![3]);
+        assert!(r.is_empty(), "remainder should be zero (stripped)");
+    }
+
+    #[test]
+    fn riscv_arithmetic_query_dividend_smaller_than_modulus() {
+        // 2 / 7 = q=0, r=2
+        let (q, r) = run_riscv_division(&[2, 0, 0, 0], &[7, 0, 0, 0]);
+        assert!(q.is_empty(), "quotient should be zero (stripped)");
+        assert_eq!(r, vec![2]);
+    }
+
     #[test]
     fn native_arithmetic_query_processes_valid_query() {
         let mut dividend = vec![10u64, 0, 0, 0];
@@ -323,6 +395,28 @@ mod tests {
         assert!(r_len.is_multiple_of(2));
         assert!(q_len > 2, "quotient should span multiple u64 limbs");
         assert!(r_len > 2, "remainder should span multiple u64 limbs");
+    }
+
+    #[test]
+    #[should_panic(expected = "A u32 should've been passed in")]
+    fn arithmetic_query_panics_on_empty_query() {
+        let memory = TestMemorySource::default();
+        let _ = ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![], &memory);
+    }
+
+    #[test]
+    #[should_panic(expected = "A single RISC-V ptr should've been passed")]
+    fn arithmetic_query_panics_on_extra_args() {
+        let memory = TestMemorySource::default();
+        let _ =
+            ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![0x100, 0x200], &memory);
+    }
+
+    #[test]
+    #[should_panic]
+    fn arithmetic_query_panics_on_misaligned_pointer() {
+        let memory = TestMemorySource::default();
+        let _ = ArithmeticQuery.process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![0x101], &memory);
     }
 
     #[test]

--- a/callable_oracles/src/blob_kzg_commitment/mod.rs
+++ b/callable_oracles/src/blob_kzg_commitment/mod.rs
@@ -141,6 +141,32 @@ pub fn blob_kzg_commitment_and_proof(data: &[u8]) -> KZGCommitmentAndProof {
 mod tests {
     use super::*;
     use oracle_provider::DummyMemorySource;
+    use oracle_provider::RamPeek;
+    use std::collections::BTreeMap;
+    use zk_ee::oracle::usize_serialization::UsizeSerializable;
+
+    #[derive(Default)]
+    struct TestMemorySource {
+        words: BTreeMap<u32, u32>,
+    }
+
+    impl TestMemorySource {
+        fn write_bytes(&mut self, offset: u32, data: &[u8]) {
+            for (i, chunk) in data.chunks(4).enumerate() {
+                let mut word = [0u8; 4];
+                word[..chunk.len()].copy_from_slice(chunk);
+                let val = u32::from_le_bytes(word);
+                let addr = offset + (i as u32) * 4;
+                self.words.insert(addr, val);
+            }
+        }
+    }
+
+    impl RamPeek for TestMemorySource {
+        fn peek_word(&self, address: u32) -> u32 {
+            self.words.get(&address).copied().unwrap_or(0)
+        }
+    }
 
     #[test]
     fn native_blob_query_processes_valid_query() {
@@ -157,12 +183,82 @@ mod tests {
     }
 
     #[test]
+    fn blob_kzg_commitment_deterministic() {
+        let data = b"hello blob commitment test data";
+        let result1 = blob_kzg_commitment_and_proof(data);
+        let result2 = blob_kzg_commitment_and_proof(data);
+        assert_eq!(result1.commitment, result2.commitment);
+        assert_eq!(result1.proof, result2.proof);
+    }
+
+    #[test]
+    fn blob_kzg_commitment_different_data() {
+        let result1 = blob_kzg_commitment_and_proof(b"data1");
+        let result2 = blob_kzg_commitment_and_proof(b"data2");
+        assert_ne!(
+            result1.commitment, result2.commitment,
+            "different data should produce different commitments"
+        );
+    }
+
+    #[test]
+    fn blob_kzg_commitment_empty_data() {
+        let result = blob_kzg_commitment_and_proof(b"");
+        assert_eq!(result.commitment.len(), 48);
+        assert_eq!(result.proof.len(), 48);
+    }
+
+    #[test]
+    fn riscv_blob_kzg_oracle_via_memory() {
+        let data = b"test blob data for oracle query";
+        let data_addr: u32 = 0x100;
+        let mut memory = TestMemorySource::default();
+        memory.write_bytes(data_addr, data);
+
+        let result: Vec<usize> = BlobCommitmentAndProofQuery
+            .process_buffered_query(
+                BLOB_COMMITMENT_AND_PROOF_QUERY_ID,
+                vec![data_addr as usize, data.len() as usize],
+                &memory,
+            )
+            .collect();
+
+        assert!(!result.is_empty(), "Oracle should return non-empty result");
+
+        let expected = blob_kzg_commitment_and_proof(data);
+        let expected_serialized: Vec<usize> = expected.iter().collect();
+        assert_eq!(result, expected_serialized);
+    }
+
+    #[test]
     #[should_panic]
     fn native_blob_query_rejects_null_pointer() {
         let _ = NativeBlobCommitmentAndProofQuery.process_buffered_query(
             BLOB_COMMITMENT_AND_PROOF_QUERY_ID,
             vec![0, 1],
             &DummyMemorySource,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "RISC-V ptr and len should've been passed")]
+    fn blob_kzg_oracle_panics_on_extra_args() {
+        let memory = TestMemorySource::default();
+        let _ = BlobCommitmentAndProofQuery.process_buffered_query(
+            BLOB_COMMITMENT_AND_PROOF_QUERY_ID,
+            vec![0x100, 10, 42],
+            &memory,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn blob_kzg_oracle_panics_on_misaligned_pointer() {
+        let memory = TestMemorySource::default();
+        let _ = BlobCommitmentAndProofQuery.process_buffered_query(
+            BLOB_COMMITMENT_AND_PROOF_QUERY_ID,
+            vec![0x101, 10],
+            &memory,
         );
     }
 }

--- a/callable_oracles/src/blob_kzg_commitment/mod.rs
+++ b/callable_oracles/src/blob_kzg_commitment/mod.rs
@@ -140,15 +140,9 @@ pub fn blob_kzg_commitment_and_proof(data: &[u8]) -> KZGCommitmentAndProof {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::TestMemorySource;
     use oracle_provider::DummyMemorySource;
-    use oracle_provider::RamPeek;
-    use std::collections::BTreeMap;
     use zk_ee::oracle::usize_serialization::UsizeSerializable;
-
-    #[derive(Default)]
-    struct TestMemorySource {
-        words: BTreeMap<u32, u32>,
-    }
 
     impl TestMemorySource {
         fn write_bytes(&mut self, offset: u32, data: &[u8]) {
@@ -159,12 +153,6 @@ mod tests {
                 let addr = offset + (i as u32) * 4;
                 self.words.insert(addr, val);
             }
-        }
-    }
-
-    impl RamPeek for TestMemorySource {
-        fn peek_word(&self, address: u32) -> u32 {
-            self.words.get(&address).copied().unwrap_or(0)
         }
     }
 

--- a/callable_oracles/src/blob_kzg_commitment/mod.rs
+++ b/callable_oracles/src/blob_kzg_commitment/mod.rs
@@ -144,18 +144,6 @@ mod tests {
     use oracle_provider::DummyMemorySource;
     use zk_ee::oracle::usize_serialization::UsizeSerializable;
 
-    impl TestMemorySource {
-        fn write_bytes(&mut self, offset: u32, data: &[u8]) {
-            for (i, chunk) in data.chunks(4).enumerate() {
-                let mut word = [0u8; 4];
-                word[..chunk.len()].copy_from_slice(chunk);
-                let val = u32::from_le_bytes(word);
-                let addr = offset + (i as u32) * 4;
-                self.words.insert(addr, val);
-            }
-        }
-    }
-
     #[test]
     fn native_blob_query_processes_valid_query() {
         let data = [1u8, 2, 3, 4, 5];

--- a/callable_oracles/src/lib.rs
+++ b/callable_oracles/src/lib.rs
@@ -37,14 +37,14 @@ use zk_ee::{
 pub mod hash_to_prime;
 
 /// Shared test utilities for callable oracle unit tests.
-#[cfg(test)]
-pub(crate) mod test_utils {
+#[cfg(any(test, feature = "testing"))]
+pub mod test_utils {
     use oracle_provider::RamPeek;
     use std::collections::BTreeMap;
 
     /// BTreeMap-backed memory source for testing oracle query processors.
     #[derive(Default)]
-    pub(crate) struct TestMemorySource {
+    pub struct TestMemorySource {
         words: BTreeMap<u32, u32>,
     }
 

--- a/callable_oracles/src/lib.rs
+++ b/callable_oracles/src/lib.rs
@@ -36,6 +36,32 @@ use zk_ee::{
 
 pub mod hash_to_prime;
 
+/// Shared test utilities for callable oracle unit tests.
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use oracle_provider::RamPeek;
+    use std::collections::BTreeMap;
+
+    /// BTreeMap-backed memory source for testing oracle query processors.
+    #[derive(Default)]
+    pub(crate) struct TestMemorySource {
+        pub words: BTreeMap<u32, u32>,
+    }
+
+    impl TestMemorySource {
+        pub fn insert_u32(&mut self, address: u32, value: u32) {
+            assert!(address.is_multiple_of(4));
+            self.words.insert(address, value);
+        }
+    }
+
+    impl RamPeek for TestMemorySource {
+        fn peek_word(&self, address: u32) -> u32 {
+            self.words.get(&address).copied().unwrap_or(0)
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryRegionDescriptionParams {
     pub offset: u32,

--- a/callable_oracles/src/lib.rs
+++ b/callable_oracles/src/lib.rs
@@ -45,13 +45,26 @@ pub(crate) mod test_utils {
     /// BTreeMap-backed memory source for testing oracle query processors.
     #[derive(Default)]
     pub(crate) struct TestMemorySource {
-        pub words: BTreeMap<u32, u32>,
+        words: BTreeMap<u32, u32>,
     }
 
     impl TestMemorySource {
         pub fn insert_u32(&mut self, address: u32, value: u32) {
             assert!(address.is_multiple_of(4));
             self.words.insert(address, value);
+        }
+
+        /// Write a byte slice into memory starting at the given word-aligned offset.
+        /// Data is written in little-endian order, 4 bytes per word.
+        /// Partial final chunks are zero-padded.
+        pub fn write_bytes(&mut self, offset: u32, data: &[u8]) {
+            for (i, chunk) in data.chunks(4).enumerate() {
+                let mut word = [0u8; 4];
+                word[..chunk.len()].copy_from_slice(chunk);
+                let val = u32::from_le_bytes(word);
+                let addr = offset + (i as u32) * 4;
+                self.insert_u32(addr, val);
+            }
         }
     }
 

--- a/tests/instances/unit/src/lib.rs
+++ b/tests/instances/unit/src/lib.rs
@@ -1,5 +1,6 @@
 mod coinbase_regression;
 mod initial_slot_regression;
 mod kzg_blobs;
+mod malicious_oracle;
 mod tracer;
 mod validator;

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -243,3 +243,309 @@ mod da_commitment_scheme {
         assert!(DACommitmentScheme::try_from(255u8).is_err());
     }
 }
+
+/// Integration tests using custom oracle factories to test security-critical
+/// oracle validation paths end-to-end. These cover cases from PR#374 where
+/// the system must properly validate and reject malicious oracle responses.
+mod custom_oracle_factories {
+    use rig::alloy::consensus::TxEip2930;
+    use rig::alloy::primitives::{TxKind, U256};
+    use rig::basic_system::system_implementation::flat_storage_model::{
+        FlatStorageCommitment, TREE_HEIGHT,
+    };
+    use rig::chain::TestingOracleFactory;
+    use rig::forward_system::run::convert_alloy::FromAlloy;
+    use rig::forward_system::run::query_processors::{
+        BlockMetadataResponder, DACommitmentSchemeResponder, GenericPreimageResponder,
+        ReadTreeResponder, ZKProofDataResponder,
+    };
+    use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
+    use rig::forward_system::run::{NextTxResponse, TxSource};
+    use rig::oracle_provider::{MemorySource, OracleQueryProcessor, ZkEENonDeterminismSource};
+    use rig::ruint::aliases::B160;
+    use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
+    use rig::zk_ee::oracle::query_ids::{
+        NEXT_TX_SIZE_QUERY_ID, TX_DATA_WORDS_QUERY_ID, TX_ENCODING_FORMAT_QUERY_ID,
+        TX_FROM_QUERY_ID,
+    };
+    use rig::zk_ee::oracle::usize_serialization::dyn_usize_iterator::DynUsizeIterator;
+    use rig::zk_ee::oracle::usize_serialization::UsizeSerializable;
+    use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
+    use rig::zk_ee::utils::usize_rw::ReadIterWrapper;
+    use rig::zksync_os_interface::traits::{EncodedTx, TxListSource};
+    use rig::{common_target_address, TestingFramework};
+    use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+    // ---- Malicious TX encoding format responder ----
+
+    /// Oracle query processor that returns an invalid encoding format value.
+    /// Handles all 4 TX-related query IDs, but overrides TX_ENCODING_FORMAT_QUERY_ID
+    /// to return a malicious (invalid) format byte.
+    struct MaliciousTxFormatResponder {
+        tx_source: TxListSource,
+        next_tx: Option<Vec<u8>>,
+        next_tx_from: Option<B160>,
+        malicious_format_value: usize,
+    }
+
+    impl MaliciousTxFormatResponder {
+        fn new(tx_source: TxListSource, malicious_format_value: usize) -> Self {
+            Self {
+                tx_source,
+                next_tx: None,
+                next_tx_from: None,
+                malicious_format_value,
+            }
+        }
+
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            NEXT_TX_SIZE_QUERY_ID,
+            TX_DATA_WORDS_QUERY_ID,
+            TX_ENCODING_FORMAT_QUERY_ID,
+            TX_FROM_QUERY_ID,
+        ];
+    }
+
+    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousTxFormatResponder {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            _query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            match query_id {
+                NEXT_TX_SIZE_QUERY_ID => {
+                    let len = match &self.next_tx {
+                        Some(next_tx) => next_tx.len(),
+                        None => match self.tx_source.get_next_tx() {
+                            NextTxResponse::SealBlock => 0,
+                            NextTxResponse::Tx(EncodedTx::Abi(next_tx)) => {
+                                let next_tx_len = next_tx.len();
+                                assert_ne!(next_tx_len, 0);
+                                self.next_tx = Some(next_tx);
+                                self.next_tx_from = None;
+                                next_tx_len
+                            }
+                            NextTxResponse::Tx(EncodedTx::Rlp(next_tx, from)) => {
+                                let next_tx_len = next_tx.len();
+                                assert_ne!(next_tx_len, 0);
+                                self.next_tx = Some(next_tx);
+                                self.next_tx_from = Some(B160::from_alloy(from));
+                                next_tx_len
+                            }
+                        },
+                    } as u32;
+                    DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
+                }
+                TX_DATA_WORDS_QUERY_ID => {
+                    let tx = self.next_tx.take().expect(
+                        "trying to read next tx content before size query or after seal response",
+                    );
+                    DynUsizeIterator::from_constructor(tx, |inner_ref| {
+                        ReadIterWrapper::from(inner_ref.iter().copied())
+                    })
+                }
+                TX_ENCODING_FORMAT_QUERY_ID => {
+                    // MALICIOUS: return an invalid encoding format value
+                    Box::new(core::iter::once(self.malicious_format_value))
+                }
+                TX_FROM_QUERY_ID => {
+                    let from = self.next_tx_from.take().expect(
+                        "trying to read next tx from before size query or after seal response",
+                    );
+                    DynUsizeIterator::from_constructor(from, UsizeSerializable::iter)
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Custom oracle factory that injects an invalid TX encoding format value.
+    struct MaliciousTxFormatOracleFactory {
+        malicious_format_value: usize,
+    }
+
+    impl MaliciousTxFormatOracleFactory {
+        fn new(malicious_format_value: usize) -> Self {
+            Self {
+                malicious_format_value,
+            }
+        }
+
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(MaliciousTxFormatResponder::new(
+                tx_source,
+                self.malicious_format_value,
+            ));
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for MaliciousTxFormatOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that the system rejects an invalid TX encoding format (value 255)
+    /// returned by a malicious oracle, via a custom oracle factory.
+    #[test]
+    fn test_malicious_oracle_invalid_tx_encoding_format() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        // Malicious oracle returns 255 as the encoding format
+        let malicious_factory = MaliciousTxFormatOracleFactory::new(255);
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_err(),
+            "Block execution should fail when oracle returns invalid TX encoding format"
+        );
+    }
+
+    /// Verifies that the system rejects TX encoding format value 2
+    /// (just above the valid range of 0-1) from a malicious oracle.
+    #[test]
+    fn test_malicious_oracle_tx_encoding_format_just_above_valid() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        // Malicious oracle returns 2 (just above valid range 0-1)
+        let malicious_factory = MaliciousTxFormatOracleFactory::new(2);
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_err(),
+            "Block execution should fail when oracle returns TX encoding format value 2"
+        );
+    }
+
+    /// Verifies that the system rejects a large TX encoding format value (u64::MAX)
+    /// from a malicious oracle via a custom oracle factory. Tests the u8 overflow path.
+    #[test]
+    fn test_malicious_oracle_tx_encoding_format_overflow() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        // Malicious oracle returns usize::MAX — overflows u8 deserialization
+        let malicious_factory = MaliciousTxFormatOracleFactory::new(usize::MAX);
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_err(),
+            "Block execution should fail when oracle returns TX encoding format overflow value"
+        );
+    }
+}

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -520,7 +520,7 @@ mod custom_oracle_factories {
         );
     }
 
-    /// Verifies that the system rejects a large TX encoding format value (u64::MAX)
+    /// Verifies that the system rejects a large TX encoding format value (usize::MAX)
     /// from a malicious oracle via a custom oracle factory. Tests the u8 overflow path.
     #[test]
     fn test_malicious_oracle_tx_encoding_format_overflow() {
@@ -1395,7 +1395,7 @@ mod custom_oracle_factories {
             rig::alloy::primitives::address!("1000000000000000000000000000000000000001");
 
         // Simple storage contract: SSTORE(0, calldata[0..32])
-        // PUSH1 0x00 CALLDATALOAD PUSH1 0x00 SSTORE STOP
+        // PUSH1 0x00 CALLDATALOAD PUSH1 0x00 SSTORE STOP POP POP
         let store_bytecode = hex::decode("600035600055005050").unwrap();
 
         tester = tester

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -605,7 +605,12 @@ mod custom_oracle_factories {
             let preimage = if hash.is_zero() {
                 vec![]
             } else if self.blocked_hashes.iter().any(|h| *h == hash) {
-                // MALICIOUS: refuse to provide preimage for blocked hashes
+                // MALICIOUS: refuse to provide preimage for blocked hashes.
+                // Note: this panic originates in the test responder, simulating the
+                // GenericPreimageResponder's behavior when a preimage is unknown.
+                // The system's hash-level preimage validation (in expose_preimage)
+                // only runs in PROOF_ENV mode; in forward mode (release), preimage
+                // hashes are checked via debug_assert only.
                 panic!(
                     "must know a preimage for hash {} for query ID 0x{:016x}",
                     hex::encode(hash.as_u8_array_ref()),
@@ -1326,9 +1331,12 @@ mod custom_oracle_factories {
     /// does not crash the system in forward mode. The wrong is_new flag corrupts pubdata
     /// accounting (a concern for proving mode), but forward execution should still complete.
     /// This test documents the forward-mode behavior for this attack vector.
+    ///
+    /// Forward-only: The custom oracle factory only overrides the storage slot responder
+    /// and does not handle tree-index queries needed by the RISC-V proving path.
     #[test]
     fn test_malicious_oracle_false_existing_slot_does_not_crash() {
-        let mut tester = TestingFramework::new();
+        let mut tester = TestingFramework::new().with_run_config(rig::run_config::forward_only());
         let wallet = tester.random_signer();
 
         let contract_address =

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -49,9 +49,12 @@ mod block_metadata {
 
         tester.set_block_context(Some(block_context));
         let result = tester.execute_block_no_panic(vec![tx]);
+        let err = result
+            .expect_err("Block execution should fail when gas limit exceeds MAX_BLOCK_GAS_LIMIT");
+        let err_message = err.to_string();
         assert!(
-            result.is_err(),
-            "Block execution should fail when gas limit exceeds MAX_BLOCK_GAS_LIMIT"
+            err_message.contains("gas limit is too high"),
+            "Expected gas limit error, got: {err_message}"
         );
     }
 
@@ -138,9 +141,11 @@ mod block_metadata {
 
         tester.set_block_context(Some(block_context));
         let result = tester.execute_block_no_panic(vec![]);
+        let err = result.expect_err("Even an empty block should fail with excessive gas limit");
+        let err_message = err.to_string();
         assert!(
-            result.is_err(),
-            "Even an empty block should fail with excessive gas limit"
+            err_message.contains("gas limit is too high"),
+            "Expected gas limit error, got: {err_message}"
         );
     }
 }

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -245,8 +245,7 @@ mod da_commitment_scheme {
 }
 
 /// Integration tests using custom oracle factories to test security-critical
-/// oracle validation paths end-to-end. These cover cases from PR#374 where
-/// the system must properly validate and reject malicious oracle responses.
+/// oracle validation paths end-to-end.
 mod custom_oracle_factories {
     use rig::alloy::consensus::TxEip2930;
     use rig::alloy::primitives::{TxKind, U256};
@@ -279,8 +278,6 @@ mod custom_oracle_factories {
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
     /// Generic oracle factory that delegates oracle construction to a closure.
-    /// Replaces per-test factory structs: each test only provides the closure
-    /// that builds its custom oracle configuration.
     pub(super) struct CustomOracleFactory<F>(pub F)
     where
         F: Fn(
@@ -344,6 +341,43 @@ mod custom_oracle_factories {
                 da_commitment_scheme,
             )
         }
+    }
+
+    /// Builds a standard oracle with common processors (block metadata, proof data,
+    /// DA commitment scheme, field ops), calling `add_custom` to inject the
+    /// test-specific (possibly malicious) processors.
+    pub(super) fn build_oracle(
+        block_metadata: BlockMetadataFromOracle,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_custom: impl FnOnce(&mut ZkEENonDeterminismSource),
+    ) -> ZkEENonDeterminismSource {
+        let mut oracle = ZkEENonDeterminismSource::default();
+        oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+        add_custom(&mut oracle);
+        oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+        oracle.add_external_processor(DACommitmentSchemeResponder {
+            da_commitment_scheme,
+        });
+        oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
+        oracle
+    }
+
+    /// Adds the standard (non-malicious) TX, preimage, and storage processors.
+    pub(super) fn add_standard_processors(
+        oracle: &mut ZkEENonDeterminismSource,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+    ) {
+        oracle.add_external_processor(TxDataResponder {
+            tx_source,
+            next_tx: None,
+            next_tx_format: None,
+            next_tx_from: None,
+        });
+        oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+        oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
     }
 
     // ---- Malicious TX encoding format responder ----
@@ -460,22 +494,14 @@ mod custom_oracle_factories {
                   tx_source,
                   proof_data,
                   da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(MaliciousTxFormatResponder::new(
-                    tx_source,
-                    malicious_format_value,
-                ));
-                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(MaliciousTxFormatResponder::new(
+                        tx_source,
+                        malicious_format_value,
+                    ));
+                    oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                    oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                })
             },
         )
     }
@@ -688,27 +714,19 @@ mod custom_oracle_factories {
                   tx_source,
                   proof_data,
                   da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(TxDataResponder {
-                    tx_source,
-                    next_tx: None,
-                    next_tx_format: None,
-                    next_tx_from: None,
-                });
-                oracle.add_external_processor(MaliciousPreimageResponder::new(
-                    preimage_source,
-                    blocked_hashes.clone(),
-                ));
-                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(TxDataResponder {
+                        tx_source,
+                        next_tx: None,
+                        next_tx_format: None,
+                        next_tx_from: None,
+                    });
+                    oracle.add_external_processor(MaliciousPreimageResponder::new(
+                        preimage_source,
+                        blocked_hashes.clone(),
+                    ));
+                    oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                })
             },
         )
     }
@@ -840,7 +858,6 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that corrupts account properties storage reads.
     /// Helper: builds a CustomOracleFactory with MaliciousAccountStorageResponder.
     fn malicious_account_storage_factory() -> CustomOracleFactory<
         impl Fn(
@@ -859,24 +876,17 @@ mod custom_oracle_factories {
              tx_source,
              proof_data,
              da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(TxDataResponder {
-                    tx_source,
-                    next_tx: None,
-                    next_tx_format: None,
-                    next_tx_from: None,
-                });
-                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-                oracle.add_external_processor(MaliciousAccountStorageResponder::new(state_tree));
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(TxDataResponder {
+                        tx_source,
+                        next_tx: None,
+                        next_tx_format: None,
+                        next_tx_from: None,
+                    });
+                    oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                    oracle
+                        .add_external_processor(MaliciousAccountStorageResponder::new(state_tree));
+                })
             },
         )
     }
@@ -1006,7 +1016,6 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that corrupts transaction data bytes.
     /// Helper: builds a CustomOracleFactory with MaliciousTxDataCorruptResponder.
     fn malicious_tx_data_corrupt_factory() -> CustomOracleFactory<
         impl Fn(
@@ -1025,19 +1034,11 @@ mod custom_oracle_factories {
              tx_source,
              proof_data,
              da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
-                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
+                    oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                    oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                })
             },
         )
     }
@@ -1207,7 +1208,6 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that lies about slot existence.
     /// Helper: builds a CustomOracleFactory with FalseExistingSlotResponder.
     fn false_existing_slot_factory() -> CustomOracleFactory<
         impl Fn(
@@ -1226,24 +1226,16 @@ mod custom_oracle_factories {
              tx_source,
              proof_data,
              da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(TxDataResponder {
-                    tx_source,
-                    next_tx: None,
-                    next_tx_format: None,
-                    next_tx_from: None,
-                });
-                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-                oracle.add_external_processor(FalseExistingSlotResponder::new(state_tree));
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(TxDataResponder {
+                        tx_source,
+                        next_tx: None,
+                        next_tx_format: None,
+                        next_tx_from: None,
+                    });
+                    oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                    oracle.add_external_processor(FalseExistingSlotResponder::new(state_tree));
+                })
             },
         )
     }
@@ -1390,7 +1382,6 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that corrupts preimage data for targeted hashes.
     /// Helper: builds a CustomOracleFactory with CorruptedPreimageResponder.
     fn corrupted_preimage_factory(
         corrupted_hashes: Vec<Bytes32>,
@@ -1411,27 +1402,19 @@ mod custom_oracle_factories {
                   tx_source,
                   proof_data,
                   da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(TxDataResponder {
-                    tx_source,
-                    next_tx: None,
-                    next_tx_format: None,
-                    next_tx_from: None,
-                });
-                oracle.add_external_processor(CorruptedPreimageResponder::new(
-                    preimage_source,
-                    corrupted_hashes.clone(),
-                ));
-                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
-                    da_commitment_scheme,
-                });
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                build_oracle(block_metadata, proof_data, da_commitment_scheme, |oracle| {
+                    oracle.add_external_processor(TxDataResponder {
+                        tx_source,
+                        next_tx: None,
+                        next_tx_format: None,
+                        next_tx_from: None,
+                    });
+                    oracle.add_external_processor(CorruptedPreimageResponder::new(
+                        preimage_source,
+                        corrupted_hashes.clone(),
+                    ));
+                    oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                })
             },
         )
     }
@@ -1512,10 +1495,6 @@ mod callable_oracle_tests {
     use rig::basic_system::system_implementation::flat_storage_model::{
         FlatStorageCommitment, TREE_HEIGHT,
     };
-    use rig::forward_system::run::query_processors::{
-        BlockMetadataResponder, DACommitmentSchemeResponder, GenericPreimageResponder,
-        ReadTreeResponder, TxDataResponder, ZKProofDataResponder,
-    };
     use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
     use rig::oracle_provider::ZkEENonDeterminismSource;
     use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
@@ -1525,8 +1504,7 @@ mod callable_oracle_tests {
     use std::collections::BTreeMap;
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
-    /// Simple BTreeMap-based memory source for testing oracle query processors.
-    /// Replaces the removed VectorMemoryImpl.
+    /// BTreeMap-based memory source for testing oracle query processors.
     #[derive(Default)]
     struct TestMemorySource {
         words: BTreeMap<u32, u32>,
@@ -1600,25 +1578,20 @@ mod callable_oracle_tests {
              tx_source,
              proof_data,
              da_commitment_scheme| {
-                let mut oracle = ZkEENonDeterminismSource::default();
-                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-                oracle.add_external_processor(TxDataResponder {
-                    tx_source,
-                    next_tx: None,
-                    next_tx_format: None,
-                    next_tx_from: None,
-                });
-                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-                oracle.add_external_processor(DACommitmentSchemeResponder {
+                super::custom_oracle_factories::build_oracle(
+                    block_metadata,
+                    proof_data,
                     da_commitment_scheme,
-                });
-                oracle.add_external_processor(MaliciousArithmeticQuery::default());
-                oracle.add_external_processor(
-                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
-                );
-                oracle
+                    |oracle| {
+                        super::custom_oracle_factories::add_standard_processors(
+                            oracle,
+                            state_tree,
+                            preimage_source,
+                            tx_source,
+                        );
+                        oracle.add_external_processor(MaliciousArithmeticQuery::default());
+                    },
+                )
             },
         )
     }

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -1378,4 +1378,237 @@ mod custom_oracle_factories {
             "Forward mode should not crash with false is_new flag — proving mode catches this"
         );
     }
+
+    // ---- Corrupted preimage responder: returns wrong bytes for targeted hashes ----
+
+    /// Oracle query processor that returns corrupted preimage data for targeted hashes.
+    /// Unlike MaliciousPreimageResponder (which blocks/panics), this responder returns
+    /// data that is the correct LENGTH but has wrong content, causing a hash mismatch
+    /// in the preimage validation path.
+    ///
+    /// In forward mode, the hash mismatch is detected via `debug_assert` only (stripped
+    /// in release builds). In proving mode (PROOF_ENV=true), the hard check returns
+    /// `internal_error!("Account hash mismatch")` or `internal_error!("Bytecode hash mismatch")`.
+    struct CorruptedPreimageResponder {
+        preimage_source: InMemoryPreimageSource,
+        /// Hashes for which preimage data will be corrupted (bytes XOR'd with 0xFF)
+        corrupted_hashes: Vec<Bytes32>,
+    }
+
+    impl CorruptedPreimageResponder {
+        fn new(preimage_source: InMemoryPreimageSource, corrupted_hashes: Vec<Bytes32>) -> Self {
+            Self {
+                preimage_source,
+                corrupted_hashes,
+            }
+        }
+    }
+
+    impl CorruptedPreimageResponder {
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            rig::basic_system::system_implementation::flat_storage_model::FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_BYTECODE_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_MPT_PREIMAGE_WORDS_QUERY_ID,
+        ];
+    }
+
+    impl<M: MemorySource> OracleQueryProcessor<M> for CorruptedPreimageResponder {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
+
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            let hash =
+                Bytes32::from_iter(&mut query.into_iter()).expect("must deserialize hash value");
+
+            let is_corrupted = self.corrupted_hashes.iter().any(|h| *h == hash);
+
+            let preimage = if hash.is_zero() {
+                vec![]
+            } else {
+                let mut data = self.preimage_source.get_preimage(hash).unwrap_or_else(|| {
+                    panic!(
+                        "must know a preimage for hash {} for query ID 0x{:016x}",
+                        hex::encode(hash.as_u8_array_ref()),
+                        query_id
+                    )
+                });
+                if is_corrupted && !data.is_empty() {
+                    // Corrupt the data by flipping bits in the first byte.
+                    // The length stays the same, but the content no longer matches the hash.
+                    data[0] ^= 0xFF;
+                }
+                data
+            };
+
+            use rig::basic_system::system_implementation::ethereum_storage_model::{
+                ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID,
+                ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID,
+            };
+            if query_id == ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID
+                || query_id == ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID
+            {
+                // Length queries return the correct length even for corrupted preimages.
+                // The corruption is in the content, not the metadata.
+                let len = preimage.len() as u32;
+                DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
+            } else {
+                DynUsizeIterator::from_constructor(preimage, |inner_ref| {
+                    ReadIterWrapper::from(inner_ref.iter().copied())
+                })
+            }
+        }
+    }
+
+    /// Custom oracle factory that corrupts preimage data for targeted hashes.
+    struct CorruptedPreimageOracleFactory {
+        corrupted_hashes: Vec<Bytes32>,
+    }
+
+    impl CorruptedPreimageOracleFactory {
+        fn new(corrupted_hashes: Vec<Bytes32>) -> Self {
+            Self { corrupted_hashes }
+        }
+
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(
+                rig::forward_system::run::query_processors::TxDataResponder {
+                    tx_source,
+                    next_tx: None,
+                    next_tx_format: None,
+                    next_tx_from: None,
+                },
+            );
+            oracle.add_external_processor(CorruptedPreimageResponder::new(
+                preimage_source,
+                self.corrupted_hashes.clone(),
+            ));
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for CorruptedPreimageOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that corrupted preimage data (hash mismatch) is detected in debug mode.
+    ///
+    /// The `expose_preimage` function validates preimage hashes:
+    /// - In PROOF_ENV (proving mode): hard error on mismatch
+    /// - In forward mode: `debug_assert` only (stripped in release builds)
+    ///
+    /// This test corrupts the bytecode preimage for a deployed contract and verifies
+    /// the debug_assert fires. Only runs in debug builds; in release mode the corruption
+    /// goes undetected in forward mode (proving mode catches it via the hard check).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic]
+    fn test_corrupted_bytecode_preimage_detected_in_debug() {
+        let mut tester = TestingFramework::new().with_run_config(rig::run_config::forward_only());
+        let wallet = tester.random_signer();
+
+        let contract_address =
+            rig::alloy::primitives::address!("1000000000000000000000000000000000000001");
+
+        // Simple contract: PUSH1 0x00 PUSH1 0x00 RETURN (returns empty)
+        let simple_bytecode = hex::decode("60006000f3").unwrap();
+
+        tester = tester
+            .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+            .with_evm_contract(contract_address, &simple_bytecode);
+
+        // Get the bytecode hash to target for corruption
+        let account_props = tester.get_account_properties(&contract_address);
+        let bytecode_hash = account_props.bytecode_hash;
+
+        let corrupted_factory = CorruptedPreimageOracleFactory::new(vec![bytecode_hash]);
+        tester = tester.with_custom_oracle_factory(corrupted_factory);
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 100_000,
+                to: TxKind::Call(contract_address),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        // In debug mode, the debug_assert in expose_preimage should catch the
+        // hash mismatch and panic. In release mode, this would silently pass.
+        let _result = tester.execute_block(vec![tx]);
+    }
 }

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -260,8 +260,8 @@ mod custom_oracle_factories {
         ReadTreeResponder, ZKProofDataResponder,
     };
     use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
-    use rig::forward_system::run::{NextTxResponse, PreimageSource, TxSource};
-    use rig::oracle_provider::{MemorySource, OracleQueryProcessor, ZkEENonDeterminismSource};
+    use rig::forward_system::run::{NextTxResponse, PreimageSource};
+    use rig::oracle_provider::{OracleQueryProcessor, RamPeek, ZkEENonDeterminismSource};
     use rig::ruint::aliases::B160;
     use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
     use rig::zk_ee::oracle::query_ids::{
@@ -274,7 +274,7 @@ mod custom_oracle_factories {
     use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
     use rig::zk_ee::utils::usize_rw::ReadIterWrapper;
     use rig::zk_ee::utils::Bytes32;
-    use rig::zksync_os_interface::traits::{EncodedTx, TxListSource};
+    use rig::zksync_os_interface::traits::{EncodedTx, TxListSource, TxSource};
     use rig::{common_target_address, TestingFramework};
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
@@ -308,7 +308,7 @@ mod custom_oracle_factories {
         ];
     }
 
-    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousTxFormatResponder {
+    impl OracleQueryProcessor for MaliciousTxFormatResponder {
         fn supported_query_ids(&self) -> Vec<u32> {
             Self::SUPPORTED_QUERY_IDS.to_vec()
         }
@@ -321,7 +321,7 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             _query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
 
@@ -353,7 +353,7 @@ mod custom_oracle_factories {
                     let tx = self.next_tx.take().expect(
                         "trying to read next tx content before size query or after seal response",
                     );
-                    DynUsizeIterator::from_constructor(tx, |inner_ref| {
+                    DynUsizeIterator::from_constructor(tx, |inner_ref: &Vec<u8>| {
                         ReadIterWrapper::from(inner_ref.iter().copied())
                     })
                 }
@@ -384,7 +384,7 @@ mod custom_oracle_factories {
             }
         }
 
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -392,7 +392,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(MaliciousTxFormatResponder::new(
@@ -405,6 +405,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -419,7 +420,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -439,8 +441,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -580,7 +582,7 @@ mod custom_oracle_factories {
         ];
     }
 
-    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousPreimageResponder {
+    impl OracleQueryProcessor for MaliciousPreimageResponder {
         fn supported_query_ids(&self) -> Vec<u32> {
             Self::SUPPORTED_QUERY_IDS.to_vec()
         }
@@ -593,7 +595,7 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
 
@@ -636,7 +638,7 @@ mod custom_oracle_factories {
                 let len = preimage.len() as u32;
                 DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
             } else {
-                DynUsizeIterator::from_constructor(preimage, |inner_ref| {
+                DynUsizeIterator::from_constructor(preimage, |inner_ref: &Vec<u8>| {
                     ReadIterWrapper::from(inner_ref.iter().copied())
                 })
             }
@@ -653,7 +655,7 @@ mod custom_oracle_factories {
             Self { blocked_hashes }
         }
 
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -661,7 +663,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(
@@ -681,6 +683,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -695,7 +698,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -715,8 +719,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -797,7 +801,7 @@ mod custom_oracle_factories {
         ];
     }
 
-    impl<S: rig::forward_system::run::ReadStorage, M: MemorySource> OracleQueryProcessor<M>
+    impl<S: rig::forward_system::run::ReadStorage> OracleQueryProcessor
         for MaliciousAccountStorageResponder<S>
     {
         fn supported_query_ids(&self) -> Vec<u32> {
@@ -812,7 +816,7 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             use rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery;
             use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
@@ -860,7 +864,7 @@ mod custom_oracle_factories {
     struct MaliciousAccountStorageOracleFactory;
 
     impl MaliciousAccountStorageOracleFactory {
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -868,7 +872,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(
@@ -885,6 +889,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -899,7 +904,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -919,8 +925,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -992,7 +998,7 @@ mod custom_oracle_factories {
         ];
     }
 
-    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousTxDataCorruptResponder {
+    impl OracleQueryProcessor for MaliciousTxDataCorruptResponder {
         fn supported_query_ids(&self) -> Vec<u32> {
             Self::SUPPORTED_QUERY_IDS.to_vec()
         }
@@ -1005,7 +1011,7 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             _query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
 
@@ -1039,7 +1045,7 @@ mod custom_oracle_factories {
                     let tx = self.next_tx.take().expect(
                         "trying to read next tx content before size query or after seal response",
                     );
-                    DynUsizeIterator::from_constructor(tx, |inner_ref| {
+                    DynUsizeIterator::from_constructor(tx, |inner_ref: &Vec<u8>| {
                         ReadIterWrapper::from(inner_ref.iter().copied())
                     })
                 }
@@ -1062,7 +1068,7 @@ mod custom_oracle_factories {
     struct MaliciousTxDataCorruptOracleFactory;
 
     impl MaliciousTxDataCorruptOracleFactory {
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -1070,7 +1076,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
@@ -1080,6 +1086,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -1094,7 +1101,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1114,8 +1122,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1182,11 +1190,11 @@ mod custom_oracle_factories {
     /// even when they are actually new. This tests whether the system handles incorrect
     /// is_new_storage_slot flags — in forward mode this may silently corrupt pubdata
     /// accounting, but should not crash.
-    struct FalseExistingSlotResponder<S: rig::forward_system::run::ReadStorage> {
+    struct FalseExistingSlotResponder<S: rig::forward_system::run::ReadStorageTree> {
         storage: S,
     }
 
-    impl<S: rig::forward_system::run::ReadStorage> FalseExistingSlotResponder<S> {
+    impl<S: rig::forward_system::run::ReadStorageTree> FalseExistingSlotResponder<S> {
         fn new(storage: S) -> Self {
             Self { storage }
         }
@@ -1195,10 +1203,13 @@ mod custom_oracle_factories {
             rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery::<
                 rig::zk_ee::types_config::EthereumIOTypesConfig,
             >::QUERY_ID,
+            rig::basic_system::system_implementation::flat_storage_model::PreviousIndexQuery::QUERY_ID,
+            rig::basic_system::system_implementation::flat_storage_model::ExactIndexQuery::QUERY_ID,
+            rig::basic_system::system_implementation::flat_storage_model::PROOF_FOR_INDEX_QUERY_ID,
         ];
     }
 
-    impl<S: rig::forward_system::run::ReadStorage, M: MemorySource> OracleQueryProcessor<M>
+    impl<S: rig::forward_system::run::ReadStorageTree> OracleQueryProcessor
         for FalseExistingSlotResponder<S>
     {
         fn supported_query_ids(&self) -> Vec<u32> {
@@ -1213,8 +1224,11 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            use rig::basic_system::system_implementation::flat_storage_model::{
+                ExactIndexQuery, PreviousIndexQuery, PROOF_FOR_INDEX_QUERY_ID,
+            };
             use rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery;
             use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
             use rig::zk_ee::storage_types::{InitialStorageSlotData, StorageAddress};
@@ -1222,32 +1236,68 @@ mod custom_oracle_factories {
 
             assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
 
-            let StorageAddress { address, key } =
-                <InitialStorageSlotQuery<EthereumIOTypesConfig> as SimpleOracleQuery>::Input::from_iter(
-                    &mut query.into_iter(),
-                )
-                .expect("must deserialize the address/slot");
+            match query_id {
+                _ if query_id == InitialStorageSlotQuery::<EthereumIOTypesConfig>::QUERY_ID => {
+                    let StorageAddress { address, key } = <InitialStorageSlotQuery<
+                        EthereumIOTypesConfig,
+                    > as SimpleOracleQuery>::Input::from_iter(
+                        &mut query.into_iter()
+                    )
+                    .expect("must deserialize the address/slot");
 
-            let flat_key = rig::zk_ee::common_structs::derive_flat_storage_key(&address, &key);
+                    let flat_key =
+                        rig::zk_ee::common_structs::derive_flat_storage_key(&address, &key);
 
-            let slot_data: InitialStorageSlotData<EthereumIOTypesConfig> =
-                if let Some(cold) = self.storage.read(flat_key) {
-                    InitialStorageSlotData {
-                        initial_value: cold,
-                        is_new_storage_slot: false,
-                    }
-                } else {
-                    // MALICIOUS: claim this new slot already exists with zero value.
-                    // This bypasses the "Initial value of empty slot must be trivial"
-                    // check (which only fires when is_new=true) and may corrupt
-                    // pubdata accounting.
-                    InitialStorageSlotData {
-                        initial_value: Bytes32::from_array([0; 32]),
-                        is_new_storage_slot: false, // Lie about slot existence
-                    }
-                };
+                    let slot_data: InitialStorageSlotData<EthereumIOTypesConfig> =
+                        if let Some(cold) = self.storage.read(flat_key) {
+                            InitialStorageSlotData {
+                                initial_value: cold,
+                                is_new_storage_slot: false,
+                            }
+                        } else {
+                            // MALICIOUS: claim this new slot already exists with zero value.
+                            InitialStorageSlotData {
+                                initial_value: Bytes32::from_array([0; 32]),
+                                is_new_storage_slot: false, // Lie about slot existence
+                            }
+                        };
 
-            DynUsizeIterator::from_constructor(slot_data, UsizeSerializable::iter)
+                    DynUsizeIterator::from_constructor(slot_data, UsizeSerializable::iter)
+                }
+                _ if query_id == PreviousIndexQuery::QUERY_ID => {
+                    let key = <PreviousIndexQuery as SimpleOracleQuery>::Input::from_iter(
+                        &mut query.into_iter(),
+                    )
+                    .expect("must deserialize key");
+                    let prev_index = self.storage.prev_tree_index(key);
+                    DynUsizeIterator::from_constructor(prev_index, UsizeSerializable::iter)
+                }
+                _ if query_id == ExactIndexQuery::QUERY_ID => {
+                    let key = <ExactIndexQuery as SimpleOracleQuery>::Input::from_iter(
+                        &mut query.into_iter(),
+                    )
+                    .expect("must deserialize key");
+                    let index = self
+                        .storage
+                        .tree_index(key)
+                        .expect("Reading index for key that is not in the tree");
+                    DynUsizeIterator::from_constructor(index, UsizeSerializable::iter)
+                }
+                _ if query_id == PROOF_FOR_INDEX_QUERY_ID => {
+                    use rig::basic_system::system_implementation::flat_storage_model::{
+                        ExistingReadProof, ValueAtIndexProof,
+                    };
+                    let index =
+                        u64::from_iter(&mut query.into_iter()).expect("must deserialize index");
+                    let proof = ValueAtIndexProof {
+                        proof: ExistingReadProof {
+                            existing: self.storage.merkle_proof(index),
+                        },
+                    };
+                    DynUsizeIterator::from_constructor(proof, UsizeSerializable::iter)
+                }
+                _ => unreachable!(),
+            }
         }
     }
 
@@ -1255,7 +1305,7 @@ mod custom_oracle_factories {
     struct FalseExistingSlotOracleFactory;
 
     impl FalseExistingSlotOracleFactory {
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -1263,7 +1313,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(
@@ -1280,6 +1330,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -1294,7 +1345,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1314,8 +1366,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1327,15 +1379,15 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Verifies that a malicious oracle claiming all new slots are existing (is_new=false)
-    /// does not crash the system in forward mode. The wrong is_new flag corrupts pubdata
-    /// accounting (a concern for proving mode), but forward execution should still complete.
-    /// This test documents the forward-mode behavior for this attack vector.
+    /// Verifies that a malicious oracle claiming new slots are existing (is_new=false)
+    /// is caught by the tree index lookup. In draft-0.4.0, the flat storage model
+    /// validates the is_new claim by looking up the tree index — if the key is not in
+    /// the tree but was reported as existing, the lookup panics.
     ///
-    /// Forward-only: The custom oracle factory only overrides the storage slot responder
-    /// and does not handle tree-index queries needed by the RISC-V proving path.
+    /// Forward-only: Uses the custom oracle factory with full tree-index support.
     #[test]
-    fn test_malicious_oracle_false_existing_slot_does_not_crash() {
+    #[should_panic(expected = "expected existing leaf for key")]
+    fn test_malicious_oracle_false_existing_slot_detected() {
         let mut tester = TestingFramework::new().with_run_config(rig::run_config::forward_only());
         let wallet = tester.random_signer();
 
@@ -1369,14 +1421,9 @@ mod custom_oracle_factories {
             ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
         };
 
-        // In forward mode, the false is_new flag should not cause a crash.
-        // The system trusts the oracle response and proceeds (pubdata accounting
-        // would be wrong, but this is caught in proving mode by Merkle proofs).
-        let result = tester.execute_block_no_panic(vec![tx]);
-        assert!(
-            result.is_ok(),
-            "Forward mode should not crash with false is_new flag — proving mode catches this"
-        );
+        // The false is_new flag is caught by the tree index lookup — the tree doesn't
+        // have the key, so the lookup panics with "expected existing leaf for key".
+        let _result = tester.execute_block(vec![tx]);
     }
 
     // ---- Corrupted preimage responder: returns wrong bytes for targeted hashes ----
@@ -1414,7 +1461,7 @@ mod custom_oracle_factories {
         ];
     }
 
-    impl<M: MemorySource> OracleQueryProcessor<M> for CorruptedPreimageResponder {
+    impl OracleQueryProcessor for CorruptedPreimageResponder {
         fn supported_query_ids(&self) -> Vec<u32> {
             Self::SUPPORTED_QUERY_IDS.to_vec()
         }
@@ -1427,7 +1474,7 @@ mod custom_oracle_factories {
             &mut self,
             query_id: u32,
             query: Vec<usize>,
-            _memory: &M,
+            _memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
 
@@ -1468,7 +1515,7 @@ mod custom_oracle_factories {
                 let len = preimage.len() as u32;
                 DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
             } else {
-                DynUsizeIterator::from_constructor(preimage, |inner_ref| {
+                DynUsizeIterator::from_constructor(preimage, |inner_ref: &Vec<u8>| {
                     ReadIterWrapper::from(inner_ref.iter().copied())
                 })
             }
@@ -1485,7 +1532,7 @@ mod custom_oracle_factories {
             Self { corrupted_hashes }
         }
 
-        fn build_oracle<M: MemorySource + 'static>(
+        fn build_oracle(
             &self,
             block_metadata: BlockMetadataFromOracle,
             state_tree: InMemoryTree<false>,
@@ -1493,7 +1540,7 @@ mod custom_oracle_factories {
             tx_source: TxListSource,
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource<M> {
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(
@@ -1513,6 +1560,7 @@ mod custom_oracle_factories {
             oracle.add_external_processor(DACommitmentSchemeResponder {
                 da_commitment_scheme,
             });
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -1527,7 +1575,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1547,8 +1596,8 @@ mod custom_oracle_factories {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             self.build_oracle(
                 block_metadata,
                 state_tree,
@@ -1622,15 +1671,14 @@ mod callable_oracle_tests {
     //! operations directly without querying callable oracles.
     //!
     //! These tests validate the callable oracle processors themselves using
-    //! VectorMemoryImpl, which allows testing the full oracle query path (memory read,
-    //! computation, response serialization) without RISC-V simulation. A malicious
-    //! oracle factory integration test is included to demonstrate the custom factory
-    //! pattern for callable oracle testing.
+    //! a TestMemorySource (BTreeMap-based RamPeek impl), which allows testing
+    //! the full oracle query path (memory read, computation, response serialization)
+    //! without RISC-V simulation. A malicious oracle factory integration test is
+    //! included to demonstrate the custom factory pattern for callable oracle testing.
 
     use rig::callable_oracles::arithmetic::ArithmeticQuery;
     use rig::callable_oracles::blob_kzg_commitment::blob_kzg_commitment_and_proof;
-    use rig::oracle_provider::OracleQueryProcessor;
-    use rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl;
+    use rig::oracle_provider::{OracleQueryProcessor, RamPeek};
 
     use rig::alloy::consensus::TxEip2930;
     use rig::alloy::primitives::{TxKind, U256};
@@ -1644,29 +1692,43 @@ mod callable_oracle_tests {
         ReadTreeResponder, TxDataResponder, ZKProofDataResponder,
     };
     use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
-    use rig::oracle_provider::{MemorySource, ZkEENonDeterminismSource};
+    use rig::oracle_provider::ZkEENonDeterminismSource;
     use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
     use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
     use rig::zksync_os_interface::traits::TxListSource;
     use rig::{common_target_address, TestingFramework};
+    use std::collections::BTreeMap;
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+    /// Simple BTreeMap-based memory source for testing oracle query processors.
+    /// Replaces the removed VectorMemoryImpl.
+    #[derive(Default)]
+    struct TestMemorySource {
+        words: BTreeMap<u32, u32>,
+    }
+
+    impl TestMemorySource {
+        fn populate(&mut self, address: u32, value: u32) {
+            assert!(address.is_multiple_of(4));
+            self.words.insert(address, value);
+        }
+    }
+
+    impl RamPeek for TestMemorySource {
+        fn peek_word(&self, address: u32) -> u32 {
+            self.words.get(&address).copied().unwrap_or(0)
+        }
+    }
 
     /// A malicious arithmetic oracle that returns deliberately wrong division results.
     /// When queried for modexp advice, it corrupts the quotient by adding 1 to each word,
     /// which will cause the verification step (q * modulus + r == dividend) to fail.
-    struct MaliciousArithmeticQuery<M: MemorySource> {
-        inner: ArithmeticQuery<M>,
+    #[derive(Default)]
+    struct MaliciousArithmeticQuery {
+        inner: ArithmeticQuery,
     }
 
-    impl<M: MemorySource> Default for MaliciousArithmeticQuery<M> {
-        fn default() -> Self {
-            Self {
-                inner: ArithmeticQuery::default(),
-            }
-        }
-    }
-
-    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousArithmeticQuery<M> {
+    impl OracleQueryProcessor for MaliciousArithmeticQuery {
         fn supported_query_ids(&self) -> Vec<u32> {
             self.inner.supported_query_ids()
         }
@@ -1675,7 +1737,7 @@ mod callable_oracle_tests {
             &mut self,
             query_id: u32,
             query: Vec<usize>,
-            memory: &M,
+            memory: &dyn RamPeek,
         ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
             // Get the correct result first
             let correct: Vec<usize> = self
@@ -1709,7 +1771,8 @@ mod callable_oracle_tests {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(TxDataResponder {
@@ -1725,9 +1788,8 @@ mod callable_oracle_tests {
                 da_commitment_scheme,
             });
             // Register malicious arithmetic oracle — not queried in forward mode
-            oracle.add_external_processor(MaliciousArithmeticQuery::<
-                rig::oracle_provider::DummyMemorySource,
-            >::default());
+            oracle.add_external_processor(MaliciousArithmeticQuery::default());
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
 
@@ -1740,8 +1802,8 @@ mod callable_oracle_tests {
             proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
             da_commitment_scheme: Option<DACommitmentScheme>,
             _add_uart: bool,
-        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
-        {
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
             let mut oracle = ZkEENonDeterminismSource::default();
             oracle.add_external_processor(BlockMetadataResponder { block_metadata });
             oracle.add_external_processor(TxDataResponder {
@@ -1757,9 +1819,8 @@ mod callable_oracle_tests {
                 da_commitment_scheme,
             });
             // Register malicious arithmetic oracle — WILL be queried in RISC-V mode
-            oracle.add_external_processor(MaliciousArithmeticQuery::<
-                rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl,
-            >::default());
+            oracle.add_external_processor(MaliciousArithmeticQuery::default());
+            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
             oracle
         }
     }
@@ -1772,9 +1833,8 @@ mod callable_oracle_tests {
         let params_addr: u32 = 0x100;
         let a_addr: u32 = 0x200;
         let m_addr: u32 = 0x400;
-        let mem_bytes = 0x800;
 
-        let mut memory = VectorMemoryImpl::new_for_byte_size(mem_bytes);
+        let mut memory = TestMemorySource::default();
 
         // ModExpAdviceParams: 10 / 3
         memory.populate(params_addr, 0); // op
@@ -1791,13 +1851,13 @@ mod callable_oracle_tests {
         memory.populate(m_addr, 3);
 
         // Get correct result
-        let mut correct_oracle = ArithmeticQuery::<VectorMemoryImpl>::default();
+        let mut correct_oracle = ArithmeticQuery::default();
         let correct: Vec<usize> = correct_oracle
             .process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![params_addr as usize], &memory)
             .collect();
 
         // Get malicious result
-        let mut malicious_oracle = MaliciousArithmeticQuery::<VectorMemoryImpl>::default();
+        let mut malicious_oracle = MaliciousArithmeticQuery::default();
         let malicious: Vec<usize> = malicious_oracle
             .process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![params_addr as usize], &memory)
             .collect();

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -1492,6 +1492,7 @@ mod callable_oracle_tests {
 
     use rig::callable_oracles::arithmetic::ArithmeticQuery;
     use rig::callable_oracles::blob_kzg_commitment::blob_kzg_commitment_and_proof;
+    use rig::callable_oracles::test_utils::TestMemorySource;
     use rig::oracle_provider::{OracleQueryProcessor, RamPeek};
 
     use rig::alloy::consensus::TxEip2930;
@@ -1506,27 +1507,7 @@ mod callable_oracle_tests {
     use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
     use rig::zksync_os_interface::traits::TxListSource;
     use rig::{common_target_address, TestingFramework};
-    use std::collections::BTreeMap;
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
-
-    /// BTreeMap-based memory source for testing oracle query processors.
-    #[derive(Default)]
-    struct TestMemorySource {
-        words: BTreeMap<u32, u32>,
-    }
-
-    impl TestMemorySource {
-        fn populate(&mut self, address: u32, value: u32) {
-            assert!(address.is_multiple_of(4));
-            self.words.insert(address, value);
-        }
-    }
-
-    impl RamPeek for TestMemorySource {
-        fn peek_word(&self, address: u32) -> u32 {
-            self.words.get(&address).copied().unwrap_or(0)
-        }
-    }
 
     /// A malicious arithmetic oracle that returns deliberately wrong division results.
     /// When queried for modexp advice, it corrupts the quotient by adding 1 to each word,
@@ -1613,18 +1594,18 @@ mod callable_oracle_tests {
         let mut memory = TestMemorySource::default();
 
         // ModExpAdviceParams: 10 / 3
-        memory.populate(params_addr, 0); // op
-        memory.populate(params_addr + 4, a_addr); // a_ptr
-        memory.populate(params_addr + 8, 1); // a_len (1 digit)
-        memory.populate(params_addr + 12, 0); // b_ptr
-        memory.populate(params_addr + 16, 0); // b_len
-        memory.populate(params_addr + 20, m_addr); // modulus_ptr
-        memory.populate(params_addr + 24, 1); // modulus_len
+        memory.insert_u32(params_addr, 0); // op
+        memory.insert_u32(params_addr + 4, a_addr); // a_ptr
+        memory.insert_u32(params_addr + 8, 1); // a_len (1 digit)
+        memory.insert_u32(params_addr + 12, 0); // b_ptr
+        memory.insert_u32(params_addr + 16, 0); // b_len
+        memory.insert_u32(params_addr + 20, m_addr); // modulus_ptr
+        memory.insert_u32(params_addr + 24, 1); // modulus_len
 
         // dividend = 10
-        memory.populate(a_addr, 10);
+        memory.insert_u32(a_addr, 10);
         // modulus = 3
-        memory.populate(m_addr, 3);
+        memory.insert_u32(m_addr, 3);
 
         // Get correct result
         let mut correct_oracle = ArithmeticQuery::default();

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -260,7 +260,7 @@ mod custom_oracle_factories {
         ReadTreeResponder, ZKProofDataResponder,
     };
     use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
-    use rig::forward_system::run::{NextTxResponse, TxSource};
+    use rig::forward_system::run::{NextTxResponse, PreimageSource, TxSource};
     use rig::oracle_provider::{MemorySource, OracleQueryProcessor, ZkEENonDeterminismSource};
     use rig::ruint::aliases::B160;
     use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
@@ -268,10 +268,12 @@ mod custom_oracle_factories {
         NEXT_TX_SIZE_QUERY_ID, TX_DATA_WORDS_QUERY_ID, TX_ENCODING_FORMAT_QUERY_ID,
         TX_FROM_QUERY_ID,
     };
+    use rig::zk_ee::oracle::simple_oracle_query::SimpleOracleQuery;
     use rig::zk_ee::oracle::usize_serialization::dyn_usize_iterator::DynUsizeIterator;
     use rig::zk_ee::oracle::usize_serialization::UsizeSerializable;
     use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
     use rig::zk_ee::utils::usize_rw::ReadIterWrapper;
+    use rig::zk_ee::utils::Bytes32;
     use rig::zksync_os_interface::traits::{EncodedTx, TxListSource};
     use rig::{common_target_address, TestingFramework};
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
@@ -546,6 +548,826 @@ mod custom_oracle_factories {
         assert!(
             result.is_err(),
             "Block execution should fail when oracle returns TX encoding format overflow value"
+        );
+    }
+
+    // ---- Malicious preimage responder ----
+
+    /// Oracle query processor that drops preimages for target hashes,
+    /// simulating a malicious oracle that refuses to provide required data.
+    struct MaliciousPreimageResponder {
+        preimage_source: InMemoryPreimageSource,
+        /// Hashes for which preimage lookups will return None (simulating missing data)
+        blocked_hashes: Vec<Bytes32>,
+    }
+
+    impl MaliciousPreimageResponder {
+        fn new(preimage_source: InMemoryPreimageSource, blocked_hashes: Vec<Bytes32>) -> Self {
+            Self {
+                preimage_source,
+                blocked_hashes,
+            }
+        }
+    }
+
+    impl MaliciousPreimageResponder {
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            rig::basic_system::system_implementation::flat_storage_model::FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_BYTECODE_PREIMAGE_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID,
+            rig::basic_system::system_implementation::ethereum_storage_model::ETHEREUM_MPT_PREIMAGE_WORDS_QUERY_ID,
+        ];
+    }
+
+    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousPreimageResponder {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
+
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            let hash =
+                Bytes32::from_iter(&mut query.into_iter()).expect("must deserialize hash value");
+
+            let preimage = if hash.is_zero() {
+                vec![]
+            } else if self.blocked_hashes.iter().any(|h| *h == hash) {
+                // MALICIOUS: refuse to provide preimage for blocked hashes
+                panic!(
+                    "must know a preimage for hash {} for query ID 0x{:016x}",
+                    hex::encode(hash.as_u8_array_ref()),
+                    query_id
+                );
+            } else {
+                self.preimage_source.get_preimage(hash).unwrap_or_else(|| {
+                    panic!(
+                        "must know a preimage for hash {} for query ID 0x{:016x}",
+                        hex::encode(hash.as_u8_array_ref()),
+                        query_id
+                    )
+                })
+            };
+
+            use rig::basic_system::system_implementation::ethereum_storage_model::{
+                ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID,
+                ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID,
+            };
+            if query_id == ETHEREUM_BYTECODE_LENGTH_FROM_PREIMAGE_QUERY_ID
+                || query_id == ETHEREUM_MPT_PREIMAGE_BYTE_LEN_QUERY_ID
+            {
+                let len = preimage.len() as u32;
+                DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
+            } else {
+                DynUsizeIterator::from_constructor(preimage, |inner_ref| {
+                    ReadIterWrapper::from(inner_ref.iter().copied())
+                })
+            }
+        }
+    }
+
+    /// Custom oracle factory that blocks preimage lookups for specific hashes.
+    struct MaliciousPreimageOracleFactory {
+        blocked_hashes: Vec<Bytes32>,
+    }
+
+    impl MaliciousPreimageOracleFactory {
+        fn new(blocked_hashes: Vec<Bytes32>) -> Self {
+            Self { blocked_hashes }
+        }
+
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(
+                rig::forward_system::run::query_processors::TxDataResponder {
+                    tx_source,
+                    next_tx: None,
+                    next_tx_format: None,
+                    next_tx_from: None,
+                },
+            );
+            oracle.add_external_processor(MaliciousPreimageResponder::new(
+                preimage_source,
+                self.blocked_hashes.clone(),
+            ));
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for MaliciousPreimageOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that the system panics when a malicious oracle refuses to provide
+    /// the bytecode preimage for a deployed contract. This simulates an attack where
+    /// the oracle withholds required data during contract execution.
+    #[test]
+    #[should_panic(expected = "must know a preimage")]
+    fn test_malicious_oracle_missing_bytecode_preimage() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+
+        let contract_address =
+            rig::alloy::primitives::address!("1000000000000000000000000000000000000001");
+
+        // Simple contract: PUSH1 0x00 PUSH1 0x00 RETURN (returns empty)
+        let simple_bytecode = hex::decode("60006000f3").unwrap();
+
+        // Deploy the contract normally first to register its account properties
+        tester = tester
+            .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+            .with_evm_contract(contract_address, &simple_bytecode);
+
+        // Get the bytecode hash from the deployed account to block it
+        let account_props = tester.get_account_properties(&contract_address);
+        let bytecode_hash = account_props.bytecode_hash;
+
+        // Now set up the malicious factory that blocks this bytecode's preimage
+        let malicious_factory = MaliciousPreimageOracleFactory::new(vec![bytecode_hash]);
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        // Call the deployed contract — the system will try to decommit its bytecode
+        // and the malicious oracle will refuse to provide the preimage
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 100_000,
+                to: TxKind::Call(contract_address),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let _result = tester.execute_block(vec![tx]);
+    }
+
+    // ---- Malicious account properties responder ----
+
+    /// Oracle query processor that returns corrupted account properties hashes.
+    /// For queries targeting ACCOUNT_PROPERTIES_STORAGE_ADDRESS, returns a non-zero
+    /// hash that doesn't correspond to any real preimage, simulating an oracle that
+    /// provides fake account data.
+    struct MaliciousAccountStorageResponder<S: rig::forward_system::run::ReadStorage> {
+        storage: S,
+    }
+
+    impl<S: rig::forward_system::run::ReadStorage> MaliciousAccountStorageResponder<S> {
+        fn new(storage: S) -> Self {
+            Self { storage }
+        }
+
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery::<
+                rig::zk_ee::types_config::EthereumIOTypesConfig,
+            >::QUERY_ID,
+        ];
+    }
+
+    impl<S: rig::forward_system::run::ReadStorage, M: MemorySource> OracleQueryProcessor<M>
+        for MaliciousAccountStorageResponder<S>
+    {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            use rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery;
+            use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
+            use rig::zk_ee::storage_types::{InitialStorageSlotData, StorageAddress};
+            use rig::zk_ee::types_config::EthereumIOTypesConfig;
+
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            let StorageAddress { address, key } =
+                <InitialStorageSlotQuery<EthereumIOTypesConfig> as SimpleOracleQuery>::Input::from_iter(
+                    &mut query.into_iter(),
+                )
+                .expect("must deserialize the address/slot");
+
+            use rig::basic_system::system_implementation::flat_storage_model::storage_cache::ACCOUNT_PROPERTIES_STORAGE_ADDRESS;
+
+            let flat_key = rig::zk_ee::common_structs::derive_flat_storage_key(&address, &key);
+
+            let slot_data: InitialStorageSlotData<EthereumIOTypesConfig> =
+                if address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS {
+                    // MALICIOUS: return a fake non-zero hash for account properties.
+                    // This hash won't correspond to any preimage in the preimage source,
+                    // so the system should fail when trying to decommit account data.
+                    InitialStorageSlotData {
+                        initial_value: Bytes32::from_array([0xDE; 32]),
+                        is_new_storage_slot: false,
+                    }
+                } else if let Some(cold) = self.storage.read(flat_key) {
+                    InitialStorageSlotData {
+                        initial_value: cold,
+                        is_new_storage_slot: false,
+                    }
+                } else {
+                    InitialStorageSlotData {
+                        initial_value: Bytes32::from_array([0; 32]),
+                        is_new_storage_slot: true,
+                    }
+                };
+
+            DynUsizeIterator::from_constructor(slot_data, UsizeSerializable::iter)
+        }
+    }
+
+    /// Custom oracle factory that corrupts account properties storage reads.
+    struct MaliciousAccountStorageOracleFactory;
+
+    impl MaliciousAccountStorageOracleFactory {
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(
+                rig::forward_system::run::query_processors::TxDataResponder {
+                    tx_source,
+                    next_tx: None,
+                    next_tx_format: None,
+                    next_tx_from: None,
+                },
+            );
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(MaliciousAccountStorageResponder::new(state_tree));
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for MaliciousAccountStorageOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that the system panics when a malicious oracle provides a fake hash
+    /// for account properties. The fake hash doesn't correspond to any real preimage,
+    /// so the system should fail when trying to decommit account data.
+    #[test]
+    #[should_panic(expected = "must know a preimage")]
+    fn test_malicious_oracle_corrupted_account_properties() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        // The malicious factory will return fake hashes for ALL account property reads,
+        // including the sender's balance lookup during transaction validation.
+        let malicious_factory = MaliciousAccountStorageOracleFactory;
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let _result = tester.execute_block(vec![tx]);
+    }
+
+    // ---- Malicious TX data corruption responder ----
+
+    /// Oracle query processor that corrupts the transaction data bytes.
+    /// Returns valid transaction size and format, but replaces the actual TX bytes
+    /// with garbage data.
+    struct MaliciousTxDataCorruptResponder {
+        tx_source: TxListSource,
+        next_tx: Option<Vec<u8>>,
+        next_tx_from: Option<B160>,
+    }
+
+    impl MaliciousTxDataCorruptResponder {
+        fn new(tx_source: TxListSource) -> Self {
+            Self {
+                tx_source,
+                next_tx: None,
+                next_tx_from: None,
+            }
+        }
+
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            NEXT_TX_SIZE_QUERY_ID,
+            TX_DATA_WORDS_QUERY_ID,
+            TX_ENCODING_FORMAT_QUERY_ID,
+            TX_FROM_QUERY_ID,
+        ];
+    }
+
+    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousTxDataCorruptResponder {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            _query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            match query_id {
+                NEXT_TX_SIZE_QUERY_ID => {
+                    let len = match &self.next_tx {
+                        Some(next_tx) => next_tx.len(),
+                        None => match self.tx_source.get_next_tx() {
+                            NextTxResponse::SealBlock => 0,
+                            NextTxResponse::Tx(EncodedTx::Abi(next_tx)) => {
+                                let next_tx_len = next_tx.len();
+                                assert_ne!(next_tx_len, 0);
+                                // MALICIOUS: replace valid tx bytes with garbage
+                                self.next_tx = Some(vec![0xFF; next_tx_len]);
+                                self.next_tx_from = None;
+                                next_tx_len
+                            }
+                            NextTxResponse::Tx(EncodedTx::Rlp(next_tx, from)) => {
+                                let next_tx_len = next_tx.len();
+                                assert_ne!(next_tx_len, 0);
+                                // MALICIOUS: replace valid tx bytes with garbage
+                                self.next_tx = Some(vec![0xFF; next_tx_len]);
+                                self.next_tx_from = Some(B160::from_alloy(from));
+                                next_tx_len
+                            }
+                        },
+                    } as u32;
+                    DynUsizeIterator::from_constructor(len, UsizeSerializable::iter)
+                }
+                TX_DATA_WORDS_QUERY_ID => {
+                    let tx = self.next_tx.take().expect(
+                        "trying to read next tx content before size query or after seal response",
+                    );
+                    DynUsizeIterator::from_constructor(tx, |inner_ref| {
+                        ReadIterWrapper::from(inner_ref.iter().copied())
+                    })
+                }
+                TX_ENCODING_FORMAT_QUERY_ID => {
+                    // Return valid RLP format so parsing is attempted on garbage data
+                    Box::new(core::iter::once(1usize)) // 1 = Rlp
+                }
+                TX_FROM_QUERY_ID => {
+                    let from = self.next_tx_from.take().expect(
+                        "trying to read next tx from before size query or after seal response",
+                    );
+                    DynUsizeIterator::from_constructor(from, UsizeSerializable::iter)
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Custom oracle factory that corrupts transaction data bytes.
+    struct MaliciousTxDataCorruptOracleFactory;
+
+    impl MaliciousTxDataCorruptOracleFactory {
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for MaliciousTxDataCorruptOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that corrupted transaction data bytes from a malicious oracle
+    /// cause the transaction to be rejected. The block still completes (an internal
+    /// error during TX parsing causes the bootloader to reject that TX), but
+    /// no transaction should be successfully executed.
+    #[test]
+    fn test_malicious_oracle_corrupted_tx_data() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let malicious_factory = MaliciousTxDataCorruptOracleFactory;
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        // The block completes (corrupted TX is rejected during parsing),
+        // but no transaction should succeed.
+        let result = tester.execute_block_no_panic(vec![tx]);
+        match result {
+            Err(_) => {
+                // Block-level error from corrupted data — expected behavior
+            }
+            Ok(output) => {
+                // Block completed, but the corrupted TX must not have succeeded.
+                // Use the same pattern as assert_all_txs_succeeded but inverted:
+                let any_succeeded = output
+                    .tx_results
+                    .iter()
+                    .any(|r| r.as_ref().is_ok_and(|o| o.is_success()));
+                assert!(
+                    !any_succeeded,
+                    "Corrupted TX data should not result in a successfully executed transaction"
+                );
+            }
+        }
+    }
+
+    // ---- Malicious storage responder: false "existing" claim for new slots ----
+
+    /// Oracle query processor that claims all storage slots already exist (is_new=false)
+    /// even when they are actually new. This tests whether the system handles incorrect
+    /// is_new_storage_slot flags — in forward mode this may silently corrupt pubdata
+    /// accounting, but should not crash.
+    struct FalseExistingSlotResponder<S: rig::forward_system::run::ReadStorage> {
+        storage: S,
+    }
+
+    impl<S: rig::forward_system::run::ReadStorage> FalseExistingSlotResponder<S> {
+        fn new(storage: S) -> Self {
+            Self { storage }
+        }
+
+        const SUPPORTED_QUERY_IDS: &[u32] = &[
+            rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery::<
+                rig::zk_ee::types_config::EthereumIOTypesConfig,
+            >::QUERY_ID,
+        ];
+    }
+
+    impl<S: rig::forward_system::run::ReadStorage, M: MemorySource> OracleQueryProcessor<M>
+        for FalseExistingSlotResponder<S>
+    {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            Self::SUPPORTED_QUERY_IDS.to_vec()
+        }
+
+        fn supports_query_id(&self, query_id: u32) -> bool {
+            Self::SUPPORTED_QUERY_IDS.contains(&query_id)
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            query: Vec<usize>,
+            _memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            use rig::zk_ee::oracle::basic_queries::InitialStorageSlotQuery;
+            use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
+            use rig::zk_ee::storage_types::{InitialStorageSlotData, StorageAddress};
+            use rig::zk_ee::types_config::EthereumIOTypesConfig;
+
+            assert!(Self::SUPPORTED_QUERY_IDS.contains(&query_id));
+
+            let StorageAddress { address, key } =
+                <InitialStorageSlotQuery<EthereumIOTypesConfig> as SimpleOracleQuery>::Input::from_iter(
+                    &mut query.into_iter(),
+                )
+                .expect("must deserialize the address/slot");
+
+            let flat_key = rig::zk_ee::common_structs::derive_flat_storage_key(&address, &key);
+
+            let slot_data: InitialStorageSlotData<EthereumIOTypesConfig> =
+                if let Some(cold) = self.storage.read(flat_key) {
+                    InitialStorageSlotData {
+                        initial_value: cold,
+                        is_new_storage_slot: false,
+                    }
+                } else {
+                    // MALICIOUS: claim this new slot already exists with zero value.
+                    // This bypasses the "Initial value of empty slot must be trivial"
+                    // check (which only fires when is_new=true) and may corrupt
+                    // pubdata accounting.
+                    InitialStorageSlotData {
+                        initial_value: Bytes32::from_array([0; 32]),
+                        is_new_storage_slot: false, // Lie about slot existence
+                    }
+                };
+
+            DynUsizeIterator::from_constructor(slot_data, UsizeSerializable::iter)
+        }
+    }
+
+    /// Custom oracle factory that lies about slot existence.
+    struct FalseExistingSlotOracleFactory;
+
+    impl FalseExistingSlotOracleFactory {
+        fn build_oracle<M: MemorySource + 'static>(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource<M> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(
+                rig::forward_system::run::query_processors::TxDataResponder {
+                    tx_source,
+                    next_tx: None,
+                    next_tx_format: None,
+                    next_tx_from: None,
+                },
+            );
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(FalseExistingSlotResponder::new(state_tree));
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            oracle
+        }
+    }
+
+    impl TestingOracleFactory<false> for FalseExistingSlotOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            self.build_oracle(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
+
+    /// Verifies that a malicious oracle claiming all new slots are existing (is_new=false)
+    /// does not crash the system in forward mode. The wrong is_new flag corrupts pubdata
+    /// accounting (a concern for proving mode), but forward execution should still complete.
+    /// This test documents the forward-mode behavior for this attack vector.
+    #[test]
+    fn test_malicious_oracle_false_existing_slot_does_not_crash() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+
+        let contract_address =
+            rig::alloy::primitives::address!("1000000000000000000000000000000000000001");
+
+        // Simple storage contract: SSTORE(0, calldata[0..32])
+        // PUSH1 0x00 CALLDATALOAD PUSH1 0x00 SSTORE STOP
+        let store_bytecode = hex::decode("600035600055005050").unwrap();
+
+        tester = tester
+            .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
+            .with_evm_contract(contract_address, &store_bytecode);
+
+        let malicious_factory = FalseExistingSlotOracleFactory;
+        tester = tester.with_custom_oracle_factory(malicious_factory);
+
+        // Write to storage slot 0 — the oracle will falsely claim the slot already exists
+        let calldata = [0u8; 32]; // store zero (avoids pubdata cost differences)
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 100_000,
+                to: TxKind::Call(contract_address),
+                value: Default::default(),
+                input: calldata.to_vec().into(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        // In forward mode, the false is_new flag should not cause a crash.
+        // The system trusts the oracle response and proceeds (pubdata accounting
+        // would be wrong, but this is caught in proving mode by Merkle proofs).
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_ok(),
+            "Forward mode should not crash with false is_new flag — proving mode catches this"
         );
     }
 }

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -257,7 +257,7 @@ mod custom_oracle_factories {
     use rig::forward_system::run::convert_alloy::FromAlloy;
     use rig::forward_system::run::query_processors::{
         BlockMetadataResponder, DACommitmentSchemeResponder, GenericPreimageResponder,
-        ReadTreeResponder, ZKProofDataResponder,
+        ReadTreeResponder, TxDataResponder, ZKProofDataResponder,
     };
     use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
     use rig::forward_system::run::{NextTxResponse, PreimageSource};
@@ -277,6 +277,74 @@ mod custom_oracle_factories {
     use rig::zksync_os_interface::traits::{EncodedTx, TxListSource, TxSource};
     use rig::{common_target_address, TestingFramework};
     use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+    /// Generic oracle factory that delegates oracle construction to a closure.
+    /// Replaces per-test factory structs: each test only provides the closure
+    /// that builds its custom oracle configuration.
+    pub(super) struct CustomOracleFactory<F>(pub F)
+    where
+        F: Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource;
+
+    impl<F> TestingOracleFactory<false> for CustomOracleFactory<F>
+    where
+        F: Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
+            (self.0)(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+            _use_native_callable_oracles: bool,
+        ) -> ZkEENonDeterminismSource {
+            (self.0)(
+                block_metadata,
+                state_tree,
+                preimage_source,
+                tx_source,
+                proof_data,
+                da_commitment_scheme,
+            )
+        }
+    }
 
     // ---- Malicious TX encoding format responder ----
 
@@ -372,86 +440,44 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that injects an invalid TX encoding format value.
-    struct MaliciousTxFormatOracleFactory {
+    /// Helper: builds a CustomOracleFactory that injects a MaliciousTxFormatResponder.
+    fn malicious_tx_format_factory(
         malicious_format_value: usize,
-    }
-
-    impl MaliciousTxFormatOracleFactory {
-        fn new(malicious_format_value: usize) -> Self {
-            Self {
-                malicious_format_value,
-            }
-        }
-
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(MaliciousTxFormatResponder::new(
-                tx_source,
-                self.malicious_format_value,
-            ));
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for MaliciousTxFormatOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+    ) -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            move |block_metadata,
+                  state_tree,
+                  preimage_source,
+                  tx_source,
+                  proof_data,
+                  da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(MaliciousTxFormatResponder::new(
+                    tx_source,
+                    malicious_format_value,
+                ));
+                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that the system rejects an invalid TX encoding format (value 255)
@@ -477,8 +503,7 @@ mod custom_oracle_factories {
         };
 
         // Malicious oracle returns 255 as the encoding format
-        let malicious_factory = MaliciousTxFormatOracleFactory::new(255);
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_tx_format_factory(255));
 
         let result = tester.execute_block_no_panic(vec![tx]);
         assert!(
@@ -510,8 +535,7 @@ mod custom_oracle_factories {
         };
 
         // Malicious oracle returns 2 (just above valid range 0-1)
-        let malicious_factory = MaliciousTxFormatOracleFactory::new(2);
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_tx_format_factory(2));
 
         let result = tester.execute_block_no_panic(vec![tx]);
         assert!(
@@ -543,8 +567,7 @@ mod custom_oracle_factories {
         };
 
         // Malicious oracle returns usize::MAX — overflows u8 deserialization
-        let malicious_factory = MaliciousTxFormatOracleFactory::new(usize::MAX);
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_tx_format_factory(usize::MAX));
 
         let result = tester.execute_block_no_panic(vec![tx]);
         assert!(
@@ -645,91 +668,49 @@ mod custom_oracle_factories {
         }
     }
 
-    /// Custom oracle factory that blocks preimage lookups for specific hashes.
-    struct MaliciousPreimageOracleFactory {
+    /// Helper: builds a CustomOracleFactory that blocks preimage lookups for specific hashes.
+    fn malicious_preimage_factory(
         blocked_hashes: Vec<Bytes32>,
-    }
-
-    impl MaliciousPreimageOracleFactory {
-        fn new(blocked_hashes: Vec<Bytes32>) -> Self {
-            Self { blocked_hashes }
-        }
-
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(
-                rig::forward_system::run::query_processors::TxDataResponder {
+    ) -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            move |block_metadata,
+                  state_tree,
+                  preimage_source,
+                  tx_source,
+                  proof_data,
+                  da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(TxDataResponder {
                     tx_source,
                     next_tx: None,
                     next_tx_format: None,
                     next_tx_from: None,
-                },
-            );
-            oracle.add_external_processor(MaliciousPreimageResponder::new(
-                preimage_source,
-                self.blocked_hashes.clone(),
-            ));
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for MaliciousPreimageOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+                });
+                oracle.add_external_processor(MaliciousPreimageResponder::new(
+                    preimage_source,
+                    blocked_hashes.clone(),
+                ));
+                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that the system panics when a malicious oracle refuses to provide
@@ -757,8 +738,7 @@ mod custom_oracle_factories {
         let bytecode_hash = account_props.bytecode_hash;
 
         // Now set up the malicious factory that blocks this bytecode's preimage
-        let malicious_factory = MaliciousPreimageOracleFactory::new(vec![bytecode_hash]);
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_preimage_factory(vec![bytecode_hash]));
 
         // Call the deployed contract — the system will try to decommit its bytecode
         // and the malicious oracle will refuse to provide the preimage
@@ -861,81 +841,44 @@ mod custom_oracle_factories {
     }
 
     /// Custom oracle factory that corrupts account properties storage reads.
-    struct MaliciousAccountStorageOracleFactory;
-
-    impl MaliciousAccountStorageOracleFactory {
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(
-                rig::forward_system::run::query_processors::TxDataResponder {
+    /// Helper: builds a CustomOracleFactory with MaliciousAccountStorageResponder.
+    fn malicious_account_storage_factory() -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            |block_metadata,
+             state_tree,
+             preimage_source,
+             tx_source,
+             proof_data,
+             da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(TxDataResponder {
                     tx_source,
                     next_tx: None,
                     next_tx_format: None,
                     next_tx_from: None,
-                },
-            );
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(MaliciousAccountStorageResponder::new(state_tree));
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for MaliciousAccountStorageOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+                });
+                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                oracle.add_external_processor(MaliciousAccountStorageResponder::new(state_tree));
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that the system panics when a malicious oracle provides a fake hash
@@ -950,8 +893,7 @@ mod custom_oracle_factories {
 
         // The malicious factory will return fake hashes for ALL account property reads,
         // including the sender's balance lookup during transaction validation.
-        let malicious_factory = MaliciousAccountStorageOracleFactory;
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_account_storage_factory());
 
         let tx = {
             let tx = TxEip2930 {
@@ -1065,74 +1007,39 @@ mod custom_oracle_factories {
     }
 
     /// Custom oracle factory that corrupts transaction data bytes.
-    struct MaliciousTxDataCorruptOracleFactory;
-
-    impl MaliciousTxDataCorruptOracleFactory {
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for MaliciousTxDataCorruptOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+    /// Helper: builds a CustomOracleFactory with MaliciousTxDataCorruptResponder.
+    fn malicious_tx_data_corrupt_factory() -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            |block_metadata,
+             state_tree,
+             preimage_source,
+             tx_source,
+             proof_data,
+             da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(MaliciousTxDataCorruptResponder::new(tx_source));
+                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that corrupted transaction data bytes from a malicious oracle
@@ -1159,8 +1066,7 @@ mod custom_oracle_factories {
             ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
         };
 
-        let malicious_factory = MaliciousTxDataCorruptOracleFactory;
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(malicious_tx_data_corrupt_factory());
 
         // The block completes (corrupted TX is rejected during parsing),
         // but no transaction should succeed.
@@ -1302,81 +1208,44 @@ mod custom_oracle_factories {
     }
 
     /// Custom oracle factory that lies about slot existence.
-    struct FalseExistingSlotOracleFactory;
-
-    impl FalseExistingSlotOracleFactory {
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(
-                rig::forward_system::run::query_processors::TxDataResponder {
+    /// Helper: builds a CustomOracleFactory with FalseExistingSlotResponder.
+    fn false_existing_slot_factory() -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            |block_metadata,
+             state_tree,
+             preimage_source,
+             tx_source,
+             proof_data,
+             da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(TxDataResponder {
                     tx_source,
                     next_tx: None,
                     next_tx_format: None,
                     next_tx_from: None,
-                },
-            );
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(FalseExistingSlotResponder::new(state_tree));
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for FalseExistingSlotOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+                });
+                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                oracle.add_external_processor(FalseExistingSlotResponder::new(state_tree));
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that a malicious oracle claiming new slots are existing (is_new=false)
@@ -1402,8 +1271,7 @@ mod custom_oracle_factories {
             .with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64))
             .with_evm_contract(contract_address, &store_bytecode);
 
-        let malicious_factory = FalseExistingSlotOracleFactory;
-        tester = tester.with_custom_oracle_factory(malicious_factory);
+        tester = tester.with_custom_oracle_factory(false_existing_slot_factory());
 
         // Write to storage slot 0 — the oracle will falsely claim the slot already exists
         let calldata = [0u8; 32]; // store zero (avoids pubdata cost differences)
@@ -1523,90 +1391,49 @@ mod custom_oracle_factories {
     }
 
     /// Custom oracle factory that corrupts preimage data for targeted hashes.
-    struct CorruptedPreimageOracleFactory {
+    /// Helper: builds a CustomOracleFactory with CorruptedPreimageResponder.
+    fn corrupted_preimage_factory(
         corrupted_hashes: Vec<Bytes32>,
-    }
-
-    impl CorruptedPreimageOracleFactory {
-        fn new(corrupted_hashes: Vec<Bytes32>) -> Self {
-            Self { corrupted_hashes }
-        }
-
-        fn build_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(
-                rig::forward_system::run::query_processors::TxDataResponder {
+    ) -> CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        CustomOracleFactory(
+            move |block_metadata,
+                  state_tree,
+                  preimage_source,
+                  tx_source,
+                  proof_data,
+                  da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(TxDataResponder {
                     tx_source,
                     next_tx: None,
                     next_tx_format: None,
                     next_tx_from: None,
-                },
-            );
-            oracle.add_external_processor(CorruptedPreimageResponder::new(
-                preimage_source,
-                self.corrupted_hashes.clone(),
-            ));
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-    }
-
-    impl TestingOracleFactory<false> for CorruptedPreimageOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            self.build_oracle(
-                block_metadata,
-                state_tree,
-                preimage_source,
-                tx_source,
-                proof_data,
-                da_commitment_scheme,
-            )
-        }
+                });
+                oracle.add_external_processor(CorruptedPreimageResponder::new(
+                    preimage_source,
+                    corrupted_hashes.clone(),
+                ));
+                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Verifies that corrupted preimage data (hash mismatch) is detected in debug mode.
@@ -1639,8 +1466,7 @@ mod custom_oracle_factories {
         let account_props = tester.get_account_properties(&contract_address);
         let bytecode_hash = account_props.bytecode_hash;
 
-        let corrupted_factory = CorruptedPreimageOracleFactory::new(vec![bytecode_hash]);
-        tester = tester.with_custom_oracle_factory(corrupted_factory);
+        tester = tester.with_custom_oracle_factory(corrupted_preimage_factory(vec![bytecode_hash]));
 
         let tx = {
             let tx = TxEip2930 {
@@ -1686,7 +1512,6 @@ mod callable_oracle_tests {
     use rig::basic_system::system_implementation::flat_storage_model::{
         FlatStorageCommitment, TREE_HEIGHT,
     };
-    use rig::chain::TestingOracleFactory;
     use rig::forward_system::run::query_processors::{
         BlockMetadataResponder, DACommitmentSchemeResponder, GenericPreimageResponder,
         ReadTreeResponder, TxDataResponder, ZKProofDataResponder,
@@ -1755,74 +1580,47 @@ mod callable_oracle_tests {
         }
     }
 
-    /// Custom oracle factory that replaces the ArithmeticQuery with a malicious version.
-    /// In forward mode, this has no effect (callable oracles aren't queried).
-    /// In RISC-V mode, the malicious arithmetic oracle will return wrong modexp results,
-    /// and the verification in the modpow delegation should catch the discrepancy.
-    struct MaliciousCallableOracleFactory;
-
-    impl TestingOracleFactory<false> for MaliciousCallableOracleFactory {
-        fn create_forward_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(TxDataResponder {
-                tx_source,
-                next_tx: None,
-                next_tx_format: None,
-                next_tx_from: None,
-            });
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            // Register malicious arithmetic oracle — not queried in forward mode
-            oracle.add_external_processor(MaliciousArithmeticQuery::default());
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
-
-        fn create_proof_oracle(
-            &self,
-            block_metadata: BlockMetadataFromOracle,
-            state_tree: InMemoryTree<false>,
-            preimage_source: InMemoryPreimageSource,
-            tx_source: TxListSource,
-            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
-            da_commitment_scheme: Option<DACommitmentScheme>,
-            _add_uart: bool,
-            _use_native_callable_oracles: bool,
-        ) -> ZkEENonDeterminismSource {
-            let mut oracle = ZkEENonDeterminismSource::default();
-            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
-            oracle.add_external_processor(TxDataResponder {
-                tx_source,
-                next_tx: None,
-                next_tx_format: None,
-                next_tx_from: None,
-            });
-            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
-            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
-            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
-            oracle.add_external_processor(DACommitmentSchemeResponder {
-                da_commitment_scheme,
-            });
-            // Register malicious arithmetic oracle — WILL be queried in RISC-V mode
-            oracle.add_external_processor(MaliciousArithmeticQuery::default());
-            oracle.add_external_processor(rig::callable_oracles::field_hints::NativeFieldOpsQuery);
-            oracle
-        }
+    /// Helper: builds a CustomOracleFactory with MaliciousArithmeticQuery.
+    /// In forward mode, callable oracles aren't queried (no effect).
+    /// In RISC-V mode, the malicious arithmetic oracle returns wrong modexp results.
+    fn malicious_callable_oracle_factory() -> super::custom_oracle_factories::CustomOracleFactory<
+        impl Fn(
+            BlockMetadataFromOracle,
+            InMemoryTree<false>,
+            InMemoryPreimageSource,
+            TxListSource,
+            Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            Option<DACommitmentScheme>,
+        ) -> ZkEENonDeterminismSource,
+    > {
+        super::custom_oracle_factories::CustomOracleFactory(
+            |block_metadata,
+             state_tree,
+             preimage_source,
+             tx_source,
+             proof_data,
+             da_commitment_scheme| {
+                let mut oracle = ZkEENonDeterminismSource::default();
+                oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+                oracle.add_external_processor(TxDataResponder {
+                    tx_source,
+                    next_tx: None,
+                    next_tx_format: None,
+                    next_tx_from: None,
+                });
+                oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+                oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+                oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+                oracle.add_external_processor(DACommitmentSchemeResponder {
+                    da_commitment_scheme,
+                });
+                oracle.add_external_processor(MaliciousArithmeticQuery::default());
+                oracle.add_external_processor(
+                    rig::callable_oracles::field_hints::NativeFieldOpsQuery,
+                );
+                oracle
+            },
+        )
     }
 
     /// Test that the MaliciousArithmeticQuery actually produces wrong results.
@@ -1898,9 +1696,8 @@ mod callable_oracle_tests {
             ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
         };
 
-        let factory = MaliciousCallableOracleFactory;
         tester = tester
-            .with_custom_oracle_factory(factory)
+            .with_custom_oracle_factory(malicious_callable_oracle_factory())
             .with_run_config(rig::run_config::forward_only());
 
         // In forward mode, callable oracles are not used, so execution should

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -1612,3 +1612,265 @@ mod custom_oracle_factories {
         let _result = tester.execute_block(vec![tx]);
     }
 }
+
+mod callable_oracle_tests {
+    //! Tests for callable oracle processors (ModExp arithmetic, Blob KZG commitment).
+    //!
+    //! Callable oracles provide computational advice to the proving system. They are
+    //! registered as external processors in ZkEENonDeterminismSource and queried
+    //! during RISC-V proof execution. In forward mode, the system computes these
+    //! operations directly without querying callable oracles.
+    //!
+    //! These tests validate the callable oracle processors themselves using
+    //! VectorMemoryImpl, which allows testing the full oracle query path (memory read,
+    //! computation, response serialization) without RISC-V simulation. A malicious
+    //! oracle factory integration test is included to demonstrate the custom factory
+    //! pattern for callable oracle testing.
+
+    use rig::callable_oracles::arithmetic::ArithmeticQuery;
+    use rig::callable_oracles::blob_kzg_commitment::blob_kzg_commitment_and_proof;
+    use rig::oracle_provider::OracleQueryProcessor;
+    use rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl;
+
+    use rig::alloy::consensus::TxEip2930;
+    use rig::alloy::primitives::{TxKind, U256};
+    use rig::basic_system::system_functions::modexp::MODEXP_ADVICE_QUERY_ID;
+    use rig::basic_system::system_implementation::flat_storage_model::{
+        FlatStorageCommitment, TREE_HEIGHT,
+    };
+    use rig::chain::TestingOracleFactory;
+    use rig::forward_system::run::query_processors::{
+        BlockMetadataResponder, DACommitmentSchemeResponder, GenericPreimageResponder,
+        ReadTreeResponder, TxDataResponder, ZKProofDataResponder,
+    };
+    use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
+    use rig::oracle_provider::{MemorySource, ZkEENonDeterminismSource};
+    use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
+    use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
+    use rig::zksync_os_interface::traits::TxListSource;
+    use rig::{common_target_address, TestingFramework};
+    use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+    /// A malicious arithmetic oracle that returns deliberately wrong division results.
+    /// When queried for modexp advice, it corrupts the quotient by adding 1 to each word,
+    /// which will cause the verification step (q * modulus + r == dividend) to fail.
+    struct MaliciousArithmeticQuery<M: MemorySource> {
+        inner: ArithmeticQuery<M>,
+    }
+
+    impl<M: MemorySource> Default for MaliciousArithmeticQuery<M> {
+        fn default() -> Self {
+            Self {
+                inner: ArithmeticQuery::default(),
+            }
+        }
+    }
+
+    impl<M: MemorySource> OracleQueryProcessor<M> for MaliciousArithmeticQuery<M> {
+        fn supported_query_ids(&self) -> Vec<u32> {
+            self.inner.supported_query_ids()
+        }
+
+        fn process_buffered_query(
+            &mut self,
+            query_id: u32,
+            query: Vec<usize>,
+            memory: &M,
+        ) -> Box<dyn ExactSizeIterator<Item = usize> + 'static + Send + Sync> {
+            // Get the correct result first
+            let correct: Vec<usize> = self
+                .inner
+                .process_buffered_query(query_id, query, memory)
+                .collect();
+
+            // Corrupt the quotient: add 1 to the first quotient word (index 1, after header)
+            let mut corrupted = correct;
+            if corrupted.len() > 1 {
+                corrupted[1] = corrupted[1].wrapping_add(1);
+            }
+
+            Box::new(corrupted.into_iter())
+        }
+    }
+
+    /// Custom oracle factory that replaces the ArithmeticQuery with a malicious version.
+    /// In forward mode, this has no effect (callable oracles aren't queried).
+    /// In RISC-V mode, the malicious arithmetic oracle will return wrong modexp results,
+    /// and the verification in the modpow delegation should catch the discrepancy.
+    struct MaliciousCallableOracleFactory;
+
+    impl TestingOracleFactory<false> for MaliciousCallableOracleFactory {
+        fn create_forward_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::oracle_provider::DummyMemorySource> {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(TxDataResponder {
+                tx_source,
+                next_tx: None,
+                next_tx_format: None,
+                next_tx_from: None,
+            });
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            // Register malicious arithmetic oracle — not queried in forward mode
+            oracle.add_external_processor(MaliciousArithmeticQuery::<
+                rig::oracle_provider::DummyMemorySource,
+            >::default());
+            oracle
+        }
+
+        fn create_proof_oracle(
+            &self,
+            block_metadata: BlockMetadataFromOracle,
+            state_tree: InMemoryTree<false>,
+            preimage_source: InMemoryPreimageSource,
+            tx_source: TxListSource,
+            proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+            da_commitment_scheme: Option<DACommitmentScheme>,
+            _add_uart: bool,
+        ) -> ZkEENonDeterminismSource<rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl>
+        {
+            let mut oracle = ZkEENonDeterminismSource::default();
+            oracle.add_external_processor(BlockMetadataResponder { block_metadata });
+            oracle.add_external_processor(TxDataResponder {
+                tx_source,
+                next_tx: None,
+                next_tx_format: None,
+                next_tx_from: None,
+            });
+            oracle.add_external_processor(GenericPreimageResponder { preimage_source });
+            oracle.add_external_processor(ReadTreeResponder { tree: state_tree });
+            oracle.add_external_processor(ZKProofDataResponder { data: proof_data });
+            oracle.add_external_processor(DACommitmentSchemeResponder {
+                da_commitment_scheme,
+            });
+            // Register malicious arithmetic oracle — WILL be queried in RISC-V mode
+            oracle.add_external_processor(MaliciousArithmeticQuery::<
+                rig::risc_v_simulator::abstractions::memory::VectorMemoryImpl,
+            >::default());
+            oracle
+        }
+    }
+
+    /// Test that the MaliciousArithmeticQuery actually produces wrong results.
+    /// This verifies the malicious oracle implementation itself works correctly
+    /// (i.e., it corrupts the output).
+    #[test]
+    fn test_malicious_arithmetic_query_corrupts_output() {
+        let params_addr: u32 = 0x100;
+        let a_addr: u32 = 0x200;
+        let m_addr: u32 = 0x400;
+        let mem_bytes = 0x800;
+
+        let mut memory = VectorMemoryImpl::new_for_byte_size(mem_bytes);
+
+        // ModExpAdviceParams: 10 / 3
+        memory.populate(params_addr, 0); // op
+        memory.populate(params_addr + 4, a_addr); // a_ptr
+        memory.populate(params_addr + 8, 1); // a_len (1 digit)
+        memory.populate(params_addr + 12, 0); // b_ptr
+        memory.populate(params_addr + 16, 0); // b_len
+        memory.populate(params_addr + 20, m_addr); // modulus_ptr
+        memory.populate(params_addr + 24, 1); // modulus_len
+
+        // dividend = 10
+        memory.populate(a_addr, 10);
+        // modulus = 3
+        memory.populate(m_addr, 3);
+
+        // Get correct result
+        let mut correct_oracle = ArithmeticQuery::<VectorMemoryImpl>::default();
+        let correct: Vec<usize> = correct_oracle
+            .process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![params_addr as usize], &memory)
+            .collect();
+
+        // Get malicious result
+        let mut malicious_oracle = MaliciousArithmeticQuery::<VectorMemoryImpl>::default();
+        let malicious: Vec<usize> = malicious_oracle
+            .process_buffered_query(MODEXP_ADVICE_QUERY_ID, vec![params_addr as usize], &memory)
+            .collect();
+
+        // Verify the malicious oracle corrupted the output
+        assert_ne!(
+            correct, malicious,
+            "Malicious oracle should produce different output from correct oracle"
+        );
+        // Header should be the same (lengths unchanged)
+        assert_eq!(correct[0], malicious[0], "Header should be unchanged");
+        // Quotient should be corrupted
+        assert_ne!(correct[1], malicious[1], "Quotient should be corrupted");
+    }
+
+    /// Integration test: register a malicious callable oracle factory and execute a block.
+    /// In forward mode, callable oracles are not queried, so this test passes — it
+    /// demonstrates that forward mode does not depend on callable oracle correctness.
+    /// In RISC-V mode (CI with ZKSYNC_RISC_V_RUN=true), the modexp precompile would
+    /// query the malicious oracle and the verification should catch the wrong result.
+    #[test]
+    fn test_malicious_callable_oracle_factory_forward_mode() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let factory = MaliciousCallableOracleFactory;
+        tester = tester
+            .with_custom_oracle_factory(factory)
+            .with_run_config(rig::run_config::forward_only());
+
+        // In forward mode, callable oracles are not used, so execution should
+        // succeed even with a malicious arithmetic oracle registered.
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_ok(),
+            "Forward mode should not depend on callable oracle correctness"
+        );
+    }
+
+    /// Test that the blob_kzg_commitment_and_proof function produces valid output
+    /// via the direct (non-oracle) path. This validates the computation that would
+    /// be verified against oracle results in proving mode.
+    #[test]
+    fn test_blob_kzg_commitment_computation_consistency() {
+        let data = b"test blob data for commitment verification";
+        let result = blob_kzg_commitment_and_proof(data);
+
+        // Verify output has correct structure
+        assert_eq!(
+            result.commitment.len(),
+            48,
+            "KZG commitment should be 48 bytes"
+        );
+        assert_eq!(result.proof.len(), 48, "KZG proof should be 48 bytes");
+
+        // Verify determinism
+        let result2 = blob_kzg_commitment_and_proof(data);
+        assert_eq!(result.commitment, result2.commitment);
+        assert_eq!(result.proof, result2.proof);
+    }
+}

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -145,6 +145,60 @@ mod block_metadata {
     }
 }
 
+mod tx_encoding_format {
+    //! Unit tests for transaction encoding format oracle validation.
+    //!
+    //! TxEncodingFormat::from_iter validates the oracle-provided encoding format byte.
+    //! Only values 0 (Abi) and 1 (Rlp) are valid. Invalid values should be rejected
+    //! with an internal error rather than panicking.
+
+    use rig::basic_bootloader::bootloader::transaction::TxEncodingFormat;
+    use rig::zk_ee::oracle::usize_serialization::UsizeDeserializable;
+
+    #[test]
+    fn test_tx_encoding_format_accepts_abi() {
+        let mut iter = [0usize].into_iter();
+        let result = TxEncodingFormat::from_iter(&mut iter);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_tx_encoding_format_accepts_rlp() {
+        let mut iter = [1usize].into_iter();
+        let result = TxEncodingFormat::from_iter(&mut iter);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_tx_encoding_format_rejects_invalid_value_2() {
+        let mut iter = [2usize].into_iter();
+        let result = TxEncodingFormat::from_iter(&mut iter);
+        assert!(
+            result.is_err(),
+            "TxEncodingFormat should reject value 2 (only 0=Abi and 1=Rlp are valid)"
+        );
+    }
+
+    #[test]
+    fn test_tx_encoding_format_rejects_invalid_value_255() {
+        let mut iter = [255usize].into_iter();
+        let result = TxEncodingFormat::from_iter(&mut iter);
+        assert!(result.is_err(), "TxEncodingFormat should reject value 255");
+    }
+
+    #[test]
+    fn test_tx_encoding_format_rejects_large_value() {
+        // Values that would be truncated to u8 — the from_iter first deserializes
+        // as u8, so large usize values test the u8 deserialization path too.
+        let mut iter = [256usize].into_iter();
+        let result = TxEncodingFormat::from_iter(&mut iter);
+        assert!(
+            result.is_err(),
+            "TxEncodingFormat should reject value 256 (overflows u8)"
+        );
+    }
+}
+
 mod da_commitment_scheme {
     //! Unit tests for DA commitment scheme validation.
     //!

--- a/tests/instances/unit/src/malicious_oracle.rs
+++ b/tests/instances/unit/src/malicious_oracle.rs
@@ -1,0 +1,191 @@
+#![cfg(test)]
+
+//!
+//! Tests for malicious oracle behavior.
+//!
+//! These tests verify that the system correctly validates and rejects
+//! invalid or malicious data returned by the oracle (untrusted host).
+//!
+
+mod block_metadata {
+    //! Tests for block metadata oracle validation.
+    //!
+    //! The bootloader validates gas limits from the oracle response.
+    //! If block_gas_limit > MAX_BLOCK_GAS_LIMIT or individual_tx_gas_limit > MAX_TX_GAS_LIMIT,
+    //! an internal error is returned.
+
+    use rig::alloy::consensus::TxEip2930;
+    use rig::alloy::primitives::{TxKind, U256};
+    use rig::basic_bootloader::bootloader::constants::MAX_BLOCK_GAS_LIMIT;
+    use rig::{common_target_address, BlockContext, TestingFramework};
+    use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+
+    /// Verifies that block execution fails when the oracle provides
+    /// a gas limit exceeding MAX_BLOCK_GAS_LIMIT.
+    #[test]
+    fn test_block_rejects_excessive_gas_limit() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let block_context = BlockContext {
+            gas_limit: MAX_BLOCK_GAS_LIMIT + 1,
+            ..Default::default()
+        };
+
+        tester.set_block_context(Some(block_context));
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_err(),
+            "Block execution should fail when gas limit exceeds MAX_BLOCK_GAS_LIMIT"
+        );
+    }
+
+    /// Verifies that block execution succeeds at the exact MAX_BLOCK_GAS_LIMIT boundary.
+    #[test]
+    fn test_block_accepts_max_gas_limit() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let block_context = BlockContext {
+            gas_limit: MAX_BLOCK_GAS_LIMIT,
+            ..Default::default()
+        };
+
+        tester.set_block_context(Some(block_context));
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_ok(),
+            "Block execution should succeed at exactly MAX_BLOCK_GAS_LIMIT"
+        );
+    }
+
+    /// Verifies that block execution fails with u64::MAX as gas limit.
+    /// This is a large overflow case — u64::MAX is well above MAX_BLOCK_GAS_LIMIT.
+    #[test]
+    fn test_block_rejects_u64_max_gas_limit() {
+        let mut tester = TestingFramework::new();
+        let wallet = tester.random_signer();
+        tester = tester.with_balance(wallet.address(), U256::from(1_000_000_000_000_000_u64));
+
+        let tx = {
+            let tx = TxEip2930 {
+                chain_id: 37u64,
+                nonce: 0,
+                gas_price: 1000,
+                gas_limit: 21_000,
+                to: TxKind::Call(common_target_address()),
+                value: Default::default(),
+                input: Default::default(),
+                access_list: Default::default(),
+            };
+            ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+        };
+
+        let block_context = BlockContext {
+            gas_limit: u64::MAX,
+            ..Default::default()
+        };
+
+        tester.set_block_context(Some(block_context));
+        let result = tester.execute_block_no_panic(vec![tx]);
+        assert!(
+            result.is_err(),
+            "Block execution should fail when gas limit is u64::MAX"
+        );
+    }
+
+    /// Verifies that block execution fails even with an empty transaction list
+    /// when the gas limit is excessive. The validation happens during metadata
+    /// initialization, before any transactions are processed.
+    #[test]
+    fn test_empty_block_rejects_excessive_gas_limit() {
+        let mut tester = TestingFramework::new();
+
+        let block_context = BlockContext {
+            gas_limit: MAX_BLOCK_GAS_LIMIT + 1,
+            ..Default::default()
+        };
+
+        tester.set_block_context(Some(block_context));
+        let result = tester.execute_block_no_panic(vec![]);
+        assert!(
+            result.is_err(),
+            "Even an empty block should fail with excessive gas limit"
+        );
+    }
+}
+
+mod da_commitment_scheme {
+    //! Unit tests for DA commitment scheme validation.
+    //!
+    //! DACommitmentScheme::try_from validates the oracle-provided scheme ID.
+    //! Only values 0-4 are valid. Invalid IDs should be rejected.
+    //! Note: the oracle query for DA commitment scheme only runs in PROOF_ENV,
+    //! so this is tested at the type level rather than through the full execution path.
+
+    use rig::zk_ee::common_structs::da_commitment_scheme::DACommitmentScheme;
+
+    #[test]
+    fn test_da_commitment_scheme_accepts_all_valid_ids() {
+        assert_eq!(
+            DACommitmentScheme::try_from(0u8),
+            Ok(DACommitmentScheme::None)
+        );
+        assert_eq!(
+            DACommitmentScheme::try_from(1u8),
+            Ok(DACommitmentScheme::EmptyNoDA)
+        );
+        assert_eq!(
+            DACommitmentScheme::try_from(2u8),
+            Ok(DACommitmentScheme::PubdataKeccak256)
+        );
+        assert_eq!(
+            DACommitmentScheme::try_from(3u8),
+            Ok(DACommitmentScheme::BlobsAndPubdataKeccak256)
+        );
+        assert_eq!(
+            DACommitmentScheme::try_from(4u8),
+            Ok(DACommitmentScheme::BlobsZKsyncOS)
+        );
+    }
+
+    #[test]
+    fn test_da_commitment_scheme_rejects_invalid_ids() {
+        // Value just above the valid range
+        assert!(DACommitmentScheme::try_from(5u8).is_err());
+        // Middle of invalid range
+        assert!(DACommitmentScheme::try_from(128u8).is_err());
+        // Maximum u8 value
+        assert!(DACommitmentScheme::try_from(255u8).is_err());
+    }
+}

--- a/tests/rig/Cargo.toml
+++ b/tests/rig/Cargo.toml
@@ -53,7 +53,7 @@ unlimited_native = ["forward_system/unlimited_native"]
 gpu = ["cli/gpu", "gpu_prover"]
 production = ["forward_system/production"]
 # Features for test instances
-for_tests = ["forward_system/for_tests"]
+for_tests = ["forward_system/for_tests", "callable_oracles/testing"]
 # Features used for eth_runner
 eth_runner = ["forward_system/eth_runner"]
 eth_stf = ["forward_system/eth_stf"]


### PR DESCRIPTION
## What ❔

Add tests that verify the system correctly validates and rejects invalid/malicious oracle responses. Covers two oracle validation areas:

**Block metadata gas limit validation (4 tests):**
- `test_block_rejects_excessive_gas_limit` — gas limit just above `MAX_BLOCK_GAS_LIMIT` is rejected
- `test_block_accepts_max_gas_limit` — exact boundary value is accepted
- `test_block_rejects_u64_max_gas_limit` — extreme overflow value is rejected
- `test_empty_block_rejects_excessive_gas_limit` — validation fires before any transactions are processed

**DA commitment scheme validation (2 tests):**
- `test_da_commitment_scheme_accepts_all_valid_ids` — all valid IDs 0–4 are accepted
- `test_da_commitment_scheme_rejects_invalid_ids` — IDs 5, 128, 255 are rejected

## Why ❔

Oracle responses come from an untrusted host and must be validated. These tests confirm that existing validation logic correctly rejects malicious metadata. Gas limit validation prevents resource accounting overflow (ergs = gas × 256). DA commitment scheme validation prevents use of undefined commitment modes.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.