### PR TITLE
feat(system): add keccak256 cache to optimize L1Messenger hash computation

### DIFF
--- a/basic_system/src/system_implementation/system/io_subsystem.rs
+++ b/basic_system/src/system_implementation/system/io_subsystem.rs
@@ -56,6 +56,10 @@ pub struct FullIO<
     pub oracle: O,
     pub tx_number: u32,
     pub da_commitment_scheme: Option<DACommitmentScheme>,
+    /// Single-entry keccak256 cache: stores (input_data, hash) from the most recent
+    /// `emit_l1_message` call so the subsequent SHA3 opcode on the same data can
+    /// skip recomputation.
+    pub keccak_cache: Option<(UsizeAlignedByteBox<A>, Bytes32)>,
 }
 
 pub struct FullIOStateSnapshot<M: StorageModel> {
@@ -221,6 +225,12 @@ impl<
         // (the L1Messenger system contract charges it before invoking the hook).
         use crypto::MiniDigest;
         let data_hash = Bytes32::from_array(crypto::sha3::Keccak256::digest(data));
+
+        // Cache (data, hash) so the subsequent SHA3 opcode on the same data can
+        // skip recomputation.
+        let cache_data = UsizeAlignedByteBox::from_slice_in(data, self.allocator.clone());
+        self.keccak_cache = Some((cache_data, data_hash));
+
         let data = UsizeAlignedByteBox::from_slice_in(data, self.allocator.clone());
         self.logs_storage
             .push_message(self.tx_number, address, data, data_hash)?;
@@ -464,6 +474,25 @@ impl<
     fn get_refund_counter(&'_ self) -> &'_ Self::Resources {
         self.storage.get_refund_counter()
     }
+
+    fn check_keccak_cache(
+        &mut self,
+        data: &[u8],
+        resources: &mut Self::Resources,
+    ) -> Result<Option<Bytes32>, SystemError> {
+        if let Some((ref cached_data, cached_hash)) = self.keccak_cache {
+            if cached_data.as_slice() == data {
+                let hash = cached_hash;
+                // Charge same resources as keccak256 computation would
+                let ergs_cost = evm_interpreter::keccak256_ergs_cost(data.len());
+                let native_cost = keccak256_native_cost::<Self::Resources>(data.len());
+                resources.charge(&R::from_ergs_and_native(ergs_cost, native_cost))?;
+                self.keccak_cache = None;
+                return Ok(Some(hash));
+            }
+        }
+        Ok(None)
+    }
 }
 
 impl<
@@ -513,6 +542,7 @@ impl<
             tx_number: 0u32,
             da_commitment_scheme,
             new_settlement_layer_chain_id_storage,
+            keccak_cache: None,
         };
 
         Ok(new)
@@ -527,6 +557,7 @@ impl<
         self.transient_storage.begin_new_tx();
         self.logs_storage.begin_new_tx();
         self.events_storage.begin_new_tx();
