### PR TITLE
perf(history_map): box elements, pointer-only pending list

### DIFF
--- a/zk_ee/src/common_structs/history_map/element_with_history.rs
+++ b/zk_ee/src/common_structs/history_map/element_with_history.rs
@@ -12,7 +12,13 @@ pub struct HistoryRecord<V> {
 }
 
 /// The history linked list. Always has at least one item with the snapshot id of 0.
-pub struct ElementWithHistory<V, A: Allocator + Clone, EP = ()> {
+///
+/// `key` is embedded so that the pending-updates list can store a stable pointer
+/// to an `ElementWithHistory` and still surface the key on iteration, avoiding
+/// a `BTreeMap::get(&K)` lookup per pending entry.
+pub struct ElementWithHistory<K, V, A: Allocator + Clone, EP = ()> {
+    /// Key owned by this element (separate from the BTreeMap key copy).
+    pub key: K,
     /// Additional properties associated with the element globally.
     /// These properties persist across rollbacks/commits and don't participate in snapshots
     pub element_properties: EP,
@@ -27,9 +33,10 @@ pub struct ElementWithHistory<V, A: Allocator + Clone, EP = ()> {
     marker: PhantomData<A>,
 }
 
-impl<V, A: Allocator + Clone, KP> ElementWithHistory<V, A, KP> {
+impl<K, V, A: Allocator + Clone, KP> ElementWithHistory<K, V, A, KP> {
     #[inline(always)]
     pub fn new(
+        key: K,
         key_properties: KP,
         initial_value: V,
         records_memory_pool: &mut ElementPool<V, A>,
@@ -38,6 +45,7 @@ impl<V, A: Allocator + Clone, KP> ElementWithHistory<V, A, KP> {
         let elem = records_memory_pool.create_element(initial_value, None, CacheSnapshotId(0));
 
         Self {
+            key,
             element_properties: key_properties,
             head: elem,
             initial: elem,
@@ -159,7 +167,7 @@ mod tests {
 
     fn check_that_head_is_initial_element(
         expected_value: usize,
-        element_with_history: &ElementWithHistory<usize, Global>,
+        element_with_history: &ElementWithHistory<(), usize, Global>,
     ) {
         assert_eq!(element_with_history.head, element_with_history.initial);
         assert_eq!(element_with_history.head, element_with_history.first);
@@ -177,8 +185,8 @@ mod tests {
     #[test]
     fn initializes_correctly() {
         let mut element_pool = ElementPool::new(Global);
-        let element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         check_that_head_is_initial_element(1, &element_with_history);
 
@@ -188,8 +196,8 @@ mod tests {
     #[test]
     fn adds_new_records_and_rollbacks_them() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         let first_element =
             element_pool.create_element(2, Some(element_with_history.head), CacheSnapshotId(1));
@@ -219,8 +227,8 @@ mod tests {
     #[test]
     fn rollbacks_to_initial_as_head() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         element_with_history.rollback(&mut element_pool, CacheSnapshotId(0));
         check_that_head_is_initial_element(1, &element_with_history);
@@ -230,8 +238,8 @@ mod tests {
     #[test]
     fn rollbacks() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         element_with_history.add_new_record(element_pool.create_element(
             2,
@@ -247,8 +255,8 @@ mod tests {
     #[test]
     fn commits_with_initial_value() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         element_with_history.commit(&mut element_pool);
         check_that_head_is_initial_element(1, &element_with_history);
@@ -258,8 +266,8 @@ mod tests {
     #[test]
     fn commits_one_record() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         let new_element =
             element_pool.create_element(2, Some(element_with_history.head), CacheSnapshotId(1));
@@ -275,8 +283,8 @@ mod tests {
     #[test]
     fn commits_two_records() {
         let mut element_pool = ElementPool::new(Global);
-        let mut element_with_history: ElementWithHistory<usize, Global> =
-            ElementWithHistory::new((), 1, &mut element_pool);
+        let mut element_with_history: ElementWithHistory<(), usize, Global> =
+            ElementWithHistory::new((), (), 1, &mut element_pool);
 
         let new_element =
             element_pool.create_element(2, Some(element_with_history.head), CacheSnapshotId(1));

--- a/zk_ee/src/common_structs/history_map/mod.rs
+++ b/zk_ee/src/common_structs/history_map/mod.rs
@@ -251,8 +251,8 @@ where
         &'_ self,
     ) -> impl ExactSizeIterator<Item = HistoryMapItemRef<'_, K, V, A, KP>> + Clone {
         self.btree
-            .iter()
-            .map(|(_k, v)| HistoryMapItemRef { history: &**v })
+            .values()
+            .map(|v| HistoryMapItemRef { history: &**v })
     }
 
     /// Iterate over all elements that changed since last commit

--- a/zk_ee/src/common_structs/history_map/mod.rs
+++ b/zk_ee/src/common_structs/history_map/mod.rs
@@ -6,9 +6,10 @@ pub mod element_with_history;
 use crate::common_structs::history_map::element_with_history::HistoryRecord;
 use crate::internal_error;
 use crate::{system::errors::internal::InternalError, utils::stack_linked_list::StackLinkedList};
+use alloc::boxed::Box;
 use alloc::collections::btree_map::Entry;
 use alloc::collections::BTreeMap;
-use core::{alloc::Allocator, fmt::Debug, ops::Bound};
+use core::{alloc::Allocator, fmt::Debug, ops::Bound, ptr::NonNull};
 pub(crate) use element_pool::ElementPool;
 use element_with_history::ElementWithHistory;
 
@@ -35,31 +36,40 @@ impl CacheSnapshotId {
     }
 }
 
+/// Stable pointer to an `ElementWithHistory` owned by the `HistoryMap`.
+/// Stability comes from the `Box` wrapper around the value in the `BTreeMap`:
+/// node splits relocate the `Box` itself but never the heap-allocated payload.
+type ElementPtr<K, V, A, KP> = NonNull<ElementWithHistory<K, V, A, KP>>;
+
 /// A key-value map with history. State can be reverted to snapshots.
 /// The snapshots are created using `Self::snapshot(...)` method.
+///
+/// Each `ElementWithHistory` is `Box`-allocated so its address is stable across
+/// BTreeMap node splits; the pending-updates list stores raw pointers to these
+/// elements, avoiding a `BTreeMap::get(&K)` lookup on rollback/commit/iter paths.
 ///
 /// Structure:
 /// [ keys ] => [ history ] := [ snapshot 0 .. snapshot n ].
 pub struct HistoryMap<K, V, A: Allocator + Clone, KP = ()> {
-    /// Map from key to history of an element
-    btree: BTreeMap<K, ElementWithHistory<V, A, KP>, A>,
-    state: HistoryMapState<K, A>,
+    /// Map from key to history of an element (boxed for address stability).
+    btree: BTreeMap<K, Box<ElementWithHistory<K, V, A, KP>, A>, A>,
+    state: HistoryMapState<K, V, A, KP>,
     /// Manages memory allocations for history records, reuses old allocations for optimization
     records_memory_pool: ElementPool<V, A>,
 }
 
-struct HistoryMapState<K, A: Allocator + Clone> {
+struct HistoryMapState<K, V, A: Allocator + Clone, KP> {
     next_snapshot_id: CacheSnapshotId,
     /// State can't be rolled back further than frozen snapshot id. Useful for transactions boundaries
     frozen_snapshot_id: CacheSnapshotId,
-    /// List of updated elements that were not yet "frozen"
-    pending_updated_elements: StackLinkedList<(K, CacheSnapshotId), A>,
+    /// Chronological list of pointers to elements updated since the last commit.
+    pending_updated_elements: StackLinkedList<(ElementPtr<K, V, A, KP>, CacheSnapshotId), A>,
     alloc: A,
 }
 
 impl<K, V, A, KP> HistoryMap<K, V, A, KP>
 where
-    K: Ord + Clone + Debug,
+    K: Ord + Clone,
     A: Allocator + Clone,
 {
     pub fn new(alloc: A) -> Self {
@@ -92,14 +102,13 @@ where
     pub fn get<'s>(&'s self, key: &'s K) -> Option<HistoryMapItemRef<'s, K, V, A, KP>> {
         self.btree
             .get(key)
-            .map(|ec| HistoryMapItemRef { key, history: ec })
+            .map(|ec| HistoryMapItemRef { history: &**ec })
     }
 
     /// Get history of an element by key, mutable
     pub fn get_mut<'s>(&'s mut self, key: &'s K) -> Option<HistoryMapItemRefMut<'s, K, V, A, KP>> {
         self.btree.get_mut(key).map(|ec| HistoryMapItemRefMut {
-            key,
-            history: ec,
+            history: &mut **ec,
             cache_state: &mut self.state,
             records_memory_pool: &mut self.records_memory_pool,
         })
@@ -117,17 +126,20 @@ where
             Entry::Occupied(o) => o.into_mut(),
             Entry::Vacant(vacant_entry) => {
                 let (v, properties) = spawn_v()?;
-                vacant_entry.insert(ElementWithHistory::new(
-                    properties,
-                    v,
-                    &mut self.records_memory_pool,
+                vacant_entry.insert(Box::new_in(
+                    ElementWithHistory::new(
+                        key.clone(),
+                        properties,
+                        v,
+                        &mut self.records_memory_pool,
+                    ),
+                    self.state.alloc.clone(),
                 ))
             }
         };
 
         Ok(HistoryMapItemRefMut {
-            key,
-            history: v,
+            history: &mut **v,
             cache_state: &mut self.state,
             records_memory_pool: &mut self.records_memory_pool,
         })
@@ -160,19 +172,19 @@ where
         loop {
             match node {
                 None => break,
-                Some((key, update_snapshot_id)) => {
+                Some((mut element_ptr, update_snapshot_id)) => {
                     // The items in the address_snapshot_updates are ordered chronologically.
                     if update_snapshot_id <= snapshot_id {
                         self.state
                             .pending_updated_elements
-                            .push((key, update_snapshot_id));
+                            .push((element_ptr, update_snapshot_id));
                         break;
                     }
 
-                    let item = self
-                        .btree
-                        .get_mut(&key)
-                        .expect("We've updated this, so it must be present.");
+                    // Safety: pointer is stable for the lifetime of the entry in the
+                    // BTreeMap. The Box pins the inner ElementWithHistory; only `clear()`
+                    // can drop it, and `clear()` also drops the pending list.
+                    let item = unsafe { element_ptr.as_mut() };
 
                     item.rollback(&mut self.records_memory_pool, snapshot_id);
 
@@ -190,12 +202,9 @@ where
         self.state.frozen_snapshot_id = self.snapshot();
 
         // Go over all elements changed since last `commit` and `commit` their history
-        for (key, _) in self.state.pending_updated_elements.iter() {
-            let item = self
-                .btree
-                .get_mut(key)
-                .expect("We've updated this, so it must be present.");
-
+        for (element_ptr, _) in self.state.pending_updated_elements.iter() {
+            // Safety: pointer is stable; no live &mut to the element exists.
+            let item = unsafe { &mut *element_ptr.as_ptr() };
             item.commit(&mut self.records_memory_pool);
         }
 
@@ -226,10 +235,9 @@ where
     where
         F: FnMut(HistoryMapItemRefMut<K, V, A, KP>) -> Result<(), InternalError>,
     {
-        for (k, v) in self.btree.range_mut(range) {
+        for (_k, v) in self.btree.range_mut(range) {
             do_fn(HistoryMapItemRefMut {
-                key: &k,
-                history: v,
+                history: &mut **v,
                 cache_state: &mut self.state,
                 records_memory_pool: &mut self.records_memory_pool,
             })?
@@ -244,7 +252,7 @@ where
     ) -> impl ExactSizeIterator<Item = HistoryMapItemRef<'_, K, V, A, KP>> + Clone {
         self.btree
             .iter()
-            .map(|(k, v)| HistoryMapItemRef { key: k, history: v })
+            .map(|(_k, v)| HistoryMapItemRef { history: &**v })
     }
 
     /// Iterate over all elements that changed since last commit
@@ -254,12 +262,10 @@ where
         self.state
             .pending_updated_elements
             .iter()
-            .map(|(k, _)| HistoryMapItemRef {
-                key: k,
-                history: self
-                    .btree
-                    .get(k)
-                    .expect("We've updated this, so it must be present."),
+            .map(|(ptr, _)| HistoryMapItemRef {
+                // Safety: pointer derived from a Box-owned ElementWithHistory which is
+                // alive for the duration of `&self`.
+                history: unsafe { ptr.as_ref() },
             })
     }
 
@@ -275,12 +281,14 @@ where
             &mut KP,
         ) -> Result<(), InternalError>,
     {
-        for (k, _v) in self.state.pending_updated_elements.iter() {
-            let record = self.btree.get_mut(&k).unwrap();
+        for (ptr, _) in self.state.pending_updated_elements.iter() {
+            // Safety: stable pointer to the Box-owned ElementWithHistory.
+            let record = unsafe { &mut *ptr.as_ptr() };
+            let key = &record.key;
             let initial = unsafe { record.initial.as_ref() };
             let current = unsafe { record.head.as_mut() };
             let cache_appearance = &mut record.element_properties;
-            do_fn(k, (initial, current), cache_appearance)?
+            do_fn(key, (initial, current), cache_appearance)?
         }
 
         Ok(())
@@ -288,21 +296,19 @@ where
 }
 
 /// External reference to element's history
-pub struct HistoryMapItemRef<'a, K: Clone, V, A: Allocator + Clone, KP = ()> {
-    key: &'a K,
-    history: &'a ElementWithHistory<V, A, KP>,
+pub struct HistoryMapItemRef<'a, K, V, A: Allocator + Clone, KP = ()> {
+    history: &'a ElementWithHistory<K, V, A, KP>,
 }
 
 impl<'a, K, V, A, KP> HistoryMapItemRef<'a, K, V, A, KP>
 where
-    K: Clone,
     A: Allocator + Clone,
 {
     pub fn key(&self) -> &'a K {
-        self.key
+        &self.history.key
     }
 
-    pub fn key_properties(&self) -> &KP {
+    pub fn key_properties(&self) -> &'a KP {
         &self.history.element_properties
     }
 
@@ -325,16 +331,14 @@ where
 }
 
 /// External mutable reference to element's history
-pub struct HistoryMapItemRefMut<'a, K: Clone, V, A: Allocator + Clone, KP = ()> {
-    history: &'a mut ElementWithHistory<V, A, KP>,
-    cache_state: &'a mut HistoryMapState<K, A>,
+pub struct HistoryMapItemRefMut<'a, K, V, A: Allocator + Clone, KP = ()> {
+    history: &'a mut ElementWithHistory<K, V, A, KP>,
+    cache_state: &'a mut HistoryMapState<K, V, A, KP>,
     records_memory_pool: &'a mut ElementPool<V, A>,
-    key: &'a K,
 }
 
 impl<'a, K, V, A, KP> HistoryMapItemRefMut<'a, K, V, A, KP>
 where
-    K: Clone + Debug,
     V: Clone,
     A: Allocator + Clone,
 {
@@ -390,9 +394,14 @@ where
 
             self.history.add_new_record(new);
 
+            // Capture a stable pointer to this element for the pending-updates list.
+            // The pointer remains valid because the underlying box is only freed by
+            // HistoryMap::clear(), which also resets the pending list.
+            let element_ptr = NonNull::from(&mut *self.history);
+
             self.cache_state
                 .pending_updated_elements
-                .push((self.key.clone(), self.cache_state.next_snapshot_id));
+                .push((element_ptr, self.cache_state.next_snapshot_id));
 
             Ok(())
         }


### PR DESCRIPTION
## What ❔

Wraps each `ElementWithHistory` in `Box` so its address is stable across BTreeMap node splits, and stores `NonNull<ElementWithHistory>` in the pending-updates list instead of cloned keys. `K` is embedded inside `ElementWithHistory` so iterators/callbacks that need a key still get one without a BTreeMap lookup.

Affected:
- `zk_ee/src/common_structs/history_map/mod.rs`
- `zk_ee/src/common_structs/history_map/element_with_history.rs`

## Why ❔

`HistoryMap` is on the hot bookkeeping path of storage cache, account cache, transient storage, and preimage publication. Every non-coalesced `update()` cloned `K` (up to 52 B for `WarmStorageKey`) into a `StackLinkedList<(K, CacheSnapshotId), A>`; every `rollback` / `commit` / `iter_altered_since_commit` / `apply_to_last_record_of_pending_changes` then re-resolved each entry via `BTreeMap::get(&K)`.

With this change:
- `update()` no longer clones `K`; pending entry shrinks from `(K, snap)` to `(NonNull, snap)` = 16 B.
- Rollback / commit / pending-iter paths bypass the BTreeMap descent entirely.
- BTreeMap lookups on warm reads/writes (`get`, `get_mut`, `get_or_insert`) are unchanged — this targets the bookkeeping paths, not steady-state EVM dispatch.

Cost: one `Box::new_in` per *unique* key inserted in the map's lifetime, plus an extra `K` copy embedded inside `ElementWithHistory` (in addition to the BTreeMap key copy).

## Benchmark results

Branch vs `draft-0.4.0` (commit `d62b8ad2`):

| Block | Base eff | Head eff | Δ |
|---|---|---|---|
| `19299001` | 208,601,280 | 204,530,358 | **−1.95 %** |
| `22244135` | 134,741,585 | 132,440,306 | **−1.71 %** |

Raw cycles drop −2.57 % / −2.17 %; Blake/Bigint/Keccak delegation counts unchanged. `compare_opcode_stats.py` reports no per-opcode regressions, consistent with the change living outside the EVM hot loop.

## Is this a breaking change?
- [ ] Yes
- [x] No

Public API of `HistoryMap`, `HistoryMapItemRef`, `HistoryMapItemRefMut` is preserved. Internal `ElementWithHistory` gains a `K` type parameter, but it isn't constructed outside this module.

## Notes / follow-ups

- Soundness rests on the fact that elements never leave the `Box` until `HistoryMap::clear()`, which also resets the pending list — so pointers stored in pending are valid for their lifetime there. The unsafe blocks are annotated.
- Pre-existing MIRI Tree-Borrows finding in `element_pool.rs` (`NonNull::from_ref` followed by later `as_mut`) is present on `draft-0.4.0` too; not addressed here.
- Option B (arena-allocate `ElementWithHistory` from a `ListVec` pool like the existing `ElementPool`) would amortize allocations and is the natural next step if `Box` per unique key shows up — left unimplemented for now.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated. (Existing `miri_*` and rig-style HistoryMap tests cover the new code paths; internal `ElementWithHistory` tests updated for the new `K` type parameter.)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.