### PR TITLE
refactor(bootloader): seed block-intrinsic pubdata/native at pre_tx_loop

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -62,6 +62,8 @@ where
         )?;
         let block_hash = Bytes32::from(block_header.hash());
         result_keeper.block_sealed(block_header);
+        result_keeper.record_block_native_used(block_data.block_computational_native_used);
+        result_keeper.record_block_pubdata_used(block_data.block_pubdata_used);
 
         let mut logger = system.get_logger();
         logger_log!(logger, "Basic header information was created\n");

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -64,6 +64,8 @@ where
         )?;
         let block_hash = Bytes32::from(block_header.hash());
         result_keeper.block_sealed(block_header);
+        result_keeper.record_block_native_used(block_data.block_computational_native_used);
+        result_keeper.record_block_pubdata_used(block_data.block_pubdata_used);
 
         let mut logger = system.get_logger();
         logger_log!(logger, "Basic header information was created\n");

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_sequencing.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_sequencing.rs
@@ -52,6 +52,8 @@ where
         )?;
         let block_hash = Bytes32::from(block_header.hash());
         result_keeper.block_sealed(block_header);
+        result_keeper.record_block_native_used(block_data.block_computational_native_used);
+        result_keeper.record_block_pubdata_used(block_data.block_pubdata_used);
 
         let mut logger = system.get_logger();
         logger_log!(logger, "Basic header information was created\n");

--- a/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
@@ -1,7 +1,10 @@
 use zk_ee::system::IOResultKeeper;
 
 use super::*;
-use crate::bootloader::block_flow::pre_tx_loop_op::PreTxLoopOp;
+use crate::bootloader::{
+    block_flow::pre_tx_loop_op::PreTxLoopOp,
+    constants::{BLOCK_INTRINSIC_NATIVE, BLOCK_INTRINSIC_PUBDATA_BYTES},
+};
 
 impl<S: EthereumLikeTypes, EA: TxHashesAccumulator> PreTxLoopOp<S> for ZKHeaderStructurePreTxOp<EA>
 where
@@ -13,7 +16,10 @@ where
         _system: &mut System<S>,
         _result_keeper: &mut impl IOResultKeeper<EthereumIOTypesConfig>,
     ) -> Self::PreTxLoopResult {
-        // Just create data keeper
-        ZKBasicBlockDataKeeper::new()
+        // Just create data keeper and set block intrinsic constants
+        let mut block_data = ZKBasicBlockDataKeeper::new();
+        block_data.block_computational_native_used = BLOCK_INTRINSIC_NATIVE;
+        block_data.block_pubdata_used = BLOCK_INTRINSIC_PUBDATA_BYTES;
+        block_data
     }
 }

--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -249,3 +249,13 @@ pub const L1_TX_INTRINSIC_PUBDATA: u64 = 88
     + TREASURY_BALANCE_INTRINSIC_PUBDATA
     + REFUND_RECIPIENT_BALANCE_INTRINSIC_PUBDATA
     + ASSET_TRACKER_INTRINSIC_PUBDATA;
+
+/// Intrinsic per-block pubdata overhead, applied to block-limit enforcement
+/// from block start. Accounts for the fixed envelope written by
+/// `write_pubdata`: 1 byte (PUBDATA_ENCODING_VERSION) + 32 bytes (block hash)
+/// + 8 bytes (timestamp).
+pub const BLOCK_INTRINSIC_PUBDATA_BYTES: u64 = 1 + 32 + 8;
+
+/// Intrinsic per-block native overhead, applied to block-limit enforcement
+/// from block start. Covers fixed pre-tx-loop system work.
+pub const BLOCK_INTRINSIC_NATIVE: u64 = 0;

--- a/basic_bootloader/src/bootloader/result_keeper.rs
+++ b/basic_bootloader/src/bootloader/result_keeper.rs
@@ -32,6 +32,10 @@ pub trait ResultKeeperExt<IOTypes: SystemIOTypesConfig>: IOResultKeeper<IOTypes>
 
     fn record_sealed_block(&mut self, _header: Self::BlockHeader) {}
 
