### PR TITLE
fix: reject non-strict RLP encodings for list lengths

### DIFF
--- a/basic_bootloader/src/bootloader/transaction/rlp_encoded/rlp/minimal_rlp_parser.rs
+++ b/basic_bootloader/src/bootloader/transaction/rlp_encoded/rlp/minimal_rlp_parser.rs
@@ -64,6 +64,10 @@ impl<'a> Rlp<'a> {
         if s.len() > 4 {
             return Err(InvalidTransaction::InvalidStructure);
         }
+        // Reject leading zeros
+        if s.len() >= 1 && s[0] == 0 {
+            return Err(InvalidTransaction::InvalidStructure);
+        }
         let mut v: u32 = 0;
         for &b in s {
             v = (v << 8) | b as u32;
@@ -601,5 +605,15 @@ mod tests {
 
         let mut rlp = Rlp::new(&[0x82, 0x00, 0x01]); // Represents 1 with leading zero
         assert!(rlp.u256().is_err());
+
+        let mut long_string = vec![0xba, 0x00, 0x38]; // Long-form length for 56 with a leading zero
+        long_string.extend_from_slice(&[0x80; 56]);
+        let mut rlp = Rlp::new(&long_string);
+        assert!(rlp.bytes().is_err());
+
+        let mut long_list = vec![0xf9, 0x00, 0x38]; // Long-form list length for 56 with a leading zero
+        long_list.extend_from_slice(&[0xc0; 56]);
+        let mut rlp = Rlp::new(&long_list);
+        assert!(rlp.list().is_err());
     }
 }

--- a/basic_bootloader/src/bootloader/transaction/rlp_encoded/rlp/minimal_rlp_parser.rs
+++ b/basic_bootloader/src/bootloader/transaction/rlp_encoded/rlp/minimal_rlp_parser.rs
@@ -606,7 +606,7 @@ mod tests {
         let mut rlp = Rlp::new(&[0x82, 0x00, 0x01]); // Represents 1 with leading zero
         assert!(rlp.u256().is_err());
 
-        let mut long_string = vec![0xba, 0x00, 0x38]; // Long-form length for 56 with a leading zero
+        let mut long_string = vec![0xb9, 0x00, 0x38]; // Long-form length for 56 with a leading zero
         long_string.extend_from_slice(&[0x80; 56]);
         let mut rlp = Rlp::new(&long_string);
         assert!(rlp.bytes().is_err());

--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -297,7 +297,7 @@ where
         &mut self,
         buffer_constructor: impl FnOnce(usize) -> B,
     ) -> Option<Result<(usize, B), NextTxSubsystemError>> {
-        use crate::utils::usize_rw::{SafeUsizeWritable, UsizeWriteable};
+        use crate::utils::usize_rw::{SafeUsizeWritable, UsizeWritable};
         let next_tx_len_bytes = match self.io.oracle().try_begin_next_tx() {
             Ok(maybe_next_len) => match maybe_next_len {
                 None => return None,

--- a/zk_ee/src/utils/aligned_vector.rs
+++ b/zk_ee/src/utils/aligned_vector.rs
@@ -1,4 +1,4 @@
-use crate::utils::usize_rw::{AsUsizeWritable, SafeUsizeWritable, UsizeWriteable};
+use crate::utils::usize_rw::{AsUsizeWritable, SafeUsizeWritable, UsizeWritable};
 
 use super::USIZE_SIZE;
 use core::{alloc::Allocator, mem::MaybeUninit};
@@ -198,7 +198,7 @@ pub struct UsizeSliceWriter<'a> {
     _marker: core::marker::PhantomData<&'a ()>,
 }
 
-impl<'a> UsizeWriteable for UsizeSliceWriter<'a> {
+impl<'a> UsizeWritable for UsizeSliceWriter<'a> {
     unsafe fn write_usize(&mut self, value: usize) {
         self.dst.write(MaybeUninit::new(value));
         self.dst = self.dst.add(1);
@@ -246,7 +246,7 @@ mod tests {
         allocate_vec_usize_aligned, num_usize_words_for_u8_capacity, UsizeAlignedByteBox,
         USIZE_SIZE,
     };
-    use crate::utils::usize_rw::{AsUsizeWritable, SafeUsizeWritable, UsizeWriteable};
+    use crate::utils::usize_rw::{AsUsizeWritable, SafeUsizeWritable, UsizeWritable};
 
     #[test]
     fn num_usize_words_for_u8_capacity_rounds_up_and_keeps_even_word_count() {
@@ -430,8 +430,8 @@ mod tests {
         {
             let mut writer = buffer.as_writable();
             unsafe {
-                UsizeWriteable::write_usize(&mut writer, usize::MAX);
-                UsizeWriteable::write_usize(&mut writer, 0);
+                UsizeWritable::write_usize(&mut writer, usize::MAX);
+                UsizeWritable::write_usize(&mut writer, 0);
             }
         }
 

--- a/zk_ee/src/utils/usize_rw.rs
+++ b/zk_ee/src/utils/usize_rw.rs
@@ -114,7 +114,7 @@ impl<I: ExactSizeIterator<Item = usize>> SafeUsizeReadable for ExactSizeIterRead
 ///
 /// This is an unsafe trait that provides direct access to raw data without bounds checking.
 /// Implementers must ensure the underlying data destination has sufficient space available.
-pub trait UsizeWriteable {
+pub trait UsizeWritable {
     /// Writes a single `usize` value to the underlying data destination.
     ///
     /// # Safety
@@ -124,17 +124,17 @@ pub trait UsizeWriteable {
     unsafe fn write_usize(&mut self, value: usize);
 }
 
-/// Safe wrapper around `UsizeWriteable` that provides bounds checking.
+/// Safe wrapper around `UsizeWritable` that provides bounds checking.
 ///
-/// This trait extends `UsizeWriteable` with length information and safe writing methods
+/// This trait extends `UsizeWritable` with length information and safe writing methods
 /// that return errors instead of causing undefined behavior on insufficient space.
-pub trait SafeUsizeWritable: UsizeWriteable {
+pub trait SafeUsizeWritable: UsizeWritable {
     /// Returns the number of `usize` values that can be written.
     fn len(&self) -> usize;
 
     fn try_write(&mut self, value: usize) -> Result<(), ()> {
         unsafe {
-            UsizeWriteable::write_usize(self, value); // TODO actual checking?
+            UsizeWritable::write_usize(self, value); // TODO actual checking?
         }
         Ok(())
     }
@@ -155,7 +155,7 @@ pub trait AsUsizeWritable: Sized {
         Self: 'a;
 }
 
-/// Adapter that wraps mutable iterators to implement `UsizeWriteable`.
+/// Adapter that wraps mutable iterators to implement `UsizeWritable`.
 ///
 /// This wrapper allows any iterator over mutable references to copyable types to be used
 /// as a `usize` data destination. It handles the conversion from `usize` values to the
@@ -182,7 +182,7 @@ impl<'a, T: 'static + Clone + Copy, I: Iterator<Item = &'a mut T>> From<I>
 
 // TODO: specialize in case of aligned iterator
 
-impl<'a, I: Iterator<Item = &'a mut u8>> UsizeWriteable for WriteIterWrapper<'a, u8, I> {
+impl<'a, I: Iterator<Item = &'a mut u8>> UsizeWritable for WriteIterWrapper<'a, u8, I> {
     unsafe fn write_usize(&mut self, value: usize) {
         let le_bytes = value.to_ne_bytes();
         for (src, dst) in le_bytes.into_iter().zip(&mut self.inner) {
@@ -191,7 +191,7 @@ impl<'a, I: Iterator<Item = &'a mut u8>> UsizeWriteable for WriteIterWrapper<'a,
     }
 }
 
-impl<'a, I: Iterator<Item = &'a mut usize>> UsizeWriteable for WriteIterWrapper<'a, usize, I> {
+impl<'a, I: Iterator<Item = &'a mut usize>> UsizeWritable for WriteIterWrapper<'a, usize, I> {
     unsafe fn write_usize(&mut self, value: usize) {
         *self.inner.next().unwrap_unchecked() = value;
     }


### PR DESCRIPTION
## What ❔
Enforce strict encoding of RLP lengths
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.