### PR TITLE
feat(evm_interpreter): specialize PUSH2 to skip U256 bytereverse+shift

### DIFF
--- a/evm_interpreter/src/instructions/stack.rs
+++ b/evm_interpreter/src/instructions/stack.rs
@@ -29,6 +29,22 @@ impl<S: EthereumLikeTypes> Interpreter<'_, S> {
         self.stack.push_u64(byte_val as u64)
     }
 
+    /// Specialized PUSH2: assemble a u64 from up to 2 big-endian bytes and push directly,
+    /// skipping the generic path's U256 copy + bytereverse + shift. Missing bytes at the
+    /// end of the bytecode are treated as zero (matching the generic path's right-padding).
+    pub fn push2(&mut self) -> InstructionResult {
+        self.gas
+            .spend_gas_and_native(gas_constants::VERYLOW, PUSH_NATIVE_COSTS[2])?;
+        let start = self.instruction_pointer;
+
+        let b0 = self.bytecode.get(start).copied().unwrap_or(0);
+        let b1 = self.bytecode.get(start + 1).copied().unwrap_or(0);
+        let val = ((b0 as u64) << 8) | (b1 as u64);
+
+        self.instruction_pointer += 2;
+        self.stack.push_u64(val)
+    }
+
     pub fn push<const N: usize>(&mut self) -> InstructionResult {
         self.gas
             .spend_gas_and_native(gas_constants::VERYLOW, PUSH_NATIVE_COSTS[N])?;

--- a/evm_interpreter/src/interpreter.rs
+++ b/evm_interpreter/src/interpreter.rs
@@ -199,7 +199,7 @@ impl<'ee, S: EthereumLikeTypes> Interpreter<'ee, S> {
                     opcodes::JUMPDEST => self.jumpdest(),
                     opcodes::PUSH0 => self.push0(),
                     opcodes::PUSH1 => self.push1(),
-                    opcodes::PUSH2 => self.push::<2>(),
+                    opcodes::PUSH2 => self.push2(),
                     opcodes::PUSH3 => self.push::<3>(),
                     opcodes::PUSH4 => self.push::<4>(),
                     opcodes::PUSH5 => self.push::<5>(),


### PR DESCRIPTION
## What ❔

Specialize the PUSH2 opcode in the EVM interpreter, mirroring the existing PUSH1 specialization.

The generic `push<const N: usize>()` path copies bytecode bytes into a `U256`, byte-reverses the full 32-byte value, and right-shifts off the unused high bytes. For a 2-byte payload that already fits in a `u64`, all of that is wasted work.

The new `push2()`:
- Reads up to 2 big-endian bytes from the bytecode (zero-padding missing trailing bytes, matching the generic path's right-padding semantics on truncated bytecode).
- Assembles a `u64` and pushes it directly via `EvmStack::push_u64`.
- Bypasses the U256 copy + bytereverse + shift.

Dispatch in `interpreter.rs` swaps `self.push::<2>()` for `self.push2()`.

## Why ❔

PUSH2 was the third-largest sampled opcode cost in profiling of the `custom-u256` branch (~5.2% of opcode cycles in `block_19299001`), and the structure of the work matched the PUSH1 specialization pattern already in the tree. Removing the bytereverse + shift round-trip brings PUSH2 to parity with PUSH1 in cycles, which translates to a measurable block-level reduction in proving cost.

### Benchmark

`bench_scripts/bench.sh compare`, baseline = `custom-u256` at HEAD:

| Block | Base Eff | Head Eff | Δ |
|-------|----------|----------|---|
| `block_19299001` | 210,947,355 | 208,664,035 | **−1.08%** |
| `block_22244135` | 139,404,849 | 134,713,085 | **−3.37%** |

Per-opcode (block_19299001, 107,945 PUSH2 executions):
- PUSH2 median cycles: 144 → 67 (**−48.5%**)
- PUSH2 total cycles: −7.23M (−48.8%)
- Delegations (Blake / BigInt / Keccak): unchanged
- No regressions visible on other opcodes (noise only on low-count ops)

Note: `block_23292836` fixture is missing locally so it's not in the comparison.

## Is this a breaking change?
- [ ] Yes
- [x] No

No protocol-visible behavior change. Gas and native cost charging are identical (`gas_constants::VERYLOW`, `PUSH_NATIVE_COSTS[2]`). The pushed value is bit-for-bit identical to the generic path on all inputs, including the truncated-bytecode edge case where the missing low byte is zero-padded.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
  - Existing tests cover PUSH2 behavior (Ethereum spec fixtures + interpreter rig tests). No semantic change → no new tests needed. Verified locally: `cargo test -p evm_interpreter` (13/13), `tests/instances/evm` (14/14), `tests/instances/unit` (46/46).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)