+    fn record_block_native_used(&mut self, _native_used: u64) {}
+
+    fn record_block_pubdata_used(&mut self, _pubdata_used: u64) {}
+
     fn get_gas_used(&self) -> u64 {
         0u64
     }

--- a/forward_system/src/run/output.rs
+++ b/forward_system/src/run/output.rs
@@ -63,10 +63,10 @@ impl<TR: TxResultCallback>
             storage_writes,
             tx_results,
             new_preimages,
+            block_computational_native_used,
+            block_pubdata_used,
             ..
         } = value;
-
-        let mut block_computational_native_used = 0;
 
         // We cannot simply use `enumerate` here, because some transactions can be invalid
         // Invalid transactions are not counted in the tx_number for events/logs, so we need
@@ -88,7 +88,6 @@ impl<TR: TxResultCallback>
                         } else {
                             ExecutionResult::Revert(output.output)
                         };
-                        block_computational_native_used += output.computational_native_used;
                         let o = TxOutput {
                             gas_used: output.gas_used,
                             gas_refunded: output.gas_refunded,
@@ -143,8 +142,7 @@ impl<TR: TxResultCallback>
             account_diffs,
             published_preimages,
             computational_native_used: block_computational_native_used,
-            // TODO: will be populated in the follow-up PR
-            pubdata_used: 0,
+            pubdata_used: block_pubdata_used,
         }
     }
 }

--- a/forward_system/src/run/result_keeper.rs
+++ b/forward_system/src/run/result_keeper.rs
@@ -25,6 +25,8 @@ pub struct ForwardRunningResultKeeper<TR: TxResultCallback, T: 'static + Sized =
     >,
     pub new_preimages: Vec<(Bytes32, Vec<u8>, PreimageType)>,
     pub tx_result_callback: TR,
+    pub block_computational_native_used: u64,
+    pub block_pubdata_used: u64,
 }
 
 impl<TR: TxResultCallback, T: 'static + Sized> ForwardRunningResultKeeper<TR, T> {
@@ -37,6 +39,8 @@ impl<TR: TxResultCallback, T: 'static + Sized> ForwardRunningResultKeeper<TR, T>
             tx_results: vec![],
             new_preimages: vec![],
             tx_result_callback,
+            block_computational_native_used: 0,
+            block_pubdata_used: 0,
         }
     }
 }
@@ -111,6 +115,14 @@ impl<TR: TxResultCallback, T: 'static + Sized> ResultKeeperExt<EthereumIOTypesCo
 
     fn block_sealed(&mut self, block_header: Self::BlockHeader) {
         self.block_header = Some(block_header);
+    }
+
+    fn record_block_native_used(&mut self, native_used: u64) {
+        self.block_computational_native_used = native_used;
+    }
+
+    fn record_block_pubdata_used(&mut self, pubdata_used: u64) {
+        self.block_pubdata_used = pubdata_used;
     }
 
     fn get_gas_used(&self) -> u64 {
@@ -201,6 +213,16 @@ impl<TR: TxResultCallback, T: 'static + Sized> ResultKeeperExt<EthereumIOTypesCo
 
     fn block_sealed(&mut self, block_header: Self::BlockHeader) {
         self.forward_running_rk.block_sealed(block_header)
+    }
+
+    fn record_block_native_used(&mut self, native_used: u64) {
+        self.forward_running_rk
+            .record_block_native_used(native_used)
+    }
+
+    fn record_block_pubdata_used(&mut self, pubdata_used: u64) {
+        self.forward_running_rk
+            .record_block_pubdata_used(pubdata_used)
     }
 
     fn get_gas_used(&self) -> u64 {


### PR DESCRIPTION


## What ❔
Block-level overheads (pubdata encoding envelope, future pre-tx-loop system work) must be visible to per-tx block-limit enforcement, not only to the final reported value. Seed block_data.block_pubdata_used and block_data.block_computational_native_used with BLOCK_INTRINSIC_* constants at pre-tx-loop start so check_for_block_limits enforces the true budget.

Plumb both counters out through the result keeper via new record_block_native_used / record_block_pubdata_used hooks, so the forward path's BlockOutput.{computational_native_used, pubdata_used} are the bootloader's post-accumulation values rather than an independent per-tx sum (native) or a zero placeholder (pubdata).
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.