### PR TITLE
chore: bump airbender-platform to ff643be8

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -6,7 +6,7 @@ description: |
 inputs:
   rev:
     description: Git revision of airbender-platform to install cargo-airbender from
-    default: "097f1489"
+    default: "ff643be8"
 runs:
   using: composite
   steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,9 @@ categories = ["cryptography"]
 zksync_os_evm_errors = { version = "0.1.1", default-features =  false }
 zksync_os_interface = {  version = "0.1.1" }
 
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
-blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607", default-features = false }
-prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
+blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace", default-features = false }
+prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
 
 airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
 airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,9 +70,9 @@ riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", re
 blake2s_u32 = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607", default-features = false }
 prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
 
-airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489" }
-airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489" }
-airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489" }
+airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
+airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
+airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
 
 ruint = { version = "1.16", default-features = false }
 arrayvec = { version = "0.7", default-features = false }

--- a/circuit_test_program/Cargo.toml
+++ b/circuit_test_program/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["blockchain", "zksync", "zk", "risc-v"]
 categories = ["cryptography"]
 
 [dependencies]
-airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489" }
+airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
 crypto = { path = "../crypto", features = ["proving"]}

--- a/crypto/src/blake2s/test_program/Cargo.toml
+++ b/crypto/src/blake2s/test_program/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["blockchain", "zksync", "zk", "risc-v"]
 categories = ["cryptography"]
 
 [dependencies]
-airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489" }
+airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8" }
 crypto = { path = "../../../", features = ["blake2s_tests"]}
 
 [workspace]

--- a/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
@@ -15,7 +15,7 @@ basic_system = { package = "basic_system_forward", path = "../basic_system_forwa
 basic_bootloader = { package = "basic_bootloader_forward", path = "../basic_bootloader_forward", default-features = false }
 
 
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607", optional = true }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace", optional = true }
 num-bigint = { version = "*", optional = true }
 num-traits = { version = "*", optional = true }
 

--- a/tests/fuzzer/fuzz/wrappers/crypto_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/crypto_forward/Cargo.toml
@@ -52,7 +52,7 @@ num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 zksync_os_runner = { path = "../../../../../zksync_os_runner"}
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
 # blake2s_u32 = {path = "../../zksync-airbender/blake2s_u32", optional = true, default-features = false}
 ark-std = { version = "0.5" }
 zeroize = { version = "1", default-features = false }

--- a/tests/fuzzer/fuzz/wrappers/crypto_proving/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/crypto_proving/Cargo.toml
@@ -52,7 +52,7 @@ num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 zksync_os_runner = { path = "../../../../../zksync_os_runner"}
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }
 # blake2s_u32 = {path = "../../zksync-airbender/blake2s_u32", optional = true, default-features = false}
 ark-std = { version = "0.5" }
 zeroize = { version = "1", default-features = false }

--- a/tests/fuzzer/fuzz/wrappers/oracle_provider_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/oracle_provider_forward/Cargo.toml
@@ -8,4 +8,4 @@ path = "../../../../../oracle_provider/src/lib.rs"
 
 [dependencies]
 zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
-riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73f46c2bc86cdcefb878d6675abfcfc0eaf04607" }
+riscv_transpiler = { git = "https://github.com/matter-labs/zksync-airbender", rev = "24a74ace" }

--- a/tests/instances/eth_runner/Cargo.toml
+++ b/tests/instances/eth_runner/Cargo.toml
@@ -28,7 +28,7 @@ csv = "1.3"
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"] }
 zstd = "0.13"
 
-airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489", default-features = false }
+airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8", default-features = false }
 
 [features]
 proving = []

--- a/zksync_os/Cargo.lock
+++ b/zksync_os/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 [[package]]
 name = "blake2s_u32"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=73f46c2bc86cdcefb878d6675abfcfc0eaf04607#73f46c2bc86cdcefb878d6675abfcfc0eaf04607"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
 dependencies = [
- "common_constants 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?rev=73f46c2bc86cdcefb878d6675abfcfc0eaf04607)",
+ "common_constants",
  "unroll",
 ]
 
@@ -323,11 +323,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "common_constants"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
-
-[[package]]
-name = "common_constants"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?rev=73f46c2bc86cdcefb878d6675abfcfc0eaf04607#73f46c2bc86cdcefb878d6675abfcfc0eaf04607"
 
 [[package]]
 name = "const-hex"
@@ -857,7 +852,7 @@ name = "riscv_common"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
 dependencies = [
- "common_constants 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace)",
+ "common_constants",
  "seq-macro",
 ]
 

--- a/zksync_os/Cargo.lock
+++ b/zksync_os/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "airbender-codec"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 dependencies = [
  "bincode",
  "serde",
@@ -26,12 +26,12 @@ dependencies = [
 [[package]]
 name = "airbender-core"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 
 [[package]]
 name = "airbender-guest"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 dependencies = [
  "airbender-codec",
  "airbender-core",
@@ -42,7 +42,7 @@ dependencies = [
 [[package]]
 name = "airbender-macros"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "airbender-rt"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 dependencies = [
  "getrandom",
  "riscv_common",
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 name = "airbender-sdk"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=097f1489#097f14891ae663fc51a2312da964780c3bdafbc7"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=ff643be8#ff643be8058b0033c67945665791a1af52286092"
 dependencies = [
  "airbender-codec",
  "airbender-guest",
@@ -322,7 +322,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "common_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#591efe90f1a5f0e0cfe23ac366bf0fc221fbfe0a"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
 
 [[package]]
 name = "common_constants"
@@ -331,9 +331,9 @@ source = "git+https://github.com/matter-labs/zksync-airbender?rev=73f46c2bc86cdc
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -855,9 +855,9 @@ dependencies = [
 [[package]]
 name = "riscv_common"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#591efe90f1a5f0e0cfe23ac366bf0fc221fbfe0a"
+source = "git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace#24a74aceac0805253537c2d749b018c55cff5777"
 dependencies = [
- "common_constants 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?branch=dev)",
+ "common_constants 0.1.0 (git+https://github.com/matter-labs/zksync-airbender?rev=24a74ace)",
  "seq-macro",
 ]
 

--- a/zksync_os/Cargo.toml
+++ b/zksync_os/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "097f1489", default-features = false, features = ["allocator-custom"] }
+airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "ff643be8", default-features = false, features = ["allocator-custom"] }
 proof_running_system = { path = "../proof_running_system", default-features = false }
 crypto = { path = "../crypto", optional = true }
 


### PR DESCRIPTION
## What ❔

Bumps `airbender-platform` dependency from `097f1489` to `ff643be8` across all Cargo.toml files.

## Why ❔

Latest changes in `zksync-airbender` cause `airbender-platform` to not compile. This commit pins `zksync-airbender` in `airbender-platform`. Bench-base will still fail

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)