### PR TITLE
feat(evm_interpreter): inline JUMPDEST after JUMP/JUMPI (RISC-V only)

### DIFF
--- a/evm_interpreter/src/instructions/control_flow.rs
+++ b/evm_interpreter/src/instructions/control_flow.rs
@@ -1,14 +1,45 @@
 use super::*;
 use native_resource_constants::*;
 
+/// `true` when building for the RISC-V proving target. JUMP / JUMPI inline the
+/// JUMPDEST gas charge and skip its dispatch iteration only in this build, so
+/// the optimization is invisible to host-mode tracers (`EvmOpcodeStatsTracer`,
+/// `EvmOpcodesLogger`, etc.), which keep recording per-opcode JUMPDEST events
+/// with correct gas/native deltas. The proving target has no live tracer that
+/// keys on JUMPDEST, and `cycle_marker` measures the dispatch iteration as a
+/// whole, so dropping the iteration is the right thing there.
+const INLINE_JUMPDEST: bool = cfg!(target_arch = "riscv32");
+
 impl<S: EthereumLikeTypes> Interpreter<'_, S> {
     pub fn jump(&mut self) -> InstructionResult {
-        self.gas
-            .spend_gas_and_native(gas_constants::MID, JUMP_NATIVE_COST)?;
+        let (gas_cost, native_cost) = if INLINE_JUMPDEST {
+            (
+                gas_constants::MID + gas_constants::JUMPDEST,
+                JUMP_NATIVE_COST + JUMPDEST_NATIVE_COST,
+            )
+        } else {
+            (gas_constants::MID, JUMP_NATIVE_COST)
+        };
+        self.gas.spend_gas_and_native(gas_cost, native_cost)?;
         let dest = self.stack.pop_1()?;
         let dest = Self::cast_to_usize(dest, EvmError::InvalidJump.into())?;
         if self.bytecode_preprocessing.is_valid_jumpdest(dest) {
-            self.instruction_pointer = dest;
+            // Advance past the JUMPDEST byte on RISC-V so the dispatcher
+            // doesn't run it again; on host builds, land on `dest` so the
+            // standard JUMPDEST handler fires and the opcode-stats tracer
+            // observes a real JUMPDEST event.
+            self.instruction_pointer = if INLINE_JUMPDEST { dest + 1 } else { dest };
+            if INLINE_JUMPDEST {
+                // Emit a synthetic cycle_marker pair so the proving-side
+                // marker count balances the host-side LABELS Vec, which
+                // still pushes a JUMPDEST entry from the (unoptimized)
+                // forward dispatch. Per-opcode cycle attribution between
+                // JUMP and JUMPDEST gets scrambled because this pair is
+                // nested inside the dispatcher's JUMP bracket, but the
+                // block-level effective-cycle total is unaffected.
+                cycle_marker::opcode_start!();
+                cycle_marker::opcode_end!("JUMPDEST");
+            }
             Ok(())
         } else {
             Err(EvmError::InvalidJump.into())
@@ -22,7 +53,18 @@ impl<S: EthereumLikeTypes> Interpreter<'_, S> {
         if !value.is_zero() {
             let dest = Self::cast_to_usize(dest, EvmError::InvalidJump.into())?;
             if self.bytecode_preprocessing.is_valid_jumpdest(dest) {
-                self.instruction_pointer = dest;
+                if INLINE_JUMPDEST {
+                    // Charged separately from the JUMPI base so the
+                    // not-taken path doesn't pay JUMPDEST gas (the OOG
+                    // boundary for marginal-gas frames must not shift).
+                    self.gas
+                        .spend_gas_and_native(gas_constants::JUMPDEST, JUMPDEST_NATIVE_COST)?;
+                    self.instruction_pointer = dest + 1;
+                    cycle_marker::opcode_start!();
+                    cycle_marker::opcode_end!("JUMPDEST");
+                } else {
+                    self.instruction_pointer = dest;
+                }
             } else {
                 return Err(EvmError::InvalidJump.into());
             }
@@ -31,6 +73,9 @@ impl<S: EthereumLikeTypes> Interpreter<'_, S> {
     }
 
     pub fn jumpdest(&mut self) -> InstructionResult {
+        // On host builds this runs for every JUMP/JUMPI target. On RISC-V
+        // builds it only runs for fall-through cases (e.g. JUMPI condition
+        // false landing on a JUMPDEST byte).
         self.gas
             .spend_gas_and_native(gas_constants::JUMPDEST, JUMPDEST_NATIVE_COST)?;
         Ok(())

--- a/evm_interpreter/src/instructions/control_flow.rs
+++ b/evm_interpreter/src/instructions/control_flow.rs
@@ -12,33 +12,30 @@ const INLINE_JUMPDEST: bool = cfg!(target_arch = "riscv32");
 
 impl<S: EthereumLikeTypes> Interpreter<'_, S> {
     pub fn jump(&mut self) -> InstructionResult {
-        let (gas_cost, native_cost) = if INLINE_JUMPDEST {
-            (
-                gas_constants::MID + gas_constants::JUMPDEST,
-                JUMP_NATIVE_COST + JUMPDEST_NATIVE_COST,
-            )
-        } else {
-            (gas_constants::MID, JUMP_NATIVE_COST)
-        };
-        self.gas.spend_gas_and_native(gas_cost, native_cost)?;
+        self.gas
+            .spend_gas_and_native(gas_constants::MID, JUMP_NATIVE_COST)?;
         let dest = self.stack.pop_1()?;
         let dest = Self::cast_to_usize(dest, EvmError::InvalidJump.into())?;
         if self.bytecode_preprocessing.is_valid_jumpdest(dest) {
-            // Advance past the JUMPDEST byte on RISC-V so the dispatcher
-            // doesn't run it again; on host builds, land on `dest` so the
-            // standard JUMPDEST handler fires and the opcode-stats tracer
-            // observes a real JUMPDEST event.
-            self.instruction_pointer = if INLINE_JUMPDEST { dest + 1 } else { dest };
             if INLINE_JUMPDEST {
-                // Emit a synthetic cycle_marker pair so the proving-side
-                // marker count balances the host-side LABELS Vec, which
-                // still pushes a JUMPDEST entry from the (unoptimized)
-                // forward dispatch. Per-opcode cycle attribution between
-                // JUMP and JUMPDEST gets scrambled because this pair is
-                // nested inside the dispatcher's JUMP bracket, but the
-                // block-level effective-cycle total is unaffected.
+                // Charged separately from the JUMP base so an invalid
+                // destination doesn't pay JUMPDEST gas/native — preserves
+                // host parity on the OOG boundary for marginal-gas frames
+                // and on native resources returned after InvalidJump.
+                self.gas
+                    .spend_gas_and_native(gas_constants::JUMPDEST, JUMPDEST_NATIVE_COST)?;
+                self.instruction_pointer = dest + 1;
+                // Synthetic cycle_marker pair so the proving-side marker
+                // count balances the host-side LABELS Vec, which still
+                // pushes a JUMPDEST entry from the (unoptimized) forward
+                // dispatch. Per-opcode cycle attribution between JUMP and
+                // JUMPDEST gets scrambled because this pair nests inside
+                // the dispatcher's JUMP bracket, but the block-level
+                // effective-cycle total is unaffected.
                 cycle_marker::opcode_start!();
                 cycle_marker::opcode_end!("JUMPDEST");
+            } else {
+                self.instruction_pointer = dest;
             }
             Ok(())
         } else {


### PR DESCRIPTION
## What

JUMP/JUMPI already validate the target byte is a `JUMPDEST`. The standalone JUMPDEST dispatch iteration that follows is then redundant — it only adds 1 gas + `JUMPDEST_NATIVE_COST` and an `Ok(())`.

This PR folds that work into JUMP/JUMPI **only when building for RISC-V** (`cfg!(target_arch = "riscv32")`). Host builds are unchanged — forward-mode tracers (`EvmOpcodeStatsTracer`, `EvmOpcodesLogger`) keep observing per-opcode JUMPDEST events with correct deltas.

### Mechanism

- JUMP: charges `MID / JUMP_NATIVE` upfront. On valid target + RISC-V, charges `JUMPDEST / JUMPDEST_NATIVE` separately inside the validated branch, then advances IP to `dest + 1`. The two-charge split preserves host parity on (a) the OOG boundary for marginal-gas frames in `[MID, MID + JUMPDEST)` and (b) native after `InvalidJump` (EVM errors only exhaust ergs, not native).
- JUMPI: same structure on the taken+valid branch.
- JUMPDEST handler: preserved. Runs as before on host; on RISC-V only for fall-through cases (e.g. JUMPI condition false landing on a JUMPDEST byte).

### Cycle-marker bookkeeping

Host still dispatches JUMPDEST while RISC-V skips it, so JUMP/JUMPI emit a synthetic `cycle_marker::opcode_start!() / opcode_end!("JUMPDEST")` pair on RISC-V to keep marker counts balanced against the host-side `LABELS` Vec.

Side effect: per-opcode attribution between JUMP/JUMPI and JUMPDEST in `compare_opcode_cycles` output is scrambled (the synthetic pair nests inside the dispatcher's JUMP bracket). Block-level `process_block` effective-cycle total — the metric we measure for proving cost — is unaffected.

## Why

After PR #648 (PUSH3..PUSH8), JUMPDEST showed as a top total-cycle contributor at ~42 cyc × 87K calls in the bench fixtures, almost all of which arrive via validated JUMP/JUMPI targets where the redundant dispatch iteration is pure overhead.

### Bench (latest bench bot, vs `draft-0.4.0`):

| Block | Δ Eff |
|---|---|
| `block_19299001` (keccak DA) | −0.30% |
| `block_19299001` (blobs DA) | −0.16% |
| `block_22244135` (keccak DA) | −0.97% |
| `block_22244135` (blobs DA) | −0.71% |

| Opcode | Median cycles | Δ |
|---|---|---|
| JUMP | 76 → 98 | +28.9% (absorbs JUMPDEST charge on valid path) |
| JUMPI | 88 → 136 | +28.3% (absorbs JUMPDEST charge on taken+valid path) |
| JUMPDEST | ~42 → 2 | −95% (synthetic-marker only on RISC-V, intentional artifact) |

DUP1–DUP10 show ~+1.8% I-cache noise consistent with prior dispatch-loop changes; net block-level deltas absorb it.

## Breaking change

- [ ] Yes
- [x] No

Total gas per `JUMP + JUMPDEST` sequence remains 9 on both targets. EVM state transitions and `InvalidJump` semantics (consume all remaining ergs, native unchanged) are identical between host and proving.

## Checklist

- [x] PR title corresponds to the body.
- [x] Tests for the changes have been added / updated. Existing rig tests exercise JUMP/JUMPI/JUMPDEST through real EVM bytecode under both host (`cargo test`) and RISC-V (`ZKSYNC_RISC_V_RUN=true`).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)