### PR TITLE
perf(caches): trim clones in storage write path

### DIFF
--- a/basic_system/src/system_implementation/caches/generic_pubdata_aware_plain_storage.rs
+++ b/basic_system/src/system_implementation/caches/generic_pubdata_aware_plain_storage.rs
@@ -240,7 +240,7 @@ impl<
         new_value: &V,
         oracle: &mut impl IOOracle,
         resources: &mut R,
-    ) -> Result<(V, V), SystemError>
+    ) -> Result<V, SystemError>
     where
         StorageAddress<EthereumIOTypesConfig>: From<K>,
     {
@@ -254,15 +254,13 @@ impl<
             oracle,
         )?;
 
+        let val_at_tx_start = addr_data.committed().value();
         let val_current = addr_data.current().value();
-
-        // Try to get initial value at the beginning of the tx.
-        let val_at_tx_start = addr_data.committed().value().clone();
-
         let is_new_slot = addr_data.element_properties().is_new_element();
+
         self.resources_policy.charge_storage_write_extra(
             ee_type,
-            &val_at_tx_start,
+            val_at_tx_start,
             val_current,
             new_value,
             resources,
@@ -270,27 +268,30 @@ impl<
             is_new_slot,
         )?;
 
-        let old_value = addr_data.current().value().clone();
+        // Compute refund before mutating the cache, so val_at_tx_start and
+        // val_current can stay borrowed from addr_data.
+        let mut refund_counter_value = self.evm_refunds_counter.value().clone();
+        self.resources_policy.refund_for_storage_write(
+            ee_type,
+            val_at_tx_start,
+            val_current,
+            new_value,
+            resources,
+            &mut refund_counter_value,
+        )?;
+
+        // Detach owned old_value from addr_data's borrow before the update.
+        let old_value = val_current.clone();
+
         addr_data.update(|cache_record| {
             cache_record.update(|x, _| {
                 *x = new_value.clone();
                 Ok(())
             })
         })?;
-
-        // Add refund for storage
-        let mut refund_counter_value = self.evm_refunds_counter.value().clone();
-        self.resources_policy.refund_for_storage_write(
-            ee_type,
-            &val_at_tx_start,
-            &old_value,
-            new_value,
-            resources,
-            &mut refund_counter_value,
-        )?;
         self.evm_refunds_counter.update(refund_counter_value);
 
-        Ok((old_value, val_at_tx_start))
+        Ok(old_value)
     }
 
     /// Clear state at specified address

--- a/basic_system/src/system_implementation/ethereum_storage_model/caches/full_storage_cache.rs
+++ b/basic_system/src/system_implementation/ethereum_storage_model/caches/full_storage_cache.rs
@@ -92,7 +92,7 @@ impl<
             key: *key,
         };
 
-        let (old_value, _) = self
+        let old_value = self
             .slot_values
             .apply_write_impl(ee_type, &key, new_value, oracle, resources)?;
 

--- a/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
@@ -99,8 +99,7 @@ impl<
             key: *key,
         };
 
-        #[allow(unused_variables)]
-        let (old_value, val_at_tx_start) = self
+        let old_value = self
             .0
             .apply_write_impl(ee_type, &key, new_value, oracle, resources)?;
 
@@ -165,7 +164,7 @@ impl<
             core::ptr::read((new_value as *const T::Value).cast::<Bytes32>())
         };
 
-        let (old_value, _) = self
+        let old_value = self
             .0
             .apply_write_impl(ee_type, &key, &new_value, oracle, resources)?;
 


### PR DESCRIPTION
## What ❔

`apply_write_impl` returned `(V, V)` where the second element (`val_at_tx_start`) was ignored at all three callers (one had `#[allow(unused_variables)]`, two used `_`). Drop it.

With the second return gone, `refund_for_storage_write` is moved before `addr_data.update(...)` so `val_at_tx_start` and `val_current` can stay borrowed straight from `addr_data` — eliminating the `val_at_tx_start.clone()` and the redundant `addr_data.current().value().clone()`. Body V clones: 2 → 1.

## Why ❔

Reduces wasted work in the SSTORE / SLOAD hot path. The cleanup also removes an `#[allow(unused_variables)]` smell at the caller site.

Bench (`bench_scripts/bench.sh` on `block_19299001` / `block_22244135`):

| Block | Eff cycles Δ | Raw cycles Δ |
|---|---|---|
| `block_19299001` | −0.036% (−74K) | −0.047% (−74K) |
| `block_22244135` | −0.037% (−49K) | −0.046% (−49K) |

Per-opcode: `SSTORE` median −3.8% (2,355 → 2,266), total −3.5% (~85K cycles across 950 SSTOREs). All Blake / BigInt / Keccak delegation counts unchanged — no behavior drift in the proven path.

## Is this a breaking change?
- [ ] Yes
- [x] No

(Internal API — only the three in-tree callers of `apply_write_impl`.)

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated. (No new tests; existing `basic_system` unit suite + block replay cover the path. Pre-existing MPT test failures on `draft-0.4.0` are unrelated and reproduce on the unmodified parent branch.)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)