### PR TITLE
perf(bytes32): word-chunked cmp on RV32, libc memcmp on host

### DIFF
--- a/zk_ee/src/utils/bytes32.rs
+++ b/zk_ee/src/utils/bytes32.rs
@@ -41,6 +41,10 @@ impl Bytes32 {
     /// the alternative is `compiler-builtins`' generic byte-by-byte `memcmp`.
     /// Observable ordering is identical to `as_u8_array_ref().cmp(...)` on
     /// either endianness.
+    // Compiled on every target so the equivalence tests can validate it on the
+    // host, but only wired into `Ord` on RV32 — non-test host builds see no
+    // callers, hence the `dead_code` allow.
+    #[cfg_attr(not(target_arch = "riscv32"), allow(dead_code))]
     #[inline]
     fn cmp_word_chunked(&self, other: &Self) -> core::cmp::Ordering {
         for i in 0..BYTES32_USIZE_SIZE {

--- a/zk_ee/src/utils/bytes32.rs
+++ b/zk_ee/src/utils/bytes32.rs
@@ -22,15 +22,70 @@ const _: () = const {
     assert!(core::mem::align_of::<Bytes32>() >= core::mem::align_of::<usize>());
 };
 
-// we compare as integers to avoid any potential ambiguity
+// Comparison: byte-lexicographic on the underlying 32-byte view.
+//
+// On the RISC-V proving target, `<[u8]>::cmp` lowers to `compiler-builtins`'
+// generic byte-by-byte `memcmp` — a hot path through `find_key_index` on
+// BTreeMap lookups. We replace it with a word-by-word equality scan over the
+// storage `usize`s (`cmp_word_chunked` below); on the first differing word
+// we resolve byte-lex order by walking the bytes of just that word — cheaper
+// than `swap_bytes()` on RV32 without the Zbb extension.
+//
+// On the host (forward mode), libc's `memcmp` is already SIMD-vectorized
+// (SSE2/AVX/NEON), so the byte path beats a word loop in pure Rust. The
+// `Ord` impl picks the right strategy via `#[cfg]`. The chunked helper is
+// always compiled so its correctness is testable on the host as well.
 
+impl Bytes32 {
+    /// Word-chunked byte-lex compare. Used as the `Ord` impl on RV32 where
+    /// the alternative is `compiler-builtins`' generic byte-by-byte `memcmp`.
+    /// Observable ordering is identical to `as_u8_array_ref().cmp(...)` on
+    /// either endianness.
+    #[inline]
+    fn cmp_word_chunked(&self, other: &Self) -> core::cmp::Ordering {
+        for i in 0..BYTES32_USIZE_SIZE {
+            let a = self.inner[i];
+            let b = other.inner[i];
+            if a != b {
+                // `to_ne_bytes()` returns the bytes of the word in their in-memory
+                // order — identical to the slice produced by `as_u8_array_ref()`
+                // for the same offsets, on either endianness.
+                let a_bytes = a.to_ne_bytes();
+                let b_bytes = b.to_ne_bytes();
+                let mut j = 0;
+                while j < core::mem::size_of::<usize>() {
+                    if a_bytes[j] != b_bytes[j] {
+                        return a_bytes[j].cmp(&b_bytes[j]);
+                    }
+                    j += 1;
+                }
+                // a != b guarantees at least one byte differs; this branch
+                // is dead. Fall through to keep the function panic-free.
+                return core::cmp::Ordering::Equal;
+            }
+        }
+        core::cmp::Ordering::Equal
+    }
+}
+
+#[cfg(target_arch = "riscv32")]
 impl Ord for Bytes32 {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.cmp_word_chunked(other)
+    }
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+impl Ord for Bytes32 {
+    #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.as_u8_array_ref().cmp(other.as_u8_array_ref())
     }
 }
 
 impl PartialOrd for Bytes32 {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -328,5 +383,113 @@ impl UsizeDeserializable for Bytes32 {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod cmp_tests {
+    use super::Bytes32;
+    use core::cmp::Ordering;
+
+    fn reference_cmp(a: &Bytes32, b: &Bytes32) -> Ordering {
+        a.as_u8_array_ref().cmp(b.as_u8_array_ref())
+    }
+
+    #[test]
+    fn cmp_matches_byte_lex_on_handcrafted_pairs() {
+        let cases: &[([u8; 32], [u8; 32])] = &[
+            ([0; 32], [0; 32]),
+            ([0; 32], [1; 32]),
+            ([0xFF; 32], [0; 32]),
+            ([0xFF; 32], [0xFF; 32]),
+            (
+                [
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ],
+                [
+                    2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                ],
+            ),
+            (
+                [
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 1,
+                ],
+                [
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 2,
+                ],
+            ),
+            (
+                [
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0xAA, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                ],
+                [
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0xBB, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                ],
+            ),
+        ];
+
+        for (a, b) in cases {
+            let lhs = Bytes32::from_array(*a);
+            let rhs = Bytes32::from_array(*b);
+            // Exercise the chunked helper directly so this test validates the
+            // RV32 codepath even when the host build's `Ord` uses libc memcmp.
+            assert_eq!(
+                lhs.cmp_word_chunked(&rhs),
+                reference_cmp(&lhs, &rhs),
+                "mismatch on {:?} vs {:?}",
+                a,
+                b
+            );
+            assert_eq!(
+                rhs.cmp_word_chunked(&lhs),
+                reference_cmp(&rhs, &lhs),
+                "reverse mismatch on {:?} vs {:?}",
+                a,
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn cmp_matches_byte_lex_on_pseudorandom_pairs() {
+        // Deterministic LCG; exercises diff at every byte position.
+        let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+        fn step(seed: &mut u64) -> u64 {
+            *seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            *seed
+        }
+
+        for _ in 0..4096 {
+            let mut a = [0u8; 32];
+            let mut b = [0u8; 32];
+            for chunk in a.chunks_exact_mut(8) {
+                chunk.copy_from_slice(&step(&mut seed).to_le_bytes());
+            }
+            for chunk in b.chunks_exact_mut(8) {
+                chunk.copy_from_slice(&step(&mut seed).to_le_bytes());
+            }
+
+            // Sometimes share a prefix so we hit varying mismatch positions.
+            let prefix_len = (step(&mut seed) as usize) % 33;
+            b[..prefix_len].copy_from_slice(&a[..prefix_len]);
+
+            let lhs = Bytes32::from_array(a);
+            let rhs = Bytes32::from_array(b);
+            assert_eq!(
+                lhs.cmp_word_chunked(&rhs),
+                reference_cmp(&lhs, &rhs),
+                "mismatch on {:?} vs {:?}",
+                a,
+                b
+            );
+        }
     }
 }


### PR DESCRIPTION
## What ❔

Replaces `Bytes32`'s `Ord` impl on **the RISC-V proving target only** with a word-by-word equality scan over the underlying `inner: [usize; BYTES32_USIZE_SIZE]` (N=4 on 64-bit, 8 on RISC-V32):

- Equal-prefix iterations stay in the fast path: load word, compare word, branch.
- On the first differing word, resolve byte-lex order by walking the bytes of just that word — cheaper than `swap_bytes()` on RV32 without the Zbb extension (which this target does not enable).
- `cmp` / `partial_cmp` are `#[inline]` since they sit on the BTreeMap descent hot path.

On non-RV32 targets (forward / sequencer host) the impl falls back to the original `as_u8_array_ref().cmp(...)`. libc's `memcmp` is already SIMD-vectorized (SSE2/AVX/NEON), so the byte path beats a pure-Rust word loop on the host. The chunked helper (`cmp_word_chunked`) is still compiled on every target so the equivalence tests can validate it on the host.

Affected:
- `zk_ee/src/utils/bytes32.rs`

## Why ❔

From the flamegraph analysis on `draft-0.4.0`:

- `impls::compare_bytes` is the **second-highest self-cost function in the binary at 6.47 %**. On no-std RISC-V the `<[u8]>::cmp` path falls back to `compiler-builtins`' generic `memcmp` (`compiler-builtins/src/mem/impls.rs:388`) — a plain byte loop with no chunking.
- Almost all of that self-cost is reached through `Bytes32::cmp` (directly, or via `WarmStorageKey::cmp` → `Bytes32::cmp`) sitting inside `NodeRef::find_key_index` in HistoryMap / preimage / FlatStorageCommitment lookups.

Comparing word-aligned 32-byte values byte-by-byte is wasteful when the struct is already a `[usize; N]` with `align(8)`. Forward mode doesn't need the rewrite because libc memcmp already handles it efficiently.

## Benchmark results

Branch vs `origin/draft-0.4.0` (commit `59bdedfa`):

| Block | Base eff | Head eff | Δ eff | Δ raw |
|---|---|---|---|---|
| `19299001` | 208,601,280 | 204,648,699 | **−1.89 %** | **−2.49 %** |
| `22244135` | 134,741,585 | 132,504,954 | **−1.66 %** | **−2.10 %** |

Blake / Bigint / Keccak delegation counts unchanged in both runs — pure raw-cycle reduction.

### Variant comparison (RV32 only — host path is unchanged)

| Variant | block 19299001 Δ eff | block 22244135 Δ eff |
|---|---|---|
| word-cmp + `to_be()` bswap on mismatch | −1.56 % | −1.39 % |
| **word-cmp + `#[inline]` + byte-fallback (this PR)** | **−1.89 %** | **−1.66 %** |
| word-cmp + 2-word XOR-OR fusion | −1.68 % | −1.45 % |

The 2-word XOR-OR variant regresses vs the simple loop — the extra arithmetic per executed iteration doesn't pay for the halved branch count on RV32. Picked the byte-fallback variant.

## Is this a breaking change?
- [ ] Yes
- [x] No

Public API of `Bytes32` is unchanged. `Ord` / `PartialOrd` impls produce identical orderings to the previous implementation on every target (verified by `cmp_tests::cmp_matches_byte_lex_on_pseudorandom_pairs`, which invokes `cmp_word_chunked` directly so the helper is exercised on the host too).

## Stackability with #668 / #669

This PR targets the leaf `compare_bytes` cost; #668 / #669 target the BTreeMap lookups themselves on the pending-list paths. They hit different code regions and are expected to compose (overlap only where BTreeMap node descent invokes `Bytes32::cmp` — and even there the per-compare cost goes down).

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated. (Equivalence tests added: `cmp_matches_byte_lex_on_handcrafted_pairs`, `cmp_matches_byte_lex_on_pseudorandom_pairs`. Both invoke `cmp_word_chunked` directly so the chunked path is exercised on the host.)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.