### PR TITLE
Clarify contributor PR workflow in fixing issues docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ There are many ways to contribute to the ZK Stack:
 ## Fixing issues
 
 To contribute code fixing issues, please fork the repo, fix an issue, commit, add documentation as per the PR template,
-and the repo's maintainers will review the PR.
-[here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
-for guidance how to work with PRs created from a fork.
+and open a PR for the repo's maintainers to review. See GitHub's guide on
+[creating a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+for guidance on working with PRs created from forks.
 
 ## Licenses
 


### PR DESCRIPTION
GN team,

## Summary

This PR improves the readability and clarity of the **Fixing issues** section in `CONTRIBUTING.md`.

## Changes

- Clarifies that contributors should open a PR after committing their fix.
- Reworks the GitHub documentation link into a complete sentence.
- Improves wording around creating pull requests from forks.

## Why

The previous text left the GitHub guidance link orphaned and omitted the key contributor action of opening a PR. This update makes the contribution flow clearer and easier to follow for new contributors.

Best,