### PR TITLE
docs: add not-a-bug notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Reference docs:
 - `docs/system/system.md`
 - `docs/da_commitment_schemes.md`
 - `docs/benchmarking.md`
+- If you are looking for bugs or triaging reports, check `docs/not-a-bug.md` for expected behavior that is commonly misreported.
 
 ## Build and Test
 Prerequisites (one-time):

--- a/docs/bootloader/bootloader.md
+++ b/docs/bootloader/bootloader.md
@@ -50,7 +50,7 @@ Currently it misses `gas_per_pubdata` and `native_price`, but we already working
 | gas_used            | block gas used                                                                   | block gas used                                                     | TBD with or without pubdata             |
 | timestamp           | block timestamp                                                                  | block timestamp                                                    |                                         |
 | extra_data          | any extra data included by proposer                                              | TBD, possibly gas_per_pubdata and native price                     |                                         |
-| mix_hash            | beacon chain provided random, prevrandao (post merge)                            | 0                                                                  | after consensus will be provided random |
+| mix_hash            | beacon chain provided random, prevrandao (post merge)                            | 1                                                                  | mocked                                  |
 | nonce               | 0 (post merge)                                                                   | 0                                                                  |                                         |
 | base_fee_per_gas    | base_fee_per_gas                                                                 | base_fee_per_gas                                                   |                                         |
 

--- a/docs/not-a-bug.md
+++ b/docs/not-a-bug.md
@@ -1,0 +1,35 @@
+# Not a Bug
+
+This page lists ZKsync OS behavior that is intentional, protocol-correct, or already documented, but is commonly misreported as a vulnerability.
+
+Use this page as a triage aid, not as a substitute for checking the code. If an observed behavior differs from what is described here, investigate it normally.
+
+## EVM / Cancun Behavior
+
+### Cancun is the supported EVM hardfork
+
+ZKsync OS currently targets Cancun EVM semantics. Reports that assume later hardfork behavior are not valid unless they identify an issue under the supported hardfork.
+
+See [EVM Execution Environment](./execution_environments/evm.md).
+
+### EIP-4844 transactions are disabled in production
+
+EIP-4844 type `0x03` transactions are implemented behind the `basic_bootloader/eip-4844` feature, but this feature is not enabled by the production feature sets. It is enabled for test and Ethereum test-runner configurations.
+
+See [Transaction formats](./bootloader/transaction_format.md).
+
+### `BLOBHASH` returns `0`
+
+This is expected in production. Since EIP-4844 transactions are disabled, transactions do not have blob versioned hashes. Cancun/EIP-4844 specifies that `BLOBHASH(index)` returns a zeroed `bytes32` when `index` is outside `tx.blob_versioned_hashes`.
+
+### `BLOBBASEFEE` returns `1`
+
+This is expected in production. There are no EIP-4844 transactions in production history, so `excess_blob_gas` remains `0`. Cancun/EIP-4844 defines the minimum blob base fee as `1`, and EIP-7516 makes `BLOBBASEFEE` return the current block's blob base fee.
+
+### Opcode `0x44` returns `1`
+
+Opcode `0x44` is `PREVRANDAO` under Cancun semantics, historically named `DIFFICULTY`. ZKsync OS uses the block `mix_hash` value for this opcode. In production, `mix_hash` is mocked to `1`.
+
+This does not contradict the block header `difficulty` field being `0` after the Merge.
+
+See [Bootloader block header](./bootloader/bootloader.md#block-header).

--- a/docs/not-a-bug.md
+++ b/docs/not-a-bug.md
@@ -33,3 +33,9 @@ Opcode `0x44` is `PREVRANDAO` under Cancun semantics, historically named `DIFFIC
 This does not contradict the block header `difficulty` field being `0` after the Merge.
 
 See [Bootloader block header](./bootloader/bootloader.md#block-header).
+
+### `SUB` operand order
+
+ZKsync OS follows the standard EVM operand order for `SUB`. The top stack item is the first operand, and the item below it is the second operand. For example, `PUSH1 0x03 PUSH1 0x05 SUB` leaves `0x02` on the stack.
+
+This is not a reversed subtraction bug.

--- a/tests/evm_divergence_validator/Cargo.toml
+++ b/tests/evm_divergence_validator/Cargo.toml
@@ -36,4 +36,5 @@ rig = { path = "../rig", features = ["no_print", "unlimited_native"] }
 zksync_os_tests_common = { path = "../common" }
 zksync_os_revm_runner = { path = "../revm_runner" }
 zk_ee = { path = "../../zk_ee" }
-forward_system = { path = "../../forward_system" }
+# The validator compares against the production EVM surface, including the P-256 precompile.
+forward_system = { path = "../../forward_system", features = ["production"] }

--- a/tests/evm_divergence_validator/README.md
+++ b/tests/evm_divergence_validator/README.md
@@ -10,6 +10,7 @@ CLI tool that checks whether a given scenario produces different results on ZKsy
 ## Prerequisites
 
 - [Foundry](https://getfoundry.sh/) (`forge`) must be on PATH for Solidity compilation (not needed for `send_raw` steps with pre-compiled bytecode).
+- The validator must run with the P-256 precompile enabled. This crate enables `forward_system/production` in `Cargo.toml`, so the standard commands below include it. Do not disable this feature when preparing a bug bounty PoC.
 
 ## Usage
 

--- a/tests/evm_divergence_validator/README.md
+++ b/tests/evm_divergence_validator/README.md
@@ -194,5 +194,6 @@ The tool uses the existing REVM consistency checker from `tests/revm_runner/`, w
 ## Design notes
 
 - All steps run in a single block. Multi-block scenarios are not yet supported.
+- The validator preinstalls the L1 Messenger and L2 Base Token bytecode at their canonical ZKsync OS system addresses before applying scenario-specific state.
 - The tool enables `unlimited_native` and `independent_gas`, so ZKsync OS gas accounting follows standard EVM rules and is not overridden from ZKsync OS to REVM. The validator reports `gas_used` per step, but does not treat per-transaction gas differences as a separate divergence check — gas differences surface through balance diffs in the state comparison.
 - The REVM side uses `zksync-os-revm` (adapted REVM), which accounts for ZKsync-specific behaviors (precompile differences, fee distribution, etc.). This is intentional — divergences caught here are real bugs, not known differences.

--- a/tests/evm_divergence_validator/src/runner.rs
+++ b/tests/evm_divergence_validator/src/runner.rs
@@ -48,7 +48,9 @@ pub fn run_scenario(
     let mut run_config = RunConfig::without_riscv_run();
     run_config.disable_revm_consistency_check();
 
-    let mut tester = TestingFramework::new().with_run_config(run_config);
+    let mut tester = TestingFramework::new()
+        .with_system_contracts(true, true)
+        .with_run_config(run_config);
 
     // Fund accounts.
     for (name, def) in &scenario.accounts {


### PR DESCRIPTION
## What ❔

Adds `docs/not-a-bug.md` with common expected-behavior cases that are often misreported as bugs:
- Cancun as the supported EVM hardfork.
- Production EIP-4844 transaction disablement.
- Expected `BLOBHASH`, `BLOBBASEFEE`, and opcode `0x44` behavior.

Also fixes the bootloader block-header table to document `mix_hash` as mocked to `1`, and adds an `AGENTS.md` pointer for bug-hunting and triage.

## Why ❔

This gives auditors, agents, and bounty triagers a concise reference for protocol-correct behavior before spending time investigating already-known false positives.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated. (Docs-only change; checked with `git diff --check`.)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted. (Markdown-only change; checked with `git diff --check`.)