### PR TITLE
chore: validate_l2_tx_intrinsic_native_resources remove intrinsic gas check

### DIFF
--- a/api/src/helpers.rs
+++ b/api/src/helpers.rs
@@ -11,13 +11,9 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy_sol_types::sol;
 use alloy_sol_types::SolCall;
 use basic_bootloader::bootloader::constants::BOOTLOADER_FORMAL_ADDRESS;
-use basic_bootloader::bootloader::constants::{
-    CALLDATA_NON_ZERO_BYTE_TOKEN_FACTOR, CALLDATA_ZERO_BYTE_TOKEN_FACTOR,
-};
 use basic_bootloader::bootloader::transaction::rlp_encoded::transaction_types::service_tx::SERVICE_TX_TYPE;
 use basic_bootloader::bootloader::transaction_flow::gas_helpers::{
     calculate_l2_tx_intrinsic_computational_native_resources, calculate_l2_tx_intrinsic_pubdata,
-    calculate_tx_intrinsic_gas,
 };
 use basic_system::system_implementation::flat_storage_model::bytecode_padding_len;
 use basic_system::system_implementation::flat_storage_model::AccountProperties;
@@ -383,10 +379,11 @@ pub fn encode_set_settlement_layer_chain_id_calldata(new_sl_chain_id: U256) -> V
 }
 
 /// Validates that a transaction provides enough gas limit and gas price
-/// to cover intrinsic resources (gas, computational native, and pubdata).
+/// to cover intrinsic native resources (computational native + pubdata).
 ///
 /// This mirrors the intrinsic-resource checks performed by the bootloader
 /// during L2 tx validation without requiring the full system infrastructure.
+/// It also validates fee fields(base_fee, native_price, max_fee_per_gas, max_priority_fee_per_gas)
 ///
 /// Please note, that it works only for Ethereum tx types (doesn't work for service txs)
 #[allow(clippy::too_many_arguments)]
@@ -396,8 +393,7 @@ pub fn validate_l2_tx_intrinsic_native_resources(
     native_price: U256,
     pubdata_price: U256,
     gas_limit: u64,
-    calldata: &[u8],
-    is_deployment: bool,
+    calldata_length: u64,
     access_list_accounts: u64,
     access_list_storage_keys: u64,
     authorization_list_num: u64,
@@ -409,29 +405,6 @@ pub fn validate_l2_tx_intrinsic_native_resources(
         return Err(());
     }
     if base_fee > max_fee_per_gas {
-        return Err(());
-    }
-
-    let calldata_length = calldata.len() as u64;
-    let calldata_tokens = {
-        let zero_bytes = calldata.iter().filter(|b| **b == 0).count() as u64;
-        let non_zero_bytes = calldata_length - zero_bytes;
-        zero_bytes
-            .saturating_mul(CALLDATA_ZERO_BYTE_TOKEN_FACTOR)
-            .saturating_add(non_zero_bytes.saturating_mul(CALLDATA_NON_ZERO_BYTE_TOKEN_FACTOR))
-    };
-
-    // Check gas limit covers intrinsic gas (bootloader rejects otherwise in
-    // create_resources_for_tx via checked_sub(intrinsic_gas))
-    let intrinsic_gas = calculate_tx_intrinsic_gas(
-        calldata_length,
-        calldata_tokens,
-        is_deployment,
-        access_list_accounts,
-        access_list_storage_keys,
-        authorization_list_num,
-    );
-    if gas_limit < intrinsic_gas {
         return Err(());
     }
 


### PR DESCRIPTION
remove intrinsic gas check from validate_l2_tx_intrinsic_native_resources

## What ❔

Remove intrinsic gas check from validate_l2_tx_intrinsic_native.

## Why ❔

This function is supposed to validate only native resources. It will be used in mempool on top of default ethereum checks(including intrinsic gas).

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.