+        self.keccak_cache = None;
     }
 
     fn finish_tx(&mut self) -> Result<(), InternalError> {

--- a/evm_interpreter/src/instructions/system.rs
+++ b/evm_interpreter/src/instructions/system.rs
@@ -5,7 +5,7 @@ use crate::gas::gas_utils;
 use super::*;
 use native_resource_constants::*;
 use zk_ee::memory::U256Builder;
-use zk_ee::system::{EthereumLikeTypes, SystemFunctions};
+use zk_ee::system::{EthereumLikeTypes, IOSubsystem, SystemFunctions};
 
 impl<S: EthereumLikeTypes> Interpreter<'_, S> {
     const EMPTY_SLICE_SHA3: U256 = U256::from_limbs([
@@ -30,28 +30,42 @@ impl<S: EthereumLikeTypes> Interpreter<'_, S> {
 
             self.resize_heap(memory_offset, len)?;
 
-            let allocator = system.get_allocator();
             let input = &self.heap[memory_offset..(memory_offset + len)];
 
-            let mut dst = U256Builder::default();
-            S::SystemFunctions::keccak256(&input, &mut dst, self.gas.resources_mut(), allocator)
+            // Check keccak cache for a precomputed result (e.g. from emit_l1_message)
+            if let Some(cached_hash) = system
+                .io
+                .check_keccak_cache(input, self.gas.resources_mut())?
+            {
+                U256::from_be_bytes(cached_hash.as_u8_array())
+            } else {
+                let allocator = system.get_allocator();
+
+                let mut dst = U256Builder::default();
+                S::SystemFunctions::keccak256(
+                    &input,
+                    &mut dst,
+                    self.gas.resources_mut(),
+                    allocator,
+                )
                 .map_err(SystemError::from)?;
 
-            let hash = dst.build();
+                let hash = dst.build();
 
-            if Self::PRINT_OPCODES {
-                use core::fmt::Write;
-                use zk_ee::logger_log;
-                use zk_ee::system::logger::Logger;
-                let mut logger = system.get_logger();
-                let input = &self.heap()[memory_offset..(memory_offset + len)];
-                let input_iter = input.iter().copied();
-                logger_log!(logger, " input: ",);
-                let _ = logger.log_data(input_iter);
-                logger_log!(logger, " -> 0x{hash:0x}");
+                if Self::PRINT_OPCODES {
+                    use core::fmt::Write;
+                    use zk_ee::logger_log;
+                    use zk_ee::system::logger::Logger;
+                    let mut logger = system.get_logger();
+                    let input = &self.heap()[memory_offset..(memory_offset + len)];
+                    let input_iter = input.iter().copied();
+                    logger_log!(logger, " input: ",);
+                    let _ = logger.log_data(input_iter);
+                    logger_log!(logger, " -> 0x{hash:0x}");
+                }
+
+                hash
             }
-
-            hash
         };
 
         self.stack.push(&hash)

--- a/system_hooks/src/call_hooks/l1_messenger.rs
+++ b/system_hooks/src/call_hooks/l1_messenger.rs
@@ -150,8 +150,6 @@ pub(crate) fn send_to_l1_inner<S: EthereumLikeTypes>(
 
     let message = &calldata[20..];
 
-    // emit L1 message (ignore returned hash)
-    // TODO(EVM-1190): hash calculation is suboptimal, to be refactored in future
     system.io.emit_l1_message(
         // Gas should be charged by the L1Messenger system contract
         ExecutionEnvironmentType::NoEE,

--- a/zk_ee/src/system/io.rs
+++ b/zk_ee/src/system/io.rs
@@ -177,6 +177,19 @@ pub trait IOSubsystem: Sized {
 
     /// Get current gas refund counter
     fn get_refund_counter(&'_ self) -> &'_ Self::Resources;
+
+    /// Check the keccak256 cache for a precomputed result matching `data`.
+    /// If found, charges the same resources as computing keccak256 would,
+    /// consumes the cache entry, and returns `Ok(Some(hash))`.
+    /// Returns `Ok(None)` if no cache entry matches.
+    /// Default: no caching, always returns `Ok(None)`.
+    fn check_keccak_cache(
+        &mut self,
+        _data: &[u8],
+        _resources: &mut Self::Resources,
+    ) -> Result<Option<Bytes32>, SystemError> {
+        Ok(None)
+    }
 }
 
 pub trait Maybe<T> {


### PR DESCRIPTION
## What ❔

Add a system-level keccak256 cache to the IO subsystem that avoids duplicate hash computation. When `emit_l1_message` computes `keccak256(data)`, the result is cached as a single-entry `(data, hash)` pair. When the EVM SHA3 opcode is subsequently called on the same data, the cached hash is returned directly instead of recomputing.

Changes:
- `IOSubsystem` trait: new `check_keccak_cache` method with default no-op implementation
- `FullIO`: `keccak_cache` field storing `Option<(UsizeAlignedByteBox, Bytes32)>`
- `emit_l1_message`: caches `(data, hash)` after computing keccak256
- SHA3 opcode handler: checks cache before calling keccak256, charges identical resources on hit
- Cache cleared on transaction boundaries (`begin_next_tx`)

## Why ❔

The L1Messenger hook computes `keccak256(message)` inside `emit_l1_message`, then the L1Messenger system contract recomputes SHA3 on the same data via the EVM opcode. This double computation is wasteful, especially in proving mode where each keccak round costs ~17,500 native cycles. The cache eliminates the redundant computation while maintaining identical resource charging for deterministic cost accounting.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.