### PR TITLE
chore(ci): optimize CI workflow performance

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,13 +58,16 @@ jobs:
       - name: Install Python dependencies
         run: pip3 install matplotlib
 
-      - name: Compile for RISC-V
-        working-directory: ./zksync_os
+      - name: Setup RISC-V tooling
         run: |
           rustup target add riscv32i-unknown-none-elf
           cargo install cargo-binutils
           rustup component add llvm-tools-preview
           rustup component add rust-src
+
+      - name: Compile for RISC-V
+        working-directory: ./zksync_os
+        run: |
           ./dump_bin.sh --type for-tests
           ./dump_bin.sh --type evm-replay-benchmarking
 
@@ -85,10 +88,6 @@ jobs:
       - name: Recompile for RISC-V
         working-directory: ./zksync_os
         run: |
-          rustup target add riscv32i-unknown-none-elf
-          cargo install cargo-binutils
-          rustup component add llvm-tools-preview
-          rustup component add rust-src
           ./dump_bin.sh --type for-tests
           ./dump_bin.sh --type evm-replay-benchmarking
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,13 @@ jobs:
             - name: Setup
               run: |
                   rustup set profile minimal
+                  rustup target add riscv32i-unknown-none-elf
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
             - name: Compile for RISC-V
               working-directory: ./zksync_os
               run: |
-                  rustup target add riscv32i-unknown-none-elf
-                  cargo install cargo-binutils
-                  rustup component add llvm-tools-preview
-                  rustup component add rust-src
                   ./dump_bin.sh --type for-tests
                   ./dump_bin.sh --type multiblock-batch
             - name: Compile
@@ -55,16 +52,13 @@ jobs:
             - name: Setup
               run: |
                   rustup set profile minimal
+                  rustup target add riscv32i-unknown-none-elf
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
             - name: Compile for RISC-V
               working-directory: ./zksync_os
               run: |
-                  rustup target add riscv32i-unknown-none-elf
-                  cargo install cargo-binutils
-                  rustup component add llvm-tools-preview
-                  rustup component add rust-src
                   ./dump_bin.sh --type for-tests
                   ./dump_bin.sh --type multiblock-batch
             - name: Compile
@@ -99,9 +93,7 @@ jobs:
                   rustflags: ""
             - name: Setup
               run: |
-                  rustup toolchain install
                   rustup set profile minimal
-                  cargo install cargo-binutils
             - name: Download ethereum execution spec tests fixtures
               working-directory: ./tests/evm_tester
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,13 @@ jobs:
             - name: Setup
               run: |
                   rustup set profile minimal
-            - name: Compile for RISC-V
-              working-directory: ./zksync_os
-              run: |
                   rustup target add riscv32i-unknown-none-elf
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
+            - name: Compile for RISC-V
+              working-directory: ./zksync_os
+              run: |
                   ./dump_bin.sh --type for-tests
             - name: Run proving test
               # Runs with e2e_proving feature
@@ -160,13 +160,13 @@ jobs:
             - name: Setup
               run: |
                   rustup set profile minimal
-            - name: Compile for RISC-V
-              working-directory: ./zksync_os
-              run: |
                   rustup target add riscv32i-unknown-none-elf
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
+            - name: Compile for RISC-V
+              working-directory: ./zksync_os
+              run: |
                   ./dump_bin.sh --type eth-stf
             - name: Run ethereum block
               working-directory: ./tests/instances/eth_runner
@@ -239,13 +239,15 @@ jobs:
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
                   rustflags: ""
-            - name: Compile for RISC-V
-              working-directory: ./zksync_os
+            - name: Setup
               run: |
                   rustup target add riscv32i-unknown-none-elf
                   cargo install cargo-binutils
                   rustup component add llvm-tools-preview
                   rustup component add rust-src
+            - name: Compile for RISC-V
+              working-directory: ./zksync_os
+              run: |
                   ./dump_bin.sh --type for-tests
             - name: Run regression tests
               working-directory: ./tests/fuzzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,16 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  rustflags: ""
+                  rustflags: "-C overflow-checks=on -C debug-assertions=on"
             - name: Setup
               run: |
                   rustup set profile minimal
+            - name: Compile crypto tests
+              run: cargo test -p crypto --no-run
             - name: Run crypto tests 10 times with overflow checks
               run: |
                   for i in {1..10}; do
-                    RUSTFLAGS="-C overflow-checks=on -C debug-assertions=on" cargo test -p crypto --quiet || exit 1
+                    cargo test -p crypto --quiet || exit 1
                   done
     evm_state_tests:
         name: EF EVM state tests


### PR DESCRIPTION
## What ❔

Optimize CI workflow performance with three targeted changes:

1. **Fix crypto_test recompilation loop** — The `crypto_test` job (CI critical path at ~26 min) was recompiling on every iteration of the 10x test loop because RUSTFLAGS was set inline per command. Now RUSTFLAGS is passed via `setup-rust-toolchain` and compilation is split into a dedicated `--no-run` step, so binaries are compiled once and reused 10 times.

2. **Remove duplicate tool installations** — `tests` and `test_revm_consistency` jobs installed `cargo-binutils`, `llvm-tools-preview`, and `rust-src` twice (in both Setup and Compile steps). `evm_state_tests` had a redundant `rustup toolchain install` and unused `cargo install cargo-binutils`. All duplicates removed.

3. **Separate tool installation from RISC-V compilation** — In `e2e_prove`, `eth_stf_run`, `run_fuzzer_regressions` (ci.yml) and `vm-benchmarks` (bench.yml), tool installation is now in a dedicated Setup step. The bench workflow's "Recompile for RISC-V" step no longer redundantly reinstalls all tools.

## Why ❔

The `crypto_test` job was the CI critical path bottleneck at ~26 minutes, making the entire CI take ~27.5 min wall-clock. The bulk of that time was spent recompiling rather than running tests. With these changes, the CI critical path should drop significantly (crypto_test should take ~5 min instead of ~26 min).

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.