### PR TITLE
feat(pubdata): port v2 compressed storage diffs (tree indices for repeated writes) onto draft-0.4.0

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -22,10 +22,17 @@ pub mod public_input;
 
 /// Version byte for pubdata encoding format.
 /// Version 1: Initial versioned pubdata format
-/// Version 2: Remove artifacts_len and artifacts from pubdata
+/// Version 2: Remove artifacts_len and artifacts from pubdata; storage diffs
+///            use a header + initial/repeated split, with repeated writes
+///            referenced by compact tree index.
 pub const PUBDATA_ENCODING_VERSION: u8 = 2;
 
 /// Helper method to write the pubdata to the DA commitment generator and result keeper.
+///
+/// Storage diffs are emitted in the v2 compressed format and reference
+/// per-block tree indices for repeated writes; the caller must therefore
+/// have already run `update_commitment` with the actual state commitment so
+/// `io.storage.key_to_index_cache` is populated.
 fn write_pubdata<
     DST: WriteBytes + ?Sized,
     A: Allocator + Clone + Default,
@@ -40,6 +47,7 @@ fn write_pubdata<
     result_keeper: &mut impl ResultKeeperExt<EthereumIOTypesConfig, BlockHeader = BlockHeader>,
     block_hash: Bytes32,
     timestamp: u64,
+    repeated_write_index_encoding_length: u8,
     io: &mut FullIO<
         A,
         R,
@@ -60,8 +68,12 @@ fn write_pubdata<
     result_keeper.pubdata(block_hash.as_u8_ref());
     result_keeper.pubdata(&timestamp.to_be_bytes());
 
-    io.storage
-        .apply_storage_diffs_pubdata(result_keeper, pubdata_dst, &mut io.oracle);
+    io.storage.apply_storage_diffs_pubdata(
+        result_keeper,
+        pubdata_dst,
+        &mut io.oracle,
+        repeated_write_index_encoding_length,
+    );
 
     io.logs_storage.apply_pubdata(pubdata_dst, result_keeper);
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -96,21 +96,6 @@ where
                 da_commitment_scheme
             );
         }
-        // See `post_tx_op_proving_singleblock_batch.rs` for the rationale.
-        cycle_marker::wrap!("da_commitment", {
-            write_pubdata(
-                batch_data
-                    .da_commitment_generator
-                    .as_mut()
-                    .unwrap()
-                    .as_mut(),
-                result_keeper,
-                block_hash,
-                metadata.block_timestamp(),
-                &mut io,
-            );
-        });
-
         io.logs_storage
             .apply_to_array_vec(&mut batch_data.logs_storage);
 
@@ -146,12 +131,30 @@ where
         };
 
         // 3. Verify/apply reads and writes — state-tree merkle commit.
+        // Must run before `write_pubdata` so that the derived-key ->
+        // tree-index map is populated for the compressed pubdata encoding.
         cycle_marker::wrap!("state_commitment_update", {
             IOTeardown::<_>::update_commitment(
                 &mut io,
                 Some(&mut state_commitment),
                 &mut logger,
                 result_keeper,
+            );
+        });
+
+        // See `post_tx_op_proving_singleblock_batch.rs` for the rationale.
+        cycle_marker::wrap!("da_commitment", {
+            write_pubdata(
+                batch_data
+                    .da_commitment_generator
+                    .as_mut()
+                    .unwrap()
+                    .as_mut(),
+                result_keeper,
+                block_hash,
+                metadata.block_timestamp(),
+                metadata.block_level.repeated_write_index_encoding_length,
+                &mut io,
             );
         });
 

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -88,22 +88,6 @@ where
         let mut da_commitment_generator =
             da_commitment_generator_from_scheme(io.da_commitment_scheme.unwrap(), A::default())
                 .unwrap();
-        // For keccak DA (`BlobsAndPubdataKeccak256`), `write_pubdata` streams
-        // bytes through `Keccak256CommitmentGenerator`, which absorbs them
-        // into the keccak state — this is where the bulk of keccak
-        // delegations fire on the DA-commit path. For blob DA
-        // (`BlobsZKsyncOS`) the same call just appends to a buffer (no
-        // hashing yet); the actual blob KZG work happens in `.finalize()`
-        // below and is already captured by the `blob_versioned_hash` marker.
-        cycle_marker::wrap!("da_commitment", {
-            write_pubdata(
-                da_commitment_generator.as_mut(),
-                result_keeper,
-                block_hash,
-                metadata.block_timestamp(),
-                &mut io,
-            );
-        });
 
         let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
 
@@ -164,12 +148,32 @@ where
         // update state commitment — this is the state-tree merkle commit
         // (Blake-heavy). Distinct from `da_commitment` (keccak/blob over
         // pubdata) and `blob_versioned_hash` (KZG per blob).
+        // Must run before `write_pubdata` so that the derived-key ->
+        // tree-index map is populated for the compressed pubdata encoding.
         cycle_marker::wrap!("state_commitment_update", {
             IOTeardown::<_>::update_commitment(
                 &mut io,
                 Some(&mut state_commitment),
                 &mut logger,
                 result_keeper,
+            );
+        });
+
+        // For keccak DA (`BlobsAndPubdataKeccak256`), `write_pubdata` streams
+        // bytes through `Keccak256CommitmentGenerator`, which absorbs them
+        // into the keccak state — this is where the bulk of keccak
+        // delegations fire on the DA-commit path. For blob DA
+        // (`BlobsZKsyncOS`) the same call just appends to a buffer (no
+        // hashing yet); the actual blob KZG work happens in `.finalize()`
+        // below and is already captured by the `blob_versioned_hash` marker.
+        cycle_marker::wrap!("da_commitment", {
+            write_pubdata(
+                da_commitment_generator.as_mut(),
+                result_keeper,
+                block_hash,
+                metadata.block_timestamp(),
+                metadata.block_level.repeated_write_index_encoding_length,
+                &mut io,
             );
         });
 

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_sequencing.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_sequencing.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::bootloader::block_flow::zk::post_tx_op::da_commitment_generator::NopCommitmentGenerator;
 use basic_system::system_implementation::caches::storage_access_policy::StorageAccessPolicy;
 use basic_system::system_implementation::flat_storage_model::FlatTreeWithAccountsUnderHashesStorageModel;
 use basic_system::system_implementation::system::FullIO;
@@ -8,7 +7,6 @@ use zk_ee::common_structs::WarmStorageKey;
 use zk_ee::logger_log;
 use zk_ee::memory::stack_trait::StackFactory;
 use zk_ee::oracle::IOOracle;
