### PR TITLE
chore(tests): add coverage tooling with per-crate reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ tests/instances/**/*.bench
 bench_results/
 bench_scripts/__pycache__/
 
+coverage_results/
+coverage_scripts/__pycache__/
+
 .DS_Store
 .idea

--- a/coverage_scripts/coverage.sh
+++ b/coverage_scripts/coverage.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RESULTS_DIR="$REPO_ROOT/coverage_results"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Crates whose tests fail to compile locally or require unavailable resources:
+#   evm_interpreter: no_std crate, tests use std::alloc::Global
+#   basic_system: dev-dependency on reqwest pulls in openssl-sys
+#   multiblock_batch_tests: requires pre-built RISC-V binary (for_tests.bin)
+EXCLUDE_FROM_TESTS=(
+    evm_interpreter
+    basic_system
+    multiblock_batch_tests
+)
+
+# Tests with pre-existing failures that must be skipped to avoid aborting
+# the entire test suite. These are known issues on the dev branch:
+#   has_upgrade_tx: stack overflow in basic_bootloader batch_data tests
+SKIP_TESTS=(
+    has_upgrade_tx
+)
+
+usage() {
+    cat <<'EOF'
+Usage: coverage_scripts/coverage.sh <command> [options]
+
+Commands:
+  summary            Collect coverage and show per-crate summary table
+  html               Collect coverage and generate HTML report
+  lcov               Collect coverage and generate LCOV file
+  all                Collect coverage and generate all report formats
+  report [format]    Re-generate report from last run (summary|html|lcov)
+
+Options:
+  --open             Open HTML report in browser after generating (html/all only)
+
+Results are saved to coverage_results/ at the repo root.
+
+Prerequisites:
+  cargo install cargo-llvm-cov
+  rustup component add llvm-tools-preview
+EOF
+    exit 1
+}
+
+check_prerequisites() {
+    if ! cargo llvm-cov --version &>/dev/null; then
+        echo "Error: cargo-llvm-cov is not installed."
+        echo ""
+        echo "Install with:"
+        echo "  cargo install cargo-llvm-cov"
+        echo "  rustup component add llvm-tools-preview"
+        exit 1
+    fi
+}
+
+build_exclude_args() {
+    local args=()
+    for pkg in "${EXCLUDE_FROM_TESTS[@]}"; do
+        args+=(--exclude "$pkg")
+    done
+    echo "${args[@]}"
+}
+
+# Regex to exclude test infrastructure source files from coverage reports.
+# These directories contain test harnesses and test instances, not production code.
+# The pattern matches the directory component in both absolute and relative paths.
+IGNORE_REGEX="/tests/"
+
+collect_coverage() {
+    mkdir -p "$RESULTS_DIR"
+    local exclude_args
+    exclude_args=$(build_exclude_args)
+
+    echo "==> Cleaning previous coverage data..."
+    cargo llvm-cov clean --workspace 2>/dev/null || true
+
+    local skip_args=()
+    for pattern in "${SKIP_TESTS[@]}"; do
+        skip_args+=(--skip "$pattern")
+    done
+
+    echo "==> Running tests and collecting coverage data..."
+    echo "    (excluded from tests: ${EXCLUDE_FROM_TESTS[*]})"
+    echo "    (skipping tests: ${SKIP_TESTS[*]})"
+    # --no-fail-fast: continue running tests even if some crates fail, so
+    # coverage data from passing crates is still collected.
+    # shellcheck disable=SC2086
+    cargo llvm-cov --no-report --no-fail-fast --workspace $exclude_args \
+        --features rig/no_print \
+        -- "${skip_args[@]}" 2>&1 || true
+    echo "==> Coverage data collected."
+}
+
+report_summary() {
+    echo "==> Generating per-crate coverage summary..."
+    cargo llvm-cov report --json \
+        --ignore-filename-regex "$IGNORE_REGEX" \
+        > "$RESULTS_DIR/coverage.json" 2>/dev/null
+
+    python3 "$SCRIPT_DIR/parse_coverage.py" \
+        --workspace-root "$REPO_ROOT" \
+        "$RESULTS_DIR/coverage.json"
+
+    echo ""
+    echo "JSON data: $RESULTS_DIR/coverage.json"
+}
+
+report_html() {
+    echo "==> Generating HTML coverage report..."
+    cargo llvm-cov report --html \
+        --output-dir "$RESULTS_DIR/html" \
+        --ignore-filename-regex "$IGNORE_REGEX" 2>/dev/null
+
+    echo "HTML report: $RESULTS_DIR/html/index.html"
+}
+
+report_lcov() {
+    echo "==> Generating LCOV coverage file..."
+    cargo llvm-cov report --lcov \
+        --output-path "$RESULTS_DIR/lcov.info" \
+        --ignore-filename-regex "$IGNORE_REGEX" 2>/dev/null
+
+    echo "LCOV file: $RESULTS_DIR/lcov.info"
+}
+
+OPEN_BROWSER=false
+CMD="${1:-}"
+shift || true
+
+# Parse remaining flags
+for arg in "$@"; do
+    case "$arg" in
+        --open) OPEN_BROWSER=true ;;
+        summary|html|lcov) CMD_ARG="$arg" ;;
+        *) echo "Unknown argument: $arg"; usage ;;
+    esac
+done
+
+open_html_if_requested() {
+    if [ "$OPEN_BROWSER" = true ] && [ -f "$RESULTS_DIR/html/index.html" ]; then
+        if command -v xdg-open &>/dev/null; then
+            xdg-open "$RESULTS_DIR/html/index.html"
+        elif command -v open &>/dev/null; then
+            open "$RESULTS_DIR/html/index.html"
+        else
+            echo "(Could not detect browser opener — open the HTML file manually)"
+        fi
+    fi
+}
+
+case "$CMD" in
+    summary)
+        check_prerequisites
+        collect_coverage
+        report_summary
+        ;;
+    html)
+        check_prerequisites
+        collect_coverage
+        report_html
+        open_html_if_requested
+        ;;
+    lcov)
+        check_prerequisites
+        collect_coverage
+        report_lcov
+        ;;
+    all)
+        check_prerequisites
+        collect_coverage
+        report_summary
+        report_html
+        report_lcov
+        open_html_if_requested
+        ;;
+    report)
+        check_prerequisites
+        case "${CMD_ARG:-summary}" in
+            summary) report_summary ;;
+            html)
+                report_html
+                open_html_if_requested
+                ;;
+            lcov) report_lcov ;;
+            *) echo "Unknown report format: ${CMD_ARG:-}"; usage ;;
+        esac
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/coverage_scripts/coverage.sh
+++ b/coverage_scripts/coverage.sh
@@ -67,7 +67,7 @@ build_exclude_args() {
 # Regex to exclude test infrastructure source files from coverage reports.
 # These directories contain test harnesses and test instances, not production code.
 # The pattern matches the directory component in both absolute and relative paths.
-IGNORE_REGEX="/tests/"
+IGNORE_REGEX="/(tests|scripts)/"
 
 collect_coverage() {
     mkdir -p "$RESULTS_DIR"
@@ -87,18 +87,27 @@ collect_coverage() {
     echo "    (skipping tests: ${SKIP_TESTS[*]})"
     # --no-fail-fast: continue running tests even if some crates fail, so
     # coverage data from passing crates is still collected.
+    # Note: we intentionally do NOT pass --features rig/no_print because
+    # the workspace contains many crates that don't depend on 'rig', and
+    # Cargo rejects unknown features when used with --workspace.
     # shellcheck disable=SC2086
+    local test_exit=0
     cargo llvm-cov --no-report --no-fail-fast --workspace $exclude_args \
-        --features rig/no_print \
-        -- "${skip_args[@]}" 2>&1 || true
-    echo "==> Coverage data collected."
+        -- "${skip_args[@]}" 2>&1 || test_exit=$?
+
+    if [ "$test_exit" -ne 0 ]; then
+        echo "==> Warning: test run exited with status $test_exit (some tests may have failed)."
+        echo "    Coverage data from passing tests was still collected."
+    else
+        echo "==> Coverage data collected successfully."
+    fi
 }
 
 report_summary() {
     echo "==> Generating per-crate coverage summary..."
     cargo llvm-cov report --json \
         --ignore-filename-regex "$IGNORE_REGEX" \
-        > "$RESULTS_DIR/coverage.json" 2>/dev/null
+        > "$RESULTS_DIR/coverage.json"
 
     python3 "$SCRIPT_DIR/parse_coverage.py" \
         --workspace-root "$REPO_ROOT" \
@@ -112,7 +121,7 @@ report_html() {
     echo "==> Generating HTML coverage report..."
     cargo llvm-cov report --html \
         --output-dir "$RESULTS_DIR/html" \
-        --ignore-filename-regex "$IGNORE_REGEX" 2>/dev/null
+        --ignore-filename-regex "$IGNORE_REGEX"
 
     echo "HTML report: $RESULTS_DIR/html/index.html"
 }
@@ -121,7 +130,7 @@ report_lcov() {
     echo "==> Generating LCOV coverage file..."
     cargo llvm-cov report --lcov \
         --output-path "$RESULTS_DIR/lcov.info" \
-        --ignore-filename-regex "$IGNORE_REGEX" 2>/dev/null
+        --ignore-filename-regex "$IGNORE_REGEX"
 
     echo "LCOV file: $RESULTS_DIR/lcov.info"
 }

--- a/coverage_scripts/parse_coverage.py
+++ b/coverage_scripts/parse_coverage.py
@@ -19,12 +19,11 @@ import argparse
 import json
 import os
 import sys
-from pathlib import Path
 
 
 # Workspace member directory prefixes that contain test infrastructure,
 # not production code. These are excluded from the coverage summary.
-TEST_INFRA_PREFIXES = ("tests/", "scripts/")
+TEST_INFRA_PREFIXES = ("tests", "scripts")
 
 
 def load_workspace_members(
@@ -65,7 +64,7 @@ def load_workspace_members(
         label = member.rstrip("/").split("/")[-1]
         prefix = member.rstrip("/") + "/"
 
-        if any(member.startswith(tip) for tip in TEST_INFRA_PREFIXES):
+        if any(member == tip or member.startswith(tip + "/") for tip in TEST_INFRA_PREFIXES):
             test_infra.append((prefix, label))
         else:
             production.append((prefix, label))
@@ -84,11 +83,14 @@ def map_file_to_crate(
     norm = filename.replace("\\", "/")
 
     for prefix, label in members:
-        if prefix in norm:
-            # Find the prefix position and check it starts at a path boundary
-            idx = norm.find(prefix)
-            if idx >= 0:
-                return label
+        idx = norm.find(prefix)
+        if idx < 0:
+            continue
+        # Ensure the match starts at a path boundary (start of string or
+        # preceded by '/') to avoid substring mismatches, e.g. "api/" in
+        # "some_api/".
+        if idx == 0 or norm[idx - 1] == "/":
+            return label
 
     return "(other)"
 

--- a/coverage_scripts/parse_coverage.py
+++ b/coverage_scripts/parse_coverage.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Parse cargo-llvm-cov JSON output into a per-crate coverage summary table.
+
+Usage:
+    python3 parse_coverage.py [--workspace-root DIR] coverage.json
+
+The JSON file is the output of:
+    cargo llvm-cov report --json > coverage.json
+
+The script maps each source file to its containing workspace crate by matching
+the file path against crate directory prefixes. Files that don't belong to any
+known crate are grouped under "(other)".
+
+Output is a Markdown table sorted by line coverage percentage (ascending),
+making it easy to spot under-tested crates.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+# Workspace member directory prefixes that contain test infrastructure,
+# not production code. These are excluded from the coverage summary.
+TEST_INFRA_PREFIXES = ("tests/", "scripts/")
+
+
+def load_workspace_members(
+    workspace_root: str,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Read Cargo.toml to discover workspace member directories.
+
+    Returns two lists of (directory_prefix, crate_label) tuples, sorted
+    longest-prefix-first so that nested crates match before their parents:
+      1. Production crates
+      2. Test infrastructure crates (under tests/, scripts/)
+    """
+    import re
+
+    cargo_toml = os.path.join(workspace_root, "Cargo.toml")
+    with open(cargo_toml) as f:
+        content = f.read()
+
+    # Extract the members array from [workspace] section.
+    # This is a simple parser — it looks for `members = [...]` and extracts
+    # quoted strings. It does not handle full TOML semantics.
+    match = re.search(r"members\s*=\s*\[([^\]]*)\]", content, re.DOTALL)
+    if not match:
+        print("Warning: could not parse workspace members from Cargo.toml", file=sys.stderr)
+        return [], []
+
+    members_block = match.group(1)
+    members = re.findall(r'"([^"]+)"', members_block)
+
+    # Build (prefix, label) pairs. The prefix is the directory path with a
+    # trailing slash so that "basic_system/" doesn't match "basic_system_hooks/".
+    production = []
+    test_infra = []
+    for member in members:
+        # Normalise path separators
+        member = member.strip().replace("\\", "/")
+        # Use the last path component as the crate label
+        label = member.rstrip("/").split("/")[-1]
+        prefix = member.rstrip("/") + "/"
+
+        if any(member.startswith(tip) for tip in TEST_INFRA_PREFIXES):
+            test_infra.append((prefix, label))
+        else:
+            production.append((prefix, label))
+
+    # Sort longest prefix first for correct matching of nested crates
+    production.sort(key=lambda x: -len(x[0]))
+    test_infra.sort(key=lambda x: -len(x[0]))
+    return production, test_infra
+
+
+def map_file_to_crate(
+    filename: str, members: list[tuple[str, str]]
+) -> str:
+    """Map a source file path to its containing crate label."""
+    # Normalise the path (llvm-cov may emit absolute or relative paths)
+    norm = filename.replace("\\", "/")
+
+    for prefix, label in members:
+        if prefix in norm:
+            # Find the prefix position and check it starts at a path boundary
+            idx = norm.find(prefix)
+            if idx >= 0:
+                return label
+
+    return "(other)"
+
+
+def parse_coverage(json_path: str, workspace_root: str) -> None:
+    with open(json_path) as f:
+        data = json.load(f)
+
+    production_members, _test_members = load_workspace_members(workspace_root)
+    # Only map files against production crates; test infrastructure is excluded
+    members = production_members
+
+    # Aggregate per-crate: {label: {lines_count, lines_covered, fn_count, fn_covered}}
+    crates: dict[str, dict[str, int]] = {}
+
+    for export in data.get("data", []):
+        for file_entry in export.get("files", []):
+            filename = file_entry.get("filename", "")
+            summary = file_entry.get("summary", {})
+
+            lines = summary.get("lines", {})
+            functions = summary.get("functions", {})
+
+            label = map_file_to_crate(filename, members)
+
+            if label not in crates:
+                crates[label] = {
+                    "lines_count": 0,
+                    "lines_covered": 0,
+                    "fn_count": 0,
+                    "fn_covered": 0,
+                }
+
+            crates[label]["lines_count"] += lines.get("count", 0)
+            crates[label]["lines_covered"] += lines.get("covered", 0)
+            crates[label]["fn_count"] += functions.get("count", 0)
+            crates[label]["fn_covered"] += functions.get("covered", 0)
+
+    if not crates:
+        print("No coverage data found.")
+        return
+
+    # Remove "(other)" if empty
+    if "(other)" in crates and crates["(other)"]["lines_count"] == 0:
+        del crates["(other)"]
+
+    # Sort by line coverage percentage ascending (lowest coverage first)
+    def sort_key(item: tuple[str, dict[str, int]]) -> tuple[float, str]:
+        label, stats = item
+        pct = (
+            (stats["lines_covered"] / stats["lines_count"] * 100)
+            if stats["lines_count"] > 0
+            else 0.0
+        )
+        return (pct, label)
+
+    sorted_crates = sorted(crates.items(), key=sort_key)
+
+    # Compute totals
+    total_lines = sum(s["lines_count"] for _, s in sorted_crates)
+    total_lines_covered = sum(s["lines_covered"] for _, s in sorted_crates)
+    total_fns = sum(s["fn_count"] for _, s in sorted_crates)
+    total_fns_covered = sum(s["fn_covered"] for _, s in sorted_crates)
+
+    # Print table
+    print("")
+    print("## Per-Crate Coverage Summary")
+    print("")
+    print(
+        f"| {'Crate':<30} | {'Lines':>7} | {'Covered':>7} | {'Line %':>7} "
+        f"| {'Functions':>9} | {'Covered':>7} | {'Fn %':>7} |"
+    )
+    print(
+        f"|{'-' * 32}|{'-' * 9}|{'-' * 9}|{'-' * 9}"
+        f"|{'-' * 11}|{'-' * 9}|{'-' * 9}|"
+    )
+
+    for label, stats in sorted_crates:
+        line_pct = (
+            stats["lines_covered"] / stats["lines_count"] * 100
+            if stats["lines_count"] > 0
+            else 0.0
+        )
+        fn_pct = (
+            stats["fn_covered"] / stats["fn_count"] * 100
+            if stats["fn_count"] > 0
+            else 0.0
+        )
+        print(
+            f"| {label:<30} | {stats['lines_count']:>7} | {stats['lines_covered']:>7} "
+            f"| {line_pct:>6.1f}% | {stats['fn_count']:>9} | {stats['fn_covered']:>7} "
+            f"| {fn_pct:>6.1f}% |"
+        )
+
+    # Totals row
+    total_line_pct = (
+        total_lines_covered / total_lines * 100 if total_lines > 0 else 0.0
+    )
+    total_fn_pct = (
+        total_fns_covered / total_fns * 100 if total_fns > 0 else 0.0
+    )
+    print(
+        f"|{'-' * 32}|{'-' * 9}|{'-' * 9}|{'-' * 9}"
+        f"|{'-' * 11}|{'-' * 9}|{'-' * 9}|"
+    )
+    print(
+        f"| {'TOTAL':<30} | {total_lines:>7} | {total_lines_covered:>7} "
+        f"| {total_line_pct:>6.1f}% | {total_fns:>9} | {total_fns_covered:>7} "
+        f"| {total_fn_pct:>6.1f}% |"
+    )
+    print("")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parse cargo-llvm-cov JSON into per-crate coverage table"
+    )
+    parser.add_argument("json_file", help="Path to coverage.json")
+    parser.add_argument(
+        "--workspace-root",
+        default=".",
+        help="Path to workspace root (default: current directory)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.json_file):
+        print(f"Error: {args.json_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    parse_coverage(args.json_file, args.workspace_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/running_tests.md
+++ b/docs/running_tests.md
@@ -44,6 +44,38 @@ Both fuzzing strategies are executed on a daily basis as part of our testing pip
  - Fuzzing of the primitives runs daily using [GitHub Actions](../.github/workflows/fuzz.yml) 
  - Metamorphic testing runs continuously in our cloud-based test infrastructure for deeper, longer fuzzing sessions.
 
+## Code coverage
+
+The [`coverage_scripts/`](../coverage_scripts/) directory contains tooling for generating per-crate code coverage reports using [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov).
+
+Prerequisites (one-time):
+```bash
+cargo install cargo-llvm-cov
+rustup component add llvm-tools-preview
+```
+
+Run tests and show a per-crate coverage summary table:
+```bash
+coverage_scripts/coverage.sh summary
+```
+
+Generate an HTML report for file-level drill-down:
+```bash
+coverage_scripts/coverage.sh html --open
+```
+
+Generate an LCOV file (for external tooling or CI):
+```bash
+coverage_scripts/coverage.sh lcov
+```
+
+Re-generate a report from the last test run without re-running tests:
+```bash
+coverage_scripts/coverage.sh report html
+```
+
+Results are saved to `coverage_results/` (gitignored). Some crates are excluded from the test run due to local compilation issues (`evm_interpreter`, `basic_system`), but their code is still covered when exercised by integration tests from other packages.
+
 ## EVM tester
 
 The in-repo [`tests/evm_tester`](../tests/evm_tester/) crate is used to parse and run the [EVM execution spec tests](https://github.com/ethereum/execution-spec-tests) compiled by the Ethereum Foundation.

--- a/docs/running_tests.md
+++ b/docs/running_tests.md
@@ -74,7 +74,7 @@ Re-generate a report from the last test run without re-running tests:
 coverage_scripts/coverage.sh report html
 ```
 
-Results are saved to `coverage_results/` (gitignored). Some crates are excluded from the test run due to local compilation issues (`evm_interpreter`, `basic_system`), but their code is still covered when exercised by integration tests from other packages.
+Results are saved to `coverage_results/` (gitignored). Some crates are excluded from the test run due to local compilation issues (`evm_interpreter`, `basic_system`) or missing resources (`multiblock_batch_tests`, which requires a pre-built RISC-V binary), but their code is still covered when exercised by integration tests from other packages.
 
 ## EVM tester
 


### PR DESCRIPTION
## What ❔

Add `coverage_scripts/` directory with `cargo-llvm-cov`-based tooling for generating per-crate code coverage reports. Includes:

- `coverage.sh` — shell script with subcommands for collecting coverage and generating reports (summary table, HTML, LCOV)
- `parse_coverage.py` — Python script that parses JSON coverage data into a per-crate Markdown table sorted by coverage percentage (lowest first)
- Documentation in `docs/running_tests.md` with usage instructions
- `coverage_results/` added to `.gitignore`

The tooling handles known compilation issues by excluding problematic crates from the test run (`evm_interpreter`, `basic_system`, `multiblock_batch_tests`) and skipping pre-existing failing tests (`has_upgrade_tx` stack overflow). Coverage data for excluded crates is still collected when their code is exercised by integration tests.

## Why ❔

Per-crate coverage reports help identify testing gaps across the workspace. A single overall coverage percentage is not meaningful for this project given the different natures of its crates (no_std proving targets, test infrastructure, etc.). The per-crate breakdown makes it easy to spot which production crates need more testing attention.

CI integration is intentionally left out — this PR provides the local tooling foundation that can be plugged into CI separately.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.