### PR TITLE
perf(bench): skip zero-tail in evaluate_blob_polynomial

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/da_commitment_generator/blob_commitment_generator/polynomial_evaluation.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/da_commitment_generator/blob_commitment_generator/polynomial_evaluation.rs
@@ -1,59 +1,57 @@
 use super::brp_roots_of_unity::BRP_ROOTS_OF_UNITY;
 use super::*;
-use core::mem::MaybeUninit;
+use arrayvec::ArrayVec;
 
-///
 /// Evaluate blob polynomial in the given point.
 ///
-/// Please note, that `data` is not the blob itself, but data we encode into the blob.
-/// For encoding, we chunk `data` by 31 bytes and interpret each chunk as BE blob element.
+/// `data` is not the blob itself, but the bytes we encode into the blob. We
+/// chunk `data` by 31 bytes and interpret each chunk as a BE blob element.
+/// Trailing positions [K, N) are implicit zeros and are skipped:
+/// they contribute nothing to the barycentric sum, so we never compute them.
 ///
+/// Correctness when `x` happens to equal a root of unity `ω_j`:
+/// - `j < K`: the K-element batch-inverse accumulator is zero; the fast-path
+///   loop returns `poly[j]` directly.
+/// - `j ≥ K`: the K-element accumulator is non-zero (none of
+///   `(x − ω_0), …, (x − ω_{K-1})` is zero), so the regular path runs. The
+///   trailing `(x^N − 1)` factor is then zero (because `x` is itself an
+///   N-th root of unity), zeroing the result — which matches the correct
+///   value `P(ω_j) = 0` since `poly[j] = 0` by construction.
 pub fn evaluate_blob_polynomial(data: &[u8], x: &crypto::bls12_381::Fr) -> crypto::bls12_381::Fr {
     debug_assert!(data.len() <= ENCODABLE_BYTES_PER_BLOB);
 
-    // encode data into polynomial (in evaluated form)
-    let mut poly: [MaybeUninit<crypto::bls12_381::Fr>; ELEMENTS_PER_4844_BLOB] =
-        [MaybeUninit::uninit(); ELEMENTS_PER_4844_BLOB];
-    let mut poly_iter = poly.iter_mut();
-
+    let mut poly: ArrayVec<crypto::bls12_381::Fr, ELEMENTS_PER_4844_BLOB> = ArrayVec::new();
     let chunks = data.as_chunks::<BLOB_CHUNK_SIZE>();
     let remainder = chunks.1;
     for chunk in chunks.0 {
-        poly_iter
-            .next()
-            .unwrap()
-            .write(crypto::bls12_381::Fr::from_bigint(parse_u256_be(chunk)).unwrap());
+        poly.push(crypto::bls12_381::Fr::from_bigint(parse_u256_be(chunk)).unwrap());
     }
-    if let Some(el) = poly_iter.next() {
-        let mut last_chunk = [0u8; 31];
+    if !remainder.is_empty() {
+        let mut last_chunk = [0u8; BLOB_CHUNK_SIZE];
         last_chunk[..remainder.len()].copy_from_slice(remainder);
-        el.write(crypto::bls12_381::Fr::from_bigint(parse_u256_be(&last_chunk)).unwrap());
+        poly.push(crypto::bls12_381::Fr::from_bigint(parse_u256_be(&last_chunk)).unwrap());
     }
-    for el in poly_iter {
-        el.write(crypto::bls12_381::Fr::zero());
+    let k = poly.len();
+
+    // Barycentric Lagrange interpolation over the K non-zero coefficients.
+    // Based on https://github.com/ethereum/c-kzg-4844/blob/8b59c2922d78ae792889452ece33a4054c60aab1/src/eip4844/eip4844.c#L192
+
+    let mut inverses_in: ArrayVec<crypto::bls12_381::Fr, ELEMENTS_PER_4844_BLOB> = ArrayVec::new();
+    for i in 0..k {
+        inverses_in.push(*x - BRP_ROOTS_OF_UNITY[i]);
     }
-    let poly = unsafe { MaybeUninit::array_assume_init(poly) };
 
-    // barycentric Lagrange interpolation evaluation
-    // based on https://github.com/ethereum/c-kzg-4844/blob/8b59c2922d78ae792889452ece33a4054c60aab1/src/eip4844/eip4844.c#L192
-
-    let inverses_in: [crypto::bls12_381::Fr; ELEMENTS_PER_4844_BLOB] =
-        core::array::from_fn(|i| *x - BRP_ROOTS_OF_UNITY[i]);
-
-    // batch inverse
-
+    // Batch-invert the K denominators.
     let mut accumulator = crypto::bls12_381::Fr::one();
-    let mut inverses: [crypto::bls12_381::Fr; ELEMENTS_PER_4844_BLOB] = core::array::from_fn(|i| {
-        let inverse = accumulator;
+    let mut inverses: ArrayVec<crypto::bls12_381::Fr, ELEMENTS_PER_4844_BLOB> = ArrayVec::new();
+    for i in 0..k {
+        inverses.push(accumulator);
         accumulator *= inverses_in[i];
-        inverse
-    });
+    }
 
     if accumulator.inverse_in_place().is_none() {
-        // It's `None` when accumulator equals to zero, it means that point to evaluate at is
-        // one of the evaluation points by which the polynomial is given, we can just return
-        // the result directly.
-        for i in 0..ELEMENTS_PER_4844_BLOB {
+        // `x` coincides with one of ω_0, …, ω_{K-1}; return P(ω_i) directly.
+        for i in 0..k {
             if *x == BRP_ROOTS_OF_UNITY[i] {
                 return poly[i];
             }
@@ -61,14 +59,14 @@ pub fn evaluate_blob_polynomial(data: &[u8], x: &crypto::bls12_381::Fr) -> crypt
         unreachable!()
     }
 
-    for i in (0..ELEMENTS_PER_4844_BLOB).rev() {
+    for i in (0..k).rev() {
         inverses[i] *= accumulator;
         accumulator *= inverses_in[i];
     }
 
     let mut out = crypto::bls12_381::Fr::zero();
     let mut tmp: crypto::bls12_381::Fr;
-    for i in 0..ELEMENTS_PER_4844_BLOB {
+    for i in 0..k {
         tmp = inverses[i] * BRP_ROOTS_OF_UNITY[i];
         tmp *= poly[i];
         out += tmp;

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/da_commitment_generator/blob_commitment_generator/polynomial_evaluation.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/da_commitment_generator/blob_commitment_generator/polynomial_evaluation.rs
@@ -37,8 +37,8 @@ pub fn evaluate_blob_polynomial(data: &[u8], x: &crypto::bls12_381::Fr) -> crypt
     // Based on https://github.com/ethereum/c-kzg-4844/blob/8b59c2922d78ae792889452ece33a4054c60aab1/src/eip4844/eip4844.c#L192
 
     let mut inverses_in: ArrayVec<crypto::bls12_381::Fr, ELEMENTS_PER_4844_BLOB> = ArrayVec::new();
-    for i in 0..k {
-        inverses_in.push(*x - BRP_ROOTS_OF_UNITY[i]);
+    for &root in &BRP_ROOTS_OF_UNITY[..k] {
+        inverses_in.push(*x - root);
     }
 
     // Batch-invert the K denominators.


### PR DESCRIPTION
## What ❔

Restrict the barycentric Lagrange interpolation in `evaluate_blob_polynomial` (blob DA commitment path) to the first **K = ⌈len/31⌉** polynomial coefficients populated from `data`. Trailing positions `[K, N)` are implicit zeros — they contribute nothing to the sum, so computing `(x - ω_i)`, batch-inverting it, and accumulating zero-weighted terms for them is wasted work.

Correctness in the `x == ω_j` case is preserved without extra special-casing:
- If `j < K`, the K-element batch-inverse accumulator is zero → fast-path returns `poly[j]` directly.
- If `j ≥ K`, the K-element accumulator is non-zero, so the regular path runs. The trailing `(x^N − 1)` factor is then zero (because `x` is itself an N-th root of unity), which zeroes the result — matching the true value `P(ω_j) = 0` since `poly[j] = 0` by construction.

Also swaps the three stack-allocated `[Fr; ELEMENTS_PER_4844_BLOB]` buffers (`poly`, `inverses_in`, `inverses`) to `ArrayVec<Fr, ELEMENTS_PER_4844_BLOB>`. Same stack footprint, length-tracked, removes the `MaybeUninit::array_assume_init` `unsafe`.

## Why ❔

`blob_versioned_hash` is one of the larger labels under the `BlobsZKsyncOS` DA scheme — ~49.6M effective cycles per block in both checked-in bench fixtures, roughly 19–26% of `process_block`. A meaningful share of that is `evaluate_blob_polynomial`, which currently iterates the Lagrange sum over the full 4096 evaluation positions regardless of how many are actually populated. Most real-world ZKsync OS pubdata blocks are far from filling a blob, so the marginal work past index K is the easiest win on this path that doesn't change the trust model or require an L1-side change.

Verified equivalence against the alloy 4844 reference via the existing three tests in `tests/instances/unit/src/kzg_blobs.rs` (covering K=1 empty, K≈34 small, K=4096 full).

## Bench

Proving-mode RISC-V simulation, `BENCH_DA_SCHEME=blobs_zksync_os`, both checked-in block fixtures. Effective cycles = `raw + 16·blake + 4·bigint + 4·keccak` per the cycle-marker formula:

| Block       | `blob_versioned_hash` eff       | Δ       | `process_block` eff       | Δ       |
|-------------|---------------------------------|---------|----------------------------|---------|
| 19299001    | 49,568,581 → 46,520,456         | −6.15%  | 259,680,540 → 256,632,399  | −1.17%  |
| 22244135    | 49,849,981 → 46,518,568         | −6.68%  | 188,902,256 → 185,570,827  | −1.76%  |

The label savings are bounded by the remaining cost — `verify_kzg_proof` (BLS12-381 pairing) and `parse_g1_compressed` for commitment + proof dominate `blob_versioned_hash`; neither is touched here. Both checked-in fixtures happen to fill their blobs to ≥90%, so we mostly shave the small zero-tail; sparser-pubdata blocks would benefit proportionally more.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated. (Existing `kzg_blobs` equivalence tests against alloy cover the K=1 / K≈34 / K=4096 cases; the change preserves the hash output.)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.