### PR TITLE
fix: add extra intrinsic pubdata to account for asset tracker call in simulation

### DIFF
--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -105,7 +105,7 @@ const REFUND_RECIPIENT_BALANCE_INTRINSIC_PUBDATA: u64 = 32 + 34;
 // Each storage diff is encoded as 32 bytes (derived key) + compressed value
 // diff. The worst-case compressed value using the Add strategy with a
 // 256-bit amount falls back to Nothing encoding = 33 bytes.
-const ASSET_TRACKER_INTRINSIC_PUBDATA: u64 = 32 + 33;
+pub const ASSET_TRACKER_INTRINSIC_PUBDATA: u64 = 32 + 33;
 
 // Needed to publish the L1 tx log, coinbase balance, treasury balance, refund
 // recipient balance, and asset tracker state diff.

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -740,7 +740,7 @@ where
     S::Metadata: ZkSpecificPricingMetadata
         + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
-    notify_l2_asset_tracker::<S>(
+    notify_l2_asset_tracker::<S, Config>(
         system,
         system_functions,
         memories,
@@ -838,7 +838,7 @@ where
 /// If no contract is deployed at L2AssetTracker, the call succeeds silently
 /// (a call to an empty address returns success with no returndata in EVM).
 /// However, we are certain that L2AssetTracker is available after the upgrade.
-fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a>(
+fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a, Config: BasicBootloaderExecutionConfig>(
     system: &mut System<S>,
     system_functions: &mut HooksStorage<S, S::Allocator>,
     memories: RunnerMemoryBuffers<'a>,
@@ -853,7 +853,7 @@ where
     S::Metadata: ZkSpecificPricingMetadata
         + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
-    if amount > U256::ZERO {
+    if amount > U256::ZERO || Config::SIMULATION {
         // Encode calldata for handleFinalizeBaseTokenBridgingOnL2(uint256,uint256):
         // selector 0x03117c8c + abi-encoded (fromChainId, amount)
         let mut calldata = [0u8; 68];

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -1,7 +1,7 @@
 use crate::bootloader::config::BasicBootloaderExecutionConfig;
 use crate::bootloader::constants::{
-    FREE_L1_TX_NATIVE_PER_GAS, L1_TX_INTRINSIC_L2_GAS, L1_TX_INTRINSIC_NATIVE_COST,
-    L1_TX_INTRINSIC_PUBDATA, L1_TX_NATIVE_PRICE,
+    ASSET_TRACKER_INTRINSIC_PUBDATA, FREE_L1_TX_NATIVE_PER_GAS, L1_TX_INTRINSIC_L2_GAS,
+    L1_TX_INTRINSIC_NATIVE_COST, L1_TX_INTRINSIC_PUBDATA, L1_TX_NATIVE_PRICE,
 };
 use crate::bootloader::errors::BootloaderInterfaceError;
 use crate::bootloader::errors::TxError;
@@ -78,6 +78,24 @@ where
     // will be refunded to the user.
     let gas_per_pubdata = transaction.gas_per_pubdata_limit.read();
 
+    // It's important to ensure that the amount of pubdata estimated during
+    // transaction simulation is never less than the amount estimated
+    // during execution of the same transaction.
+    // Since the introduction of the asset tracker calls during the base token
+    // minting, the pubdata for the storage diff of the first of such calls
+    // depends indirectly on the gas price, which can fluctuate from simulation
+    // to execution.
+    // Even though the pubdata for this storage change is already considered in
+    // L1_TX_INTRINSIC_PUBDATA (for the calls related to refunds), we need to
+    // add an extra worst case when in simulation to ensure that simulation
+    // never underestimates pubdata used.
+    let extra_pubdata_for_simulation = if Config::SIMULATION {
+        ASSET_TRACKER_INTRINSIC_PUBDATA
+    } else {
+        0
+    };
+    let intrinsic_pubdata = L1_TX_INTRINSIC_PUBDATA + extra_pubdata_for_simulation;
+
     // Compute resource and fee information, making sure we handle
     // all possible validation errors carefully.
     // L1 transactions cannot be invalidated. Therefore, the following
@@ -100,6 +118,7 @@ where
         gas_limit,
         gas_price,
         gas_per_pubdata,
+        intrinsic_pubdata,
     )?;
 
     // Just used for computing native used
@@ -387,7 +406,7 @@ where
         gas_refunded: evm_refund,
         computational_native_used,
         native_used,
-        pubdata_used: pubdata_used + L1_TX_INTRINSIC_PUBDATA,
+        pubdata_used: pubdata_used + intrinsic_pubdata,
         blob_gas_used: 0,
     })
 }
@@ -423,6 +442,7 @@ fn prepare_and_check_resources<
     gas_limit: u64,
     gas_price: U256,
     gas_per_pubdata: u32,
+    intrinsic_pubdata: u64,
 ) -> Result<ResourceAndFeeInfo<S>, BootloaderSubsystemError>
 where
     S::IO: IOSubsystemExt,
@@ -489,7 +509,7 @@ where
         transaction.calldata().len() as u64,
         calldata_tokens,
         L1_TX_INTRINSIC_L2_GAS,
-        L1_TX_INTRINSIC_PUBDATA,
+        intrinsic_pubdata,
         L1_TX_INTRINSIC_NATIVE_COST,
     )?;
 

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -1678,7 +1678,7 @@ fn test_l1_simulation_zero_gas_price_gas_used_matches_execution_leftover_balance
     let base_fee = 1_000u128;
     let simulation_total_deposited = U256::from(1_000u64);
     let execution_total_deposited =
-        U256::from(gas_limit) * U256::from(base_fee) + value + U256::from(100u64);
+        U256::from(gas_limit) * U256::from(base_fee) + value + U256::from(100_000u64);
 
     let simulation_tx = L1TxBuilder::new()
         .from(from)
@@ -1750,6 +1750,18 @@ fn test_l1_simulation_zero_gas_price_gas_used_matches_execution_leftover_balance
         "Mismatch in gas used between simulation and execution"
     );
     assert!(simulation_result.pubdata_used >= execution_result.pubdata_used);
+    // Expected number of bytes simulation will overestimate for pubdata.
+    // It's important to check that the introduction of the asset tracker
+    // call doesn't increment this difference.
+    println!(
+        "sim: {}, execution {}",
+        simulation_result.pubdata_used, execution_result.pubdata_used
+    );
+    let expected_pubdata_diff_before_asset_tracker = 61;
+    assert!(
+        simulation_result.pubdata_used
+            >= execution_result.pubdata_used + expected_pubdata_diff_before_asset_tracker
+    );
 }
 
 /// Check that gas price doesn't affect gas used in simulation.


### PR DESCRIPTION
## What ❔
Add extra intrinsic pubdata to account for asset tracker call in simulation for L1 transactions
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.