-use zk_ee::system::metadata::basic_metadata::BasicBlockMetadata;
 use zk_ee::system::{IOTeardown, Resources};
 
 impl<
@@ -73,18 +71,14 @@ where
         result_keeper.logs(io.logs_storage.messages_ref_iter());
         result_keeper.events(io.events_storage.events_ref_iter());
 
-        // Sequencing-mode post-op uses NopCommitmentGenerator (no DA work),
-        // but we still mark `da_commitment` for parity with the proving
-        // paths so the bench label set is consistent across STFs.
-        cycle_marker::wrap!("da_commitment", {
-            write_pubdata(
-                &mut NopCommitmentGenerator,
-                result_keeper,
-                block_hash,
-                metadata.block_timestamp(),
-                &mut io,
-            );
-        });
+        // Sequencing-mode post-op does no DA work and does not emit pubdata.
+        // The v2 compressed pubdata format references repeated writes by
+        // their tree index, which is only available on the proving path
+        // (computed inside `verify_and_apply_batch`). The block hash and
+        // timestamp are still part of the sealed block header that the
+        // sequencer surfaces above.
+        let _ = block_hash;
+        let _ = metadata;
 
         cycle_marker::wrap!("state_commitment_update", {
             io.update_commitment(None, &mut logger, result_keeper);

--- a/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
@@ -423,9 +423,13 @@ pub fn get_resources_to_charge_for_pubdata<S: EthereumLikeTypes>(
     system: &mut System<S>,
     native_per_pubdata: u64,
     base_pubdata: Option<u64>,
-) -> Result<(u64, S::Resources), SystemError> {
+) -> Result<(u64, S::Resources), SystemError>
+where
+    S::Metadata: zk_ee::system::metadata::basic_metadata::ZkSpecificPricingMetadata,
+{
+    let repeated_write_index_encoding_length = system.repeated_write_index_encoding_length();
     let current_pubdata_spent = system
-        .net_pubdata_used()?
+        .net_pubdata_used(repeated_write_index_encoding_length)?
         .saturating_sub(base_pubdata.unwrap_or(0));
     let native = current_pubdata_spent
         .checked_mul(native_per_pubdata)
@@ -447,7 +451,10 @@ pub fn check_enough_resources_for_pubdata<S: EthereumLikeTypes>(
     native_per_pubdata: u64,
     resources: &S::Resources,
     base_pubdata: Option<u64>,
-) -> Result<(bool, S::Resources, u64), SystemError> {
+) -> Result<(bool, S::Resources, u64), SystemError>
+where
+    S::Metadata: zk_ee::system::metadata::basic_metadata::ZkSpecificPricingMetadata,
+{
     let (pubdata_used, resources_for_pubdata) =
         get_resources_to_charge_for_pubdata(system, native_per_pubdata, base_pubdata)?;
     system_log!(system, "Checking gas for pubdata, resources_for_pubdata: {resources_for_pubdata:?}, resources: {resources:?}\n");

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
@@ -294,7 +294,8 @@ where
         // from pubdata payment after execution.
         // In the future we may consider using intrinsic pubdata here,
         // so worst case validation pubdata will be "refunded" if not used
-        context.validation_pubdata = system.net_pubdata_used()?;
+        context.validation_pubdata =
+            system.net_pubdata_used(system.repeated_write_index_encoding_length())?;
 
         // Save resources to be able to calculate computational native consumption after everything
         let initial_resources = context.resources.main_resources.clone();

--- a/basic_system/src/system_implementation/ethereum_storage_model/storage_model.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/storage_model.rs
@@ -94,7 +94,7 @@ impl<
         }
     }
 
-    fn pubdata_used_by_tx(&self) -> u32 {
+    fn pubdata_used_by_tx(&self, _repeated_write_index_encoding_length: u8) -> u32 {
         0
     }
 

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -430,7 +430,7 @@ impl<
         })
     }
 
-    pub fn calculate_pubdata_used_by_tx(&self) -> u32 {
+    pub fn calculate_pubdata_used_by_tx(&self, repeated_write_index_encoding_length: u8) -> u32 {
         let mut visited_elements = BTreeSet::new_in(self.alloc.clone());
 
         let mut pubdata_used = 0u32;
@@ -457,8 +457,16 @@ impl<
                 continue;
             }
 
+            let is_initial_write = element_history.key_properties().is_new_element();
+
             if current.value() != at_tx_start.value() || current.metadata().not_compress_balance {
-                pubdata_used += 32; // key
+                pubdata_used += if is_initial_write {
+                    // Account address (20 bytes) — we publish account properties
+                    // by address rather than the full 32-byte derived key.
+                    20
+                } else {
+                    repeated_write_index_encoding_length as u32
+                };
                 pubdata_used += AccountProperties::diff_compression_length(
                     at_tx_start.value(),
                     current.value(),

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -115,9 +115,12 @@ impl<
         }
     }
 
-    fn pubdata_used_by_tx(&self) -> u32 {
-        self.account_data_cache.calculate_pubdata_used_by_tx()
-            + self.storage_cache.calculate_pubdata_used_by_tx()
+    fn pubdata_used_by_tx(&self, repeated_write_index_encoding_length: u8) -> u32 {
+        self.account_data_cache
+            .calculate_pubdata_used_by_tx(repeated_write_index_encoding_length)
+            + self
+                .storage_cache
+                .calculate_pubdata_used_by_tx(repeated_write_index_encoding_length)
     }
 
     fn storage_read(

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -17,6 +17,7 @@ pub use self::preimage_cache::*;
 pub use self::simple_growable_storage::*;
 pub use self::storage_cache::*;
 use crate::system_implementation::caches::storage_access_policy::StorageAccessPolicy;
+use alloc::collections::BTreeMap;
 use core::alloc::Allocator;
 use crypto::MiniDigest;
 use ruint::aliases::B160;
@@ -73,6 +74,11 @@ pub struct FlatTreeWithAccountsUnderHashesStorageModel<
     pub(crate) preimages_cache: BytecodeAndAccountDataPreimagesStorage<R, A>,
     pub(crate) account_data_cache: NewModelAccountCache<A, R, P, SF, M>,
     pub(crate) allocator: A,
+    /// Map of derived flat storage key -> tree index, populated by
+    /// `update_commitment` (only when a state commitment is being updated)
+    /// and consumed by `apply_storage_diffs_pubdata` to encode repeated
+    /// writes as compact indices.
+    pub(crate) key_to_index_cache: Option<BTreeMap<Bytes32, u64, A>>,
 }
 
 pub struct FlatTreeWithAccountsUnderHashesStorageModelStateSnapshot {
@@ -112,6 +118,7 @@ impl<
             preimages_cache,
             account_data_cache,
             allocator,
+            key_to_index_cache: None,
         }
     }
 
@@ -497,9 +504,13 @@ impl<
         if let Some(state_commitment) = state_commitment {
             use zk_ee::common_structs::state_root_view::StateRootView;
             let it = self.storage_cache.net_accesses_iter();
-            state_commitment
+            let key_to_index_cache = state_commitment
                 .verify_and_apply_batch(oracle, it, self.allocator.clone(), logger)
                 .expect("must persist changes to state");
+            // Cache the derived_key -> tree-index map so the subsequent
+            // pubdata emission can reference repeated writes by their
+            // compact tree index.
+            self.key_to_index_cache = Some(key_to_index_cache);
         }
     }
 }
@@ -563,69 +574,192 @@ impl<
         const PROOF_ENV: bool,
     > FlatTreeWithAccountsUnderHashesStorageModel<A, R, P, SF, N, PROOF_ENV>
 {
+    /// Emit storage diffs to `pubdata_dst` (and mirror to `result_keeper`)
+    /// in the v2 compressed format:
+    ///
+    /// - 4 bytes BE total number of diffs
+    /// - 4 bytes BE number of initial account writes
+    /// - 4 bytes BE number of initial slot writes
+    /// - 1 byte repeated-write index encoding length
+    /// - for each initial account write: 20-byte address + diff-compressed account
+    /// - for each initial slot write: 32-byte derived key + value diff
+    /// - for each repeated write: `index_len`-byte tree index + diff
+    ///
+    /// Repeated writes reference the tree index built by
+    /// `verify_and_apply_batch` (cached on `self.key_to_index_cache` by
+    /// `update_commitment`). Callers must therefore invoke
+    /// `update_commitment` with a non-`None` state commitment before calling
+    /// this method.
     pub fn apply_storage_diffs_pubdata<T: WriteBytes + ?Sized>(
         &mut self,
         result_keeper: &mut impl IOResultKeeper<EthereumIOTypesConfig>,
         pubdata_dst: &mut T,
         oracle: &mut impl IOOracle,
+        repeated_write_index_encoding_length: u8,
     ) {
         use zk_ee::common_structs::*;
 
+        let key_to_index_cache = self
+            .key_to_index_cache
+            .as_ref()
+            .expect("update_commitment with Some(state_commitment) must run before pubdata emission");
+
         let mut flat_storage_key_hasher = crypto::blake2s::Blake2s256::new();
 
-        let encoded_state_diffs_count =
-            (self.storage_cache.net_diffs_iter().count() as u32).to_be_bytes();
-        pubdata_dst.write(&encoded_state_diffs_count);
-        result_keeper.pubdata(&encoded_state_diffs_count);
-
-        self.storage_cache
-            .0
-            .cache
-            .apply_to_all_updated_elements::<_, ()>(|l, r, k| {
-                // Skip on empty diff
-                if l.value() == r.value() {
-                    return Ok(());
-                }
-                // TODO(EVM-1074): use tree index instead of key for repeated writes
-                let derived_key = derive_flat_storage_key_with_hasher(
-                    &k.address,
-                    &k.key,
-                    &mut flat_storage_key_hasher,
-                );
-                pubdata_dst.write(derived_key.as_u8_ref());
-                result_keeper.pubdata(derived_key.as_u8_ref());
-
-                // we publish preimages for account details
-                if k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS {
-                    let account_address = B160::try_from_be_slice(&k.key.as_u8_ref()[12..])
-                        .unwrap()
-                        .into();
-                    let cache_item = self
-                        .account_data_cache
-                        .cache
-                        .get(&account_address)
-                        .ok_or(())?;
-                    let (l, r) = cache_item.get_initial_and_last_values().ok_or(())?;
-                    AccountProperties::diff_compression::<PROOF_ENV, _, _, _>(
-                        l.value(),
-                        r.value(),
-                        r.metadata().not_publish_bytecode,
-                        pubdata_dst,
-                        result_keeper,
-                        &mut self.preimages_cache,
-                        oracle,
-                    )
-                    .map_err(|_| ())?;
-                } else {
-                    ValueDiffCompressionStrategy::optimal_compression(
-                        l.value(),
-                        r.value(),
-                        pubdata_dst,
-                        result_keeper,
-                    );
-                }
-                Ok(())
+        // Header: total diffs / initial account / initial slot / index width.
+        let total_diffs = self.storage_cache.net_diffs_iter().count() as u32;
+        let initial_account_writes = self
+            .storage_cache
+            .net_diffs_iter()
+            .filter(|(k, v)| {
+                k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS && v.is_new_storage_slot
             })
-            .expect("must compute pubdata");
+            .count() as u32;
+        let initial_slot_writes = self
+            .storage_cache
+            .net_diffs_iter()
+            .filter(|(k, v)| {
+                k.address != ACCOUNT_PROPERTIES_STORAGE_ADDRESS && v.is_new_storage_slot
+            })
+            .count() as u32;
+
+        let header = [
+            total_diffs.to_be_bytes(),
+            initial_account_writes.to_be_bytes(),
+            initial_slot_writes.to_be_bytes(),
+        ];
+        for word in &header {
+            pubdata_dst.write(word);
+            result_keeper.pubdata(word);
+        }
+        pubdata_dst.write(&[repeated_write_index_encoding_length]);
+        result_keeper.pubdata(&[repeated_write_index_encoding_length]);
+
+        // 1. Initial account writes — keyed by address (20 bytes).
+        for (k, v) in self.storage_cache.net_diffs_iter() {
+            if k.address != ACCOUNT_PROPERTIES_STORAGE_ADDRESS || !v.is_new_storage_slot {
+                continue;
+            }
+            let address = B160::try_from_be_slice(&k.key.as_u8_ref()[12..]).unwrap();
+            let address_bytes = address.to_be_bytes::<{ B160::BYTES }>();
+            pubdata_dst.write(&address_bytes);
+            result_keeper.pubdata(&address_bytes);
+
+            let account_address = address.into();
+            let cache_item = self
+                .account_data_cache
+                .cache
+                .get(&account_address)
+                .expect("account data must be cached for initial write");
+            let (l, r) = cache_item
+                .get_initial_and_last_values()
+                .expect("account must have initial and last values");
+            AccountProperties::diff_compression::<PROOF_ENV, _, _, _>(
+                l.value(),
+                r.value(),
+                r.metadata().not_publish_bytecode,
+                pubdata_dst,
+                result_keeper,
+                &mut self.preimages_cache,
+                oracle,
+            )
+            .expect("must compute account pubdata");
+        }
+
+        // 2. Initial slot writes — keyed by full 32-byte derived key.
+        for (k, v) in self.storage_cache.net_diffs_iter() {
+            if k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS || !v.is_new_storage_slot {
+                continue;
+            }
+            let derived_key = derive_flat_storage_key_with_hasher(
+                &k.address,
+                &k.key,
+                &mut flat_storage_key_hasher,
+            );
+            pubdata_dst.write(derived_key.as_u8_ref());
+            result_keeper.pubdata(derived_key.as_u8_ref());
+            ValueDiffCompressionStrategy::optimal_compression(
+                &v.initial_value,
+                &v.current_value,
+                pubdata_dst,
+                result_keeper,
+            );
+        }
+
+        // 3. Repeated writes — keyed by compact tree index.
+        for (k, v) in self.storage_cache.net_diffs_iter() {
+            if v.is_new_storage_slot {
+                continue;
+            }
+            let derived_key = derive_flat_storage_key_with_hasher(
+                &k.address,
+                &k.key,
+                &mut flat_storage_key_hasher,
+            );
+            let index = key_to_index_cache
+                .get(&derived_key)
+                .copied()
+                .expect("repeated write must have tree index from verify_and_apply_batch");
+            write_index_fixed_width(
+                index,
+                repeated_write_index_encoding_length,
+                pubdata_dst,
+                result_keeper,
+            )
+            .expect("repeated_write_index_encoding_length too small to encode index");
+
+            if k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS {
+                let account_address = B160::try_from_be_slice(&k.key.as_u8_ref()[12..])
+                    .unwrap()
+                    .into();
+                let cache_item = self
+                    .account_data_cache
+                    .cache
+                    .get(&account_address)
+                    .expect("account data must be cached for repeated write");
+                let (l, r) = cache_item
+                    .get_initial_and_last_values()
+                    .expect("account must have initial and last values");
+                AccountProperties::diff_compression::<PROOF_ENV, _, _, _>(
+                    l.value(),
+                    r.value(),
+                    r.metadata().not_publish_bytecode,
+                    pubdata_dst,
+                    result_keeper,
+                    &mut self.preimages_cache,
+                    oracle,
+                )
+                .expect("must compute account pubdata");
+            } else {
+                ValueDiffCompressionStrategy::optimal_compression(
+                    &v.initial_value,
+                    &v.current_value,
+                    pubdata_dst,
+                    result_keeper,
+                );
+            }
+        }
     }
+}
+
+/// Write a single u64 tree index as a fixed-width big-endian integer.
+/// Fails if `width` would truncate the high bits of `index`.
+fn write_index_fixed_width<T: WriteBytes + ?Sized>(
+    index: u64,
+    width: u8,
+    pubdata_dst: &mut T,
+    result_keeper: &mut impl IOResultKeeper<EthereumIOTypesConfig>,
+) -> Result<(), ()> {
+    if width > 8 {
+        return Err(());
+    }
+    let required = ((64 - index.leading_zeros() + 7) / 8) as u8;
+    if required > width {
+        return Err(());
+    }
+    let be = index.to_be_bytes();
+    let tail = &be[(8 - width as usize)..];
+    pubdata_dst.write(tail);
+    result_keeper.pubdata(tail);
+    Ok(())
 }

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -599,29 +599,31 @@ impl<
     ) {
         use zk_ee::common_structs::*;
 
-        let key_to_index_cache = self
-            .key_to_index_cache
-            .as_ref()
-            .expect("update_commitment with Some(state_commitment) must run before pubdata emission");
+        let key_to_index_cache = self.key_to_index_cache.as_ref().expect(
+            "update_commitment with Some(state_commitment) must run before pubdata emission",
+        );
 
         let mut flat_storage_key_hasher = crypto::blake2s::Blake2s256::new();
 
         // Header: total diffs / initial account / initial slot / index width.
-        let total_diffs = self.storage_cache.net_diffs_iter().count() as u32;
-        let initial_account_writes = self
-            .storage_cache
-            .net_diffs_iter()
-            .filter(|(k, v)| {
-                k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS && v.is_new_storage_slot
-            })
-            .count() as u32;
-        let initial_slot_writes = self
-            .storage_cache
-            .net_diffs_iter()
-            .filter(|(k, v)| {
-                k.address != ACCOUNT_PROPERTIES_STORAGE_ADDRESS && v.is_new_storage_slot
-            })
-            .count() as u32;
+        // Fold the three counts into one pass over `net_diffs_iter` — each
+        // pass copies ~96 B of `WarmStorageKey + WarmStorageValue` per
+        // accessed slot (reads included, since `iter_as_storage_types`
+        // yields all accesses and the filter happens at the consumer), so
+        // each saved pass is N elements of iteration + filter overhead.
+        let mut total_diffs: u32 = 0;
+        let mut initial_account_writes: u32 = 0;
+        let mut initial_slot_writes: u32 = 0;
+        for (k, v) in self.storage_cache.net_diffs_iter() {
+            total_diffs += 1;
+            if v.is_new_storage_slot {
+                if k.address == ACCOUNT_PROPERTIES_STORAGE_ADDRESS {
+                    initial_account_writes += 1;
+                } else {
+                    initial_slot_writes += 1;
+                }
+            }
+        }
 
         let header = [
             total_diffs.to_be_bytes(),

--- a/basic_system/src/system_implementation/flat_storage_model/simple_growable_storage.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/simple_growable_storage.rs
@@ -189,7 +189,7 @@ impl<const N: usize> StateRootView<EthereumIOTypesConfig> for FlatStorageCommitm
         source: impl Iterator<Item = (WarmStorageKey, WarmStorageValue)> + Clone,
         allocator: A,
         logger: &mut impl Logger,
-    ) -> Result<(), InternalError> {
+    ) -> Result<BTreeMap<Bytes32, u64, A>, InternalError> {
         // we know that for our storage model we have a luxury of amortizing all new writes,
         // so our strategy is to:
         // - verify all reads
@@ -214,7 +214,7 @@ impl<const N: usize> StateRootView<EthereumIOTypesConfig> for FlatStorageCommitm
 
         // If there was no IO, just return
         if source.clone().next().is_none() {
-            return Ok(());
+            return Ok(key_to_index_cache);
         }
 
         let reads_iter = source
@@ -790,7 +790,7 @@ impl<const N: usize> StateRootView<EthereumIOTypesConfig> for FlatStorageCommitm
             // root should not change in such case
         }
 
-        Ok(())
+        Ok(key_to_index_cache)
     }
 }
 

--- a/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
@@ -262,7 +262,7 @@ impl<
             .filter(|(_, v)| v.current_value != v.initial_value)
     }
 
-    pub fn calculate_pubdata_used_by_tx(&self) -> u32 {
+    pub fn calculate_pubdata_used_by_tx(&self, repeated_write_index_encoding_length: u8) -> u32 {
         let mut visited_elements = BTreeSet::new_in(self.0.alloc.clone());
 
         let mut pubdata_used = 0u32;
@@ -294,9 +294,15 @@ impl<
                 continue;
             }
 
+            let is_initial_write = element_history.key_properties().is_new_element();
+
             if at_tx_start_value != current_value {
-                // TODO(EVM-1074): use tree index instead of key for repeated writes
-                pubdata_used += 32; // key
+                pubdata_used += if is_initial_write {
+                    // Full derived key.
+                    32
+                } else {
+                    repeated_write_index_encoding_length as u32
+                };
                 pubdata_used += ValueDiffCompressionStrategy::optimal_compression_length(
                     at_tx_start_value,
                     current_value,

--- a/basic_system/src/system_implementation/system/io_subsystem.rs
+++ b/basic_system/src/system_implementation/system/io_subsystem.rs
@@ -396,8 +396,13 @@ impl<
         )
     }
 
-    fn net_pubdata_used(&self) -> Result<u64, InternalError> {
-        Ok(self.storage.pubdata_used_by_tx() as u64
+    fn net_pubdata_used(
+        &self,
+        repeated_write_index_encoding_length: u8,
+    ) -> Result<u64, InternalError> {
+        Ok(self
+            .storage
+            .pubdata_used_by_tx(repeated_write_index_encoding_length) as u64
             + self.logs_storage.calculate_pubdata_used_by_tx()? as u64)
     }
 

--- a/forward_system/src/run/convert.rs
+++ b/forward_system/src/run/convert.rs
@@ -93,6 +93,8 @@ impl FromInterface<BlockContext> for BlockMetadataFromOracle {
             pubdata_limit: value.pubdata_limit,
             mix_hash: value.mix_hash,
             blob_fee: value.blob_fee,
+            // TODO: expose this in BlockContext / interface.
+            repeated_write_index_encoding_length: 5,
         }
     }
 }

--- a/storage_models/src/common_structs/traits/storage_model.rs
+++ b/storage_models/src/common_structs/traits/storage_model.rs
@@ -226,7 +226,10 @@ pub trait StorageModel: Sized + SnapshottableIo {
     fn construct(init_data: Self::InitData, allocator: Self::Allocator) -> Self;
 
     /// Get amount of pubdata needed to encode current tx diff in bytes.
-    fn pubdata_used_by_tx(&self) -> u32;
+    ///
+    /// `repeated_write_index_encoding_length` is the per-block constant width
+    /// (in bytes) used to encode tree indices for repeated storage writes.
+    fn pubdata_used_by_tx(&self, repeated_write_index_encoding_length: u8) -> u32;
 
     /// Get current counter of refunds
     fn get_refund_counter(&'_ self) -> &'_ Self::Resources;

--- a/tests/rig/src/chain.rs
+++ b/tests/rig/src/chain.rs
@@ -616,6 +616,9 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
             pubdata_limit: block_context.pubdata_limit,
             mix_hash: block_context.mix_hash,
             blob_fee: block_context.blob_fee,
+            // TODO: expose in BlockContext; matches the default the converter
+            // uses in `forward_system/src/run/convert.rs`.
+            repeated_write_index_encoding_length: 5,
         };
         let tx_source = TxListSource {
             transactions: transactions.into(),
@@ -808,6 +811,9 @@ impl<const RANDOMIZED_TREE: bool> Chain<RANDOMIZED_TREE> {
             pubdata_limit: block_context.pubdata_limit,
             mix_hash: block_context.mix_hash,
             blob_fee: block_context.blob_fee,
+            // TODO: expose in BlockContext; matches the default the converter
+            // uses in `forward_system/src/run/convert.rs`.
+            repeated_write_index_encoding_length: 5,
         };
         let state_commitment = FlatStorageCommitment::<{ TREE_HEIGHT }> {
             root: *self.state_tree.storage_tree.root(),

--- a/zk_ee/src/common_structs/pubdata_compression.rs
+++ b/zk_ee/src/common_structs/pubdata_compression.rs
@@ -163,25 +163,77 @@ impl ValueDiffCompressionStrategy {
         dst: &mut T,
         result_keeper: &mut impl IOResultKeeper<IOTypes>,
     ) {
-        let mut optimal_strategy = Self::Nothing;
-        let mut optimal_length = optimal_strategy
-            .compression_length(initial_value, final_value)
-            .unwrap();
+        // Compute each candidate's `(payload, payload_bytes)` once. The
+        // previous shape ran `compression_length` for every strategy *then*
+        // recomputed the same arithmetic inside `compress`, doubling the
+        // U256 subtract + `bit_len` work on the chosen strategy and burning
+        // a redundant `to_be_bytes::<32>()` on top.
+        //
+        // Tag values match `compress`'s metadata-byte low nibble:
+        //   0 = Nothing, 1 = Add, 2 = Sub, 3 = Transform.
+        // "Nothing" (33 bytes total: metadata + 32-byte value) is always
+        // applicable and is the initial best.
+        let mut best_tag = 0u8;
+        let mut best_total = 33u8;
+        let mut best_payload = final_value;
+        let mut best_payload_bytes = 32u8;
 
-        // nothing already checked
-        for strategy in [Self::Add, Self::Sub, Self::Transform] {
-            if let Some(length) = strategy.compression_length(initial_value, final_value) {
-                if length < optimal_length {
-                    optimal_strategy = strategy;
-                    optimal_length = length;
-                }
+        // Add: final - initial (mod 2^256). Applicable iff no overflow and
+        // the result fits in <32 bytes (otherwise Nothing is at least as
+        // good).
+        let (add_diff, add_of) = final_value.overflowing_sub(initial_value);
+        if !add_of {
+            let bytes = add_diff.bit_len().div_ceil(8) as u8;
+            if bytes < 32 && bytes + 1 < best_total {
+                best_tag = 1;
+                best_total = bytes + 1;
+                best_payload = add_diff;
+                best_payload_bytes = bytes;
             }
         }
 
-        // safe to unwrap here as strategy is checked to be applicable to the current values
-        optimal_strategy
-            .compress(initial_value, final_value, dst, result_keeper)
-            .unwrap()
+        // Sub: initial - final.
+        let (sub_diff, sub_of) = initial_value.overflowing_sub(final_value);
+        if !sub_of {
+            let bytes = sub_diff.bit_len().div_ceil(8) as u8;
+            if bytes < 32 && bytes + 1 < best_total {
+                best_tag = 2;
+                best_total = bytes + 1;
+                best_payload = sub_diff;
+                best_payload_bytes = bytes;
+            }
+        }
+
+        // Transform: emit `final_value` truncated to its high non-zero
+        // bytes (BE). Applicable iff `final_value` itself is <32 bytes.
+        {
+            let bytes = final_value.bit_len().div_ceil(8) as u8;
+            if bytes < 32 && bytes + 1 < best_total {
+                best_tag = 3;
+                best_total = bytes + 1;
+                best_payload = final_value;
+                best_payload_bytes = bytes;
+            }
+        }
+
+        // Pack metadata + payload into a single 33-byte stack buffer and
+        // emit one slice each to `dst` and `result_keeper`. Previously
+        // every value diff did 4 write calls (metadata, payload, ×2 sinks)
+        // — for streaming sinks downstream that's a lot of per-call
+        // overhead.
+        let mut buf = [0u8; 33];
+        let total = best_total as usize;
+        if best_tag == 0 {
+            // Nothing: 0x00 metadata + full 32-byte BE value.
+            // SAFETY of slice math: `best_total == 33` here.
+            buf[1..33].copy_from_slice(&final_value.to_be_bytes::<32>());
+        } else {
+            buf[0] = (best_payload_bytes << 3) | best_tag;
+            let payload_bytes = best_payload.to_be_bytes::<32>();
+            buf[1..total].copy_from_slice(&payload_bytes[32 - best_payload_bytes as usize..]);
+        }
+        dst.write(&buf[..total]);
+        result_keeper.pubdata(&buf[..total]);
     }
 
     pub fn optimal_compression<IOTypes: SystemIOTypesConfig, T: WriteBytes + ?Sized>(
@@ -245,5 +297,124 @@ mod tests {
         println!("{:?}", compression);
         assert_eq!(compression[0], 0b00001001);
         assert_eq!(compression[1], 3);
+    }
+
+    fn run(initial: [u8; 32], r#final: [u8; 32]) -> Vec<u8> {
+        let initial = Bytes32::from_array(initial);
+        let r#final = Bytes32::from_array(r#final);
+        let mut nop_hasher = NopHasher::new();
+        let mut rk = TestResultKeeper { pubdata: vec![] };
+        ValueDiffCompressionStrategy::optimal_compression(
+            &initial,
+            &r#final,
+            &mut nop_hasher,
+            &mut rk,
+        );
+        let len = ValueDiffCompressionStrategy::optimal_compression_length(&initial, &r#final);
+        // Reported length must match the emitted bytes — exposing this skew
+        // would corrupt pubdata accounting.
+        assert_eq!(rk.pubdata.len(), len as usize, "length-vs-emit mismatch");
+        rk.pubdata
+    }
+
+    fn be32(low: u128) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out[16..].copy_from_slice(&low.to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn add_strategy_picked_when_diff_small() {
+        // initial = 1, final = 257. Add diff = 256 (2 bytes), Sub diff = ~U256::MAX (32 bytes),
+        // Transform = 2 bytes (final fits in 2 bytes). Tie between Add and Transform
+        // on length=2, both encode as 3 bytes total (metadata + 2 payload). Selection
+        // depends on first-applicable-with-strictly-less-length; Add is tested first
+        // so it should win.
+        let out = run(be32(1), be32(257));
+        // metadata byte: low nibble = 1 (Add), high 5 bits = length (2)
+        assert_eq!(out[0], (2u8 << 3) | 1, "metadata = (len<<3)|tag");
+        assert_eq!(&out[1..], &[1u8, 0]); // 256 = 0x0100 in BE, top 2 bytes
+    }
+
+    #[test]
+    fn sub_strategy_picked_when_decreasing() {
+        // initial = 1000, final = 998. Add diff overflows (final < initial); Sub diff = 2;
+        // Transform encodes final (998 = 0x03E6 = 2 bytes).
+        // Sub wins because Sub.length=1 (payload 2) < Transform.length=2.
+        let out = run(be32(1000), be32(998));
+        assert_eq!(out[0], (1u8 << 3) | 2, "Sub with 1-byte payload");
+        assert_eq!(&out[1..], &[2u8]);
+    }
+
+    #[test]
+    fn transform_strategy_picked_when_only_one_applies() {
+        // initial = U256::MAX, final = 5:
+        //  - Add (final - initial) overflows on unsigned subtract (final < initial) -> not applicable
+        //  - Sub (initial - final) = 2^256 - 6 -> 32-byte payload, not applicable
+        //  - Transform (final itself) = 5 -> 1-byte payload, applicable
+        // Only Transform fits, so it must be picked even though it isn't first.
+        let max = [0xff_u8; 32];
+        let out = run(max, be32(5));
+        assert_eq!(out[0], (1u8 << 3) | 3, "Transform with 1-byte payload");
+        assert_eq!(&out[1..], &[5u8]);
+    }
+
+    #[test]
+    fn nothing_strategy_when_all_diffs_too_large() {
+        // initial and final are both random-looking 32-byte values that don't compress.
+        // We construct values such that:
+        // - Add diff = 32 bytes (because the result has top bytes set)
+        // - Sub diff = 32 bytes
+        // - Transform on final = 32 bytes
+        // -> Nothing is the only applicable strategy, emits 33 bytes.
+        let initial = [
+            0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
+            0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
+            0x00, 0xff, 0x00, 0xff,
+        ];
+        let r#final = [
+            0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00,
+            0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00,
+            0xff, 0x00, 0xff, 0x00,
+        ];
+        let out = run(initial, r#final);
+        assert_eq!(out.len(), 33, "Nothing strategy emits metadata + 32 bytes");
+        assert_eq!(out[0], 0, "Nothing metadata = 0");
+        assert_eq!(&out[1..], &r#final[..]);
+    }
+
+    #[test]
+    fn no_change_uses_one_byte() {
+        // initial == final → both Add/Sub diffs are 0 (length 0), Transform on final
+        // depends on final. For final = 0, Transform also = 0. The metadata is then
+        // 1 byte total (metadata) + 0 byte payload. Add is selected first with bytes=0.
+        let out = run(be32(42), be32(42));
+        assert_eq!(out.len(), 1, "zero-byte payload + 1-byte metadata");
+        // Add wins (bytes=0, tag=1) -> metadata = (0<<3)|1 = 1
+        assert_eq!(out[0], 1);
+    }
+
+    #[test]
+    fn length_function_agrees_with_emit_across_corpus() {
+        // Sweep a small grid of value pairs and assert
+        // optimal_compression_length matches the byte count emitted by
+        // optimal_compression. This is the contract pubdata accounting
+        // depends on.
+        let corpus_lo: [u128; 7] = [0, 1, 255, 256, 1 << 32, 1 << 64, u128::MAX];
+        let mut hi_pattern = [0u8; 32];
+        hi_pattern[0] = 0xab;
+        hi_pattern[15] = 0xcd;
+        let extras = [[0u8; 32], hi_pattern, [0xff; 32]];
+
+        for &a in &corpus_lo {
+            for &b in &corpus_lo {
+                let _ = run(be32(a), be32(b));
+            }
+        }
+        for &a in &extras {
+            for &b in &extras {
+                let _ = run(a, b);
+            }
+        }
     }
 }

--- a/zk_ee/src/common_structs/state_root_view.rs
+++ b/zk_ee/src/common_structs/state_root_view.rs
@@ -1,7 +1,9 @@
 use crate::oracle::usize_serialization::{UsizeDeserializable, UsizeSerializable};
 use crate::system::errors::internal::InternalError;
 use crate::system::logger::Logger;
+use crate::utils::Bytes32;
 use crate::{oracle::IOOracle, types_config::SystemIOTypesConfig};
+use alloc::collections::BTreeMap;
 use core::alloc::Allocator;
 
 #[derive(Clone, Copy, Debug)]
@@ -24,11 +26,14 @@ use crate::common_structs::{WarmStorageKey, WarmStorageValue};
 pub trait StateRootView<IOTypes: SystemIOTypesConfig>:
     Clone + UsizeSerializable + UsizeDeserializable + core::fmt::Debug
 {
+    /// Returns a `BTreeMap` mapping derived flat storage keys to their tree indices.
+    /// Pubdata encoding uses this to write a compact index for repeated writes
+    /// instead of the full 32-byte derived key.
     fn verify_and_apply_batch<O: IOOracle, A: Allocator + Clone + Default>(
         &mut self,
         oracle: &mut O,
         source: impl Iterator<Item = (WarmStorageKey, WarmStorageValue)> + Clone,
         allocator: A,
         logger: &mut impl Logger,
-    ) -> Result<(), InternalError>;
+    ) -> Result<BTreeMap<Bytes32, u64, A>, InternalError>;
 }

--- a/zk_ee/src/system/io.rs
+++ b/zk_ee/src/system/io.rs
@@ -144,7 +144,10 @@ pub trait IOSubsystem: Sized {
         DeconstructionSubsystemError,
     >;
 
-    fn net_pubdata_used(&self) -> Result<u64, InternalError>;
+    fn net_pubdata_used(
+        &self,
+        repeated_write_index_encoding_length: u8,
+    ) -> Result<u64, InternalError>;
 
     /// Starts a new "local" frame that does not track memory (like `near_call` in the EraVM).
     /// Returns a snapshot to which the system can rollback to on frame finish.

--- a/zk_ee/src/system/metadata/basic_metadata.rs
+++ b/zk_ee/src/system/metadata/basic_metadata.rs
@@ -66,6 +66,9 @@ pub trait ZkSpecificPricingMetadata {
 
     /// Price in base token of 1 byte of pubdata.
     fn get_pubdata_price(&self) -> U256;
+
+    /// Length in bytes of the encoding of repeated write indices in storage diffs.
+    fn repeated_write_index_encoding_length(&self) -> u8;
 }
 
 /// Convenience super-trait for environments that expose both block- and tx-level

--- a/zk_ee/src/system/metadata/system_metadata.rs
+++ b/zk_ee/src/system/metadata/system_metadata.rs
@@ -100,6 +100,9 @@ impl<
     fn get_pubdata_price(&self) -> U256 {
         self.block_level.get_pubdata_price()
     }
+    fn repeated_write_index_encoding_length(&self) -> u8 {
+        self.block_level.repeated_write_index_encoding_length()
+    }
 }
 
 impl<

--- a/zk_ee/src/system/metadata/zk_metadata.rs
+++ b/zk_ee/src/system/metadata/zk_metadata.rs
@@ -129,6 +129,10 @@ pub struct BlockMetadataFromOracle {
     /// of prevRandao.
     pub mix_hash: U256,
     pub blob_fee: U256,
+    /// Length in bytes used to encode tree indices for repeated storage writes in
+    /// the block's pubdata. Each repeated write encodes its index using exactly
+    /// this many bytes (big-endian, no metadata byte).
+    pub repeated_write_index_encoding_length: u8,
 }
 
 impl BasicBlockMetadata<EthereumIOTypesConfig> for BlockMetadataFromOracle {
@@ -200,6 +204,9 @@ impl ZkSpecificPricingMetadata for BlockMetadataFromOracle {
     fn get_pubdata_limit(&self) -> u64 {
         self.pubdata_limit
     }
+    fn repeated_write_index_encoding_length(&self) -> u8 {
+        self.repeated_write_index_encoding_length
+    }
 }
 
 impl BlockMetadataFromOracle {
@@ -217,6 +224,7 @@ impl BlockMetadataFromOracle {
             block_hashes: BlockHashes::default(),
             mix_hash: U256::ONE,
             blob_fee: U256::ZERO,
+            repeated_write_index_encoding_length: 4,
         }
     }
 }
@@ -225,7 +233,8 @@ impl UsizeSerializable for BlockMetadataFromOracle {
     const USIZE_LEN: usize = <U256 as UsizeSerializable>::USIZE_LEN
         * (5 + BLOCK_HASHES_WINDOW_SIZE)
         + <u64 as UsizeSerializable>::USIZE_LEN * 5
-        + <B160 as UsizeDeserializable>::USIZE_LEN;
+        + <B160 as UsizeDeserializable>::USIZE_LEN
+        + <u8 as UsizeDeserializable>::USIZE_LEN;
 
     fn iter(&self) -> impl ExactSizeIterator<Item = usize> {
         ExactSizeChain::new(
@@ -239,28 +248,31 @@ impl UsizeSerializable for BlockMetadataFromOracle {
                                         ExactSizeChain::new(
                                             ExactSizeChain::new(
                                                 ExactSizeChain::new(
-                                                    UsizeSerializable::iter(&self.eip1559_basefee),
-                                                    UsizeSerializable::iter(&self.pubdata_price),
+                                                    ExactSizeChain::new(
+                                                        UsizeSerializable::iter(&self.eip1559_basefee),
+                                                        UsizeSerializable::iter(&self.pubdata_price),
+                                                    ),
+                                                    UsizeSerializable::iter(&self.native_price),
                                                 ),
-                                                UsizeSerializable::iter(&self.native_price),
+                                                UsizeSerializable::iter(&self.block_number),
                                             ),
-                                            UsizeSerializable::iter(&self.block_number),
+                                            UsizeSerializable::iter(&self.timestamp),
                                         ),
-                                        UsizeSerializable::iter(&self.timestamp),
+                                        UsizeSerializable::iter(&self.chain_id),
                                     ),
-                                    UsizeSerializable::iter(&self.chain_id),
+                                    UsizeSerializable::iter(&self.gas_limit),
                                 ),
-                                UsizeSerializable::iter(&self.gas_limit),
+                                UsizeSerializable::iter(&self.pubdata_limit),
                             ),
-                            UsizeSerializable::iter(&self.pubdata_limit),
+                            UsizeSerializable::iter(&self.coinbase),
                         ),
-                        UsizeSerializable::iter(&self.coinbase),
+                        UsizeSerializable::iter(&self.block_hashes),
                     ),
-                    UsizeSerializable::iter(&self.block_hashes),
+                    UsizeSerializable::iter(&self.mix_hash),
                 ),
-                UsizeSerializable::iter(&self.mix_hash),
+                UsizeSerializable::iter(&self.blob_fee),
             ),
-            UsizeSerializable::iter(&self.blob_fee),
+            UsizeSerializable::iter(&self.repeated_write_index_encoding_length),
         )
     }
 }
@@ -281,6 +293,7 @@ impl UsizeDeserializable for BlockMetadataFromOracle {
         let block_hashes = UsizeDeserializable::from_iter(src)?;
         let mix_hash = UsizeDeserializable::from_iter(src)?;
         let blob_fee = UsizeDeserializable::from_iter(src)?;
+        let repeated_write_index_encoding_length = UsizeDeserializable::from_iter(src)?;
 
         let new = Self {
             eip1559_basefee,
@@ -295,6 +308,7 @@ impl UsizeDeserializable for BlockMetadataFromOracle {
             block_hashes,
             mix_hash,
             blob_fee,
+            repeated_write_index_encoding_length,
         };
 
         Ok(new)

--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -183,8 +183,12 @@ impl<S: SystemTypes> System<S> {
         self.metadata.set_transaction_metadata(tx_level_metadata);
     }
 
-    pub fn net_pubdata_used(&self) -> Result<u64, InternalError> {
-        self.io.net_pubdata_used()
+    pub fn net_pubdata_used(
+        &self,
+        repeated_write_index_encoding_length: u8,
+    ) -> Result<u64, InternalError> {
+        self.io
+            .net_pubdata_used(repeated_write_index_encoding_length)
     }
 
     /// Emit an event, potentially capturing some using an event hook.

--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -231,6 +231,10 @@ where
     pub fn get_pubdata_price(&self) -> ruint::aliases::U256 {
         self.metadata.get_pubdata_price()
     }
+
+    pub fn repeated_write_index_encoding_length(&self) -> u8 {
+        self.metadata.repeated_write_index_encoding_length()
+    }
 }
 
 impl<S: SystemTypes> System<S>


### PR DESCRIPTION
## What ❔

Ports the pubdata-compression feature from `alocascio-pubdata-compression` onto current `draft-0.4.0`. The proving path now emits storage diffs in a v2 compressed format that references **repeated writes by their tree index** (configurable fixed width per block) instead of the full 32-byte derived flat-storage key.

Commits, smallest-first:

1. `feat(metadata): add repeated_write_index_encoding_length to block metadata` — new `u8` field on `BlockMetadataFromOracle` + accessor on `ZkSpecificPricingMetadata` / `System`. Serialization updated; defaults to `4` in `new_for_test`, `5` from the converter (matches the original branch's placeholder).
2. `feat(pubdata): thread repeated_write_index_encoding_length through pubdata accounting` — sized into `net_pubdata_used` / `pubdata_used_by_tx` / per-cache `calculate_pubdata_used_by_tx`. Initial writes still cost the full key (32B slot / 20B account); repeated writes now cost `repeated_write_index_encoding_length` bytes. `StateRootView::verify_and_apply_batch` returns the `BTreeMap<Bytes32, u64, A>` it already builds internally so callers can reuse it.
3. `feat(pubdata): emit v2 compressed storage diffs using tree indices for repeated writes` — new emission layout:
   - Diffs header: `total_diffs (u32 BE) || initial_account_writes (u32 BE) || initial_slot_writes (u32 BE) || index_encoding_length (u8)`
   - Order: initial account writes (20-byte address), initial slot writes (32-byte derived key), then repeated writes (fixed-width tree index).
   - `update_commitment` caches the `derived_key → tree_index` map on the storage model; `apply_storage_diffs_pubdata` consumes it. The proving post-tx-op flows now run `update_commitment` *before* `write_pubdata` so the cache is populated. Sequencing-mode skips pubdata (was a no-op against `ForwardRunningResultKeeper`).
4. `test(rig): set repeated_write_index_encoding_length on rig-built block metadata` — fills the new field in both rig constructors.

## Why ❔

Storage diffs are the dominant pubdata cost. Repeated writes to slots/accounts that already exist in the tree don't need their 32-byte derived key — a per-block fixed-width tree index suffices, since the recipient can recover the key from its tree. With the typical 5-byte index width, repeated writes shrink by **27 bytes each**, and the new explicit initial/repeated split also lets the recipient parse the stream without per-record metadata.

The original branch (`alocascio-pubdata-compression`) was ~140 commits behind current `draft-0.4.0`; ~13 of its 20 commits had been independently upstreamed via PR #418 (native-arch prover input). Rather than fight an unmergeable rebase, this PR re-implements just the pubdata-compression piece on top of current `draft-0.4.0`'s `IOTeardown` / `update_commitment` / `flat_storage_model::apply_storage_diffs_pubdata` architecture.

## Is this a breaking change?
- [x] Yes
- [ ] No

This bumps the on-chain pubdata format and adds a new field to `BlockMetadataFromOracle` (the oracle-side serialization changes).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. — original branch's `pubdata_format.rs` byte-level test was **not** ported (it depends on a new rig `run_block_get_pubdata` helper). Pubdata size is exercised by the existing CI pubdata benchmark.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

## Follow-ups before merge

- Wire `repeated_write_index_encoding_length` through `BlockContext` in `zksync-os-interface`; the two hardcoded `5` placeholders (`forward_system/src/run/convert.rs`, `tests/rig/src/chain.rs`) and the test default `4` (`new_for_test`) are tagged with TODOs.
- Port the byte-level pubdata-format unit test once `run_block_get_pubdata` exists in the rig.
- Confirm the CI pubdata benchmark numbers (this is the headline savings figure for the PR).