### PR TITLE
fix(history_map): sound pointer provenance via PtrArena

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,29 @@ jobs:
               run: |
                   cargo clippy --features proving -- -D warnings
 
+    miri:
+        # Runs the `history_map` unit tests under Miri to guard the storage
+        # cache's raw-pointer/arena code against aliasing-provenance UB. Scoped
+        # to `history_map` because that is the module verified Miri-clean; widen
+        # the filter as other modules are made clean. Pure unit tests — no
+        # RISC-V binary needed, so this runs on a lightweight runner.
+        name: Miri (history_map aliasing/UB)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                  # Channel comes from rust-toolchain.toml (pinned nightly);
+                  # `miri` needs `rust-src` to build a checked std.
+                  components: miri, rust-src
+                  rustflags: ""
+            - name: Miri (Stacked Borrows)
+              run: cargo miri test -p zk_ee history_map
+            - name: Miri (Tree Borrows)
+              env:
+                  MIRIFLAGS: "-Zmiri-tree-borrows"
+              run: cargo miri test -p zk_ee history_map
+
     typos:
         name: typos check
         runs-on: ubuntu-latest

--- a/zk_ee/src/common_structs/history_map/element_pool.rs
+++ b/zk_ee/src/common_structs/history_map/element_pool.rs
@@ -1,11 +1,9 @@
-use crate::{common_structs::skip_list_quasi_vec::ListVec, memory::stack_trait::Stack};
-
 use super::{
     element_with_history::{HistoryRecord, HistoryRecordLink},
+    ptr_arena::PtrArena,
     CacheSnapshotId,
 };
-use core::mem::MaybeUninit;
-use core::{alloc::Allocator, ptr::NonNull};
+use core::alloc::Allocator;
 
 /// Manages memory allocations for history records, reuses old allocations for optimization
 pub struct ElementPool<V, A: Allocator + Clone> {
@@ -13,7 +11,9 @@ pub struct ElementPool<V, A: Allocator + Clone> {
     head: Option<HistoryRecordLink<V>>,
     /// Tail of `recycled` sub-list
     last: Option<HistoryRecordLink<V>>,
-    buffer: ListVec<MaybeUninit<HistoryRecord<V>>, 50, A>,
+    /// Stable-address, stable-provenance storage for the records. Handed-out
+    /// `HistoryRecordLink`s stay valid for writes across later allocations.
+    buffer: PtrArena<HistoryRecord<V>, 50, A>,
 }
 
 impl<V, A: Allocator + Clone> ElementPool<V, A> {
@@ -21,7 +21,7 @@ impl<V, A: Allocator + Clone> ElementPool<V, A> {
         Self {
             head: Default::default(),
             last: Default::default(),
-            buffer: ListVec::new_in(alloc.clone()),
+            buffer: PtrArena::new_in(alloc),
         }
     }
 
@@ -34,16 +34,15 @@ impl<V, A: Allocator + Clone> ElementPool<V, A> {
     ) -> HistoryRecordLink<V> {
         match self.head {
             None => {
-                self.buffer.push(MaybeUninit::uninit());
-                let new_element = self.buffer.top_mut().unwrap();
-
-                new_element.write(HistoryRecord {
+                // Bump-allocate a fresh record. The returned pointer carries
+                // page-wide provenance (see `PtrArena`) so later `as_mut()`
+                // writes through it — here, in `reuse_memory`, `rollback`,
+                // `commit` — are sound.
+                self.buffer.push(HistoryRecord {
                     touch_ss_id: snapshot_id,
                     value,
                     previous,
-                });
-
-                unsafe { NonNull::from_ref(new_element.assume_init_ref()) }
+                })
             }
             Some(mut elem) => {
                 // Reuse old allocation

--- a/zk_ee/src/common_structs/history_map/element_with_history_arena.rs
+++ b/zk_ee/src/common_structs/history_map/element_with_history_arena.rs
@@ -1,18 +1,16 @@
 //! Arena allocator for `ElementWithHistory` values.
 //!
-//! Wraps a `ListVec<ElementWithHistory<...>, N, A>` so the underlying values
-//! get a stable in-memory address (the `ArrayVec` slots never relocate, and
-//! new pages are appended to the linked list without touching existing
-//! pages). Storing `NonNull` pointers from this arena in the `HistoryMap`'s
-//! BTreeMap and pending-updates list bypasses BTreeMap descents on the
-//! rollback/commit/iter-pending paths and avoids per-element heap allocations.
+//! Wraps a [`PtrArena`] so the underlying values get a stable in-memory address
+//! *and* stable provenance: the `NonNull` pointers stored in the `HistoryMap`'s
+//! BTreeMap and pending-updates list stay valid for reads and writes across
+//! later allocations. This bypasses BTreeMap descents on the
+//! rollback/commit/iter-pending paths and amortizes per-element allocation over
+//! arena pages.
 
 use core::{alloc::Allocator, ptr::NonNull};
 
-use crate::{common_structs::skip_list_quasi_vec::ListVec, memory::stack_trait::Stack};
-// `Stack` is imported solely for its `clear` method on `ListVec`.
-
 use super::element_with_history::ElementWithHistory;
+use super::ptr_arena::PtrArena;
 
 /// Number of `ElementWithHistory` slots per backing page. Sized so a page
 /// fits within a small handful of cache lines for the K/V types in use
@@ -21,35 +19,26 @@ use super::element_with_history::ElementWithHistory;
 pub(crate) const ELEMENT_PAGE_CAPACITY: usize = 32;
 
 pub struct ElementWithHistoryArena<K, V, A: Allocator + Clone, KP> {
-    buffer: ListVec<ElementWithHistory<K, V, A, KP>, ELEMENT_PAGE_CAPACITY, A>,
+    buffer: PtrArena<ElementWithHistory<K, V, A, KP>, ELEMENT_PAGE_CAPACITY, A>,
 }
 
 impl<K, V, A: Allocator + Clone, KP> ElementWithHistoryArena<K, V, A, KP> {
     pub fn new(alloc: A) -> Self {
         Self {
-            buffer: ListVec::new_in(alloc),
+            buffer: PtrArena::new_in(alloc),
         }
     }
 
     /// Moves `element` into the arena and returns a stable pointer to it.
-    ///
-    /// Uses `ListVec::push_returning_ref` so we walk the backing linked list
-    /// once via `back_mut()` (O(1)) rather than twice via `iter_mut().last()`
-    /// (O(pages) each) as separate `push` + `top_mut` calls would.
     pub fn allocate(
         &mut self,
         element: ElementWithHistory<K, V, A, KP>,
     ) -> NonNull<ElementWithHistory<K, V, A, KP>> {
-        let slot = self.buffer.push_returning_ref(element);
-        NonNull::from(slot)
+        self.buffer.push(element)
     }
 
-    /// Drops every element and releases the arena pages.
+    /// Drops every element (and its owned key) and releases the arena pages.
     pub fn clear(&mut self) {
-        // Goes through the `Stack` trait so we don't couple to `ListVec`'s
-        // internal tuple-struct field. Drops the ArrayVec nodes, which in
-        // turn drop the contained `ElementWithHistory` values (and their
-        // owned keys).
         self.buffer.clear();
     }
 }

--- a/zk_ee/src/common_structs/history_map/mod.rs
+++ b/zk_ee/src/common_structs/history_map/mod.rs
@@ -3,13 +3,14 @@
 mod element_pool;
 pub(crate) mod element_with_history;
 mod element_with_history_arena;
+mod ptr_arena;
 
 use crate::common_structs::history_map::element_with_history::HistoryRecord;
 use crate::internal_error;
 use crate::{system::errors::internal::InternalError, utils::stack_linked_list::StackLinkedList};
 use alloc::collections::btree_map::Entry;
 use alloc::collections::BTreeMap;
-use core::{alloc::Allocator, fmt::Debug, ops::Bound, ptr::NonNull};
+use core::{alloc::Allocator, fmt::Debug, marker::PhantomData, ops::Bound, ptr::NonNull};
 pub(crate) use element_pool::ElementPool;
 use element_with_history::ElementWithHistory;
 use element_with_history_arena::ElementWithHistoryArena;
@@ -126,13 +127,14 @@ where
     pub fn get_mut(&mut self, key: &K) -> Option<HistoryMapItemRefMut<'_, K, V, A, KP>> {
         let ptr = *self.btree.get(key)?;
         Some(HistoryMapItemRefMut {
-            // Safety: pointer is valid for the lifetime of `&mut self`. We borrow
-            // the arena element via the raw pointer rather than re-entering the
-            // BTreeMap so that `cache_state` and `records_memory_pool` can be
-            // borrowed mutably alongside.
-            history: unsafe { &mut *ptr.as_ptr() },
+            // Pointer is valid for the lifetime of `&mut self`. We carry the raw
+            // arena pointer rather than re-entering the BTreeMap so that
+            // `cache_state` and `records_memory_pool` can be borrowed mutably
+            // alongside.
+            element: ptr,
             cache_state: &mut self.state,
             records_memory_pool: &mut self.records_memory_pool,
+            _element_borrow: PhantomData,
         })
     }
 
@@ -158,10 +160,11 @@ where
         };
 
         Ok(HistoryMapItemRefMut {
-            // Safety: pointer is valid for the lifetime of `&mut self`.
-            history: unsafe { &mut *ptr.as_ptr() },
+            // Pointer is valid for the lifetime of `&mut self`.
+            element: ptr,
             cache_state: &mut self.state,
             records_memory_pool: &mut self.records_memory_pool,
+            _element_borrow: PhantomData,
         })
     }
 
@@ -258,10 +261,11 @@ where
     {
         for (_k, ptr) in self.btree.range_mut(range) {
             do_fn(HistoryMapItemRefMut {
-                // Safety: pointer is valid for the lifetime of `&mut self`.
-                history: unsafe { &mut *ptr.as_ptr() },
+                // Pointer is valid for the lifetime of `&mut self`.
+                element: *ptr,
                 cache_state: &mut self.state,
                 records_memory_pool: &mut self.records_memory_pool,
+                _element_borrow: PhantomData,
             })?
         }
 
@@ -354,9 +358,16 @@ where
 
 /// External mutable reference to element's history
 pub struct HistoryMapItemRefMut<'a, K, V, A: Allocator + Clone, KP = ()> {
-    history: &'a mut ElementWithHistory<K, V, A, KP>,
+    /// Canonical arena pointer to the element — the *same* pointer the BTreeMap
+    /// stores. We keep the raw pointer (rather than a `&mut`) so that the
+    /// pointer pushed into the pending-updates list shares the arena's
+    /// provenance: a fresh `&mut`-derived pointer would be invalidated before
+    /// the later commit/rollback writes through it. Borrowed for `'a` via the
+    /// `&'a mut` fields below (and the marker).
+    element: NonNull<ElementWithHistory<K, V, A, KP>>,
     cache_state: &'a mut HistoryMapState<K, V, A, KP>,
     records_memory_pool: &'a mut ElementPool<V, A>,
+    _element_borrow: PhantomData<&'a mut ElementWithHistory<K, V, A, KP>>,
 }
 
 impl<'a, K, V, A, KP> HistoryMapItemRefMut<'a, K, V, A, KP>
@@ -365,29 +376,31 @@ where
     A: Allocator + Clone,
 {
     pub fn current(&self) -> &V {
-        unsafe { &self.history.head.as_ref().value }
+        // Safety: `element` is a valid arena pointer borrowed for `'a`; each
+        // access goes through a transient borrow tied to `&self`.
+        unsafe { &self.element.as_ref().head.as_ref().value }
     }
 
     pub fn initial(&self) -> &V {
-        unsafe { &self.history.initial.as_ref().value }
+        unsafe { &self.element.as_ref().initial.as_ref().value }
     }
 
     pub fn committed(&self) -> &V {
-        unsafe { &self.history.committed.as_ref().value }
+        unsafe { &self.element.as_ref().committed.as_ref().value }
     }
 
     pub fn element_properties(&self) -> &KP {
-        &self.history.element_properties
+        unsafe { &self.element.as_ref().element_properties }
     }
 
     pub fn element_properties_mut(&mut self) -> &mut KP {
-        &mut self.history.element_properties
+        unsafe { &mut self.element.as_mut().element_properties }
     }
 
     #[allow(dead_code)]
     /// Returns (initial_value, current_value) if any
     pub fn get_initial_and_last_values(&self) -> Option<(&V, &V)> {
-        self.history.get_initial_and_last_values()
+        unsafe { self.element.as_ref() }.get_initial_and_last_values()
     }
 
     #[must_use]
@@ -396,17 +409,21 @@ where
     where
         F: FnOnce(&mut V) -> Result<(), E>,
     {
-        let last_history_record = unsafe { self.history.head.as_mut() };
+        // Copy of the current head link; the record lives in the records pool,
+        // a separate allocation from the element, so transient borrows of one
+        // don't conflict with `&mut`-borrows of the other.
+        let head_link = unsafe { self.element.as_ref() }.head;
 
-        if last_history_record.touch_ss_id == self.cache_state.next_snapshot_id {
+        if unsafe { head_link.as_ref() }.touch_ss_id == self.cache_state.next_snapshot_id {
             // We're in the context of the current snapshot: there are changes that we will simply override
-            f(&mut last_history_record.value)
+            let head_record = unsafe { &mut *head_link.as_ptr() };
+            f(&mut head_record.value)
         } else {
             // The item was last updated before the current snapshot.
 
             let mut new = self.records_memory_pool.create_element(
-                last_history_record.value.clone(),
-                Some(self.history.head),
+                unsafe { head_link.as_ref() }.value.clone(),
+                Some(head_link),
                 self.cache_state.next_snapshot_id,
             );
 
@@ -414,15 +431,15 @@ where
                 f(&mut new.as_mut().value)?;
             }
 
-            self.history.add_new_record(new);
+            unsafe { self.element.as_mut() }.add_new_record(new);
 
-            // Stable arena pointer to this element; valid until `HistoryMap::clear`,
-            // which also resets the pending list.
-            let element_ptr = NonNull::from(&mut *self.history);
-
+            // Push the *canonical* arena pointer (the one the BTreeMap holds):
+            // it shares the arena's provenance, so it stays valid for the writes
+            // performed later by `commit`/`rollback`. Valid until
+            // `HistoryMap::clear`, which also resets the pending list.
             self.cache_state
                 .pending_updated_elements
-                .push((element_ptr, self.cache_state.next_snapshot_id));
+                .push((self.element, self.cache_state.next_snapshot_id));
 
             Ok(())
         }
@@ -739,9 +756,9 @@ mod tests {
         use super::element_with_history_arena::ELEMENT_PAGE_CAPACITY;
 
         // Span several pages, with a partially-filled final page (the `+ 1`),
-        // so both the full-page and the new-node-append branches of
-        // `push_returning_ref` are hit. Derived from the real capacity so the
-        // test keeps spanning multiple pages if the constant is retuned.
+        // so both the same-page and new-page branches of the arena's `push` are
+        // hit. Derived from the real capacity so the test keeps spanning
+        // multiple pages if the constant is retuned.
         let count = ELEMENT_PAGE_CAPACITY * 3 + 1;
 
         let mut map = HistoryMap::<usize, usize, Global>::new(Global);

--- a/zk_ee/src/common_structs/history_map/ptr_arena.rs
+++ b/zk_ee/src/common_structs/history_map/ptr_arena.rs
@@ -63,6 +63,10 @@ impl<T, const N: usize, A: Allocator> PtrArena<T, N, A> {
     where
         A: Clone,
     {
+        // Page capacity must be non-zero: a zero-length page would allocate a
+        // size-0 (dangling) payload, and `push` would write through it (UB).
+        // Enforced at compile time so misuse can't even build.
+        const { assert!(N > 0, "PtrArena page capacity N must be non-zero") };
         Self {
             pages: LinkedList::new_in(alloc.clone()),
             alloc,

--- a/zk_ee/src/common_structs/history_map/ptr_arena.rs
+++ b/zk_ee/src/common_structs/history_map/ptr_arena.rs
@@ -1,0 +1,257 @@
+//! A paged bump arena that hands out provenance-stable pointers.
+//!
+//! # Why this exists
+//!
+//! The history map stores `NonNull` pointers into its backing storage and keeps
+//! using them (read *and* write) across later insertions. That requires two
+//! properties from the storage:
+//!
+//! 1. **Stable addresses** — a value never moves once allocated.
+//! 2. **Stable provenance** — a handed-out pointer stays valid for writes across
+//!    later arena operations.
+//!
+//! A `ListVec` (`LinkedList<ArrayVec<T, N>>`) gives (1) but not (2): every
+//! `push`/`top_mut`/`back_mut` reborrows a node mutably (`iter_mut().last()` /
+//! `back_mut()`), and under both Stacked and Tree Borrows that reborrow acts as
+//! a foreign access that invalidates pointers handed out earlier — making any
+//! later write through them Undefined Behavior.
+//!
+//! `PtrArena` fixes (2) by owning each page as a raw allocation and deriving
+//! *every* slot pointer — both the append write and the returned handle — from
+//! that one raw page pointer via offset arithmetic. No `&mut`/`&` reference is
+//! ever formed over the page's payload, so appending never reasserts exclusive
+//! access over previously handed-out slots: the handles stay valid for the
+//! lifetime of the arena.
+
+use alloc::collections::LinkedList;
+use core::alloc::{Allocator, Layout};
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+
+/// One fixed-capacity page: a raw allocation of `N` slots plus the count of
+/// initialized slots at the front. The payload is reached only through `data`
+/// (a raw pointer with provenance over the whole page); we never form a
+/// reference to it.
+struct Page<T, const N: usize> {
+    data: NonNull<MaybeUninit<T>>,
+    len: usize,
+}
+
+/// A bump arena storing `T` in a chain of `N`-slot pages.
+///
+/// `push` returns a `NonNull<T>` that remains valid (for reads and writes) until
+/// [`PtrArena::clear`] or drop, regardless of subsequent `push` calls. Slots are
+/// never freed or moved individually.
+pub struct PtrArena<T, const N: usize, A: Allocator> {
+    /// Page metadata, in a `LinkedList` (not a `Vec`): the proving-mode
+    /// allocator is allocate-only and forbids `realloc`/`grow`, so a growable
+    /// `Vec` would panic ("grow is not allowed") once it outgrew its capacity.
+    /// A `LinkedList` only ever `allocate`s one node per page. Reborrowing a
+    /// node (e.g. `back_mut`) is harmless: the page *payload* is a separate
+    /// allocation reached via `Page::data`, so handed-out element pointers are
+    /// never invalidated.
+    pages: LinkedList<Page<T, N>, A>,
+    alloc: A,
+}
+
+impl<T, const N: usize, A: Allocator> PtrArena<T, N, A> {
+    /// Layout of a single page payload (`[MaybeUninit<T>; N]`). Infallible:
+    /// `N` is a fixed positive constant and the element type is sized.
+    const PAGE_LAYOUT: Layout = Layout::new::<[MaybeUninit<T>; N]>();
+
+    pub fn new_in(alloc: A) -> Self
+    where
+        A: Clone,
+    {
+        Self {
+            pages: LinkedList::new_in(alloc.clone()),
+            alloc,
+        }
+    }
+
+    /// Allocates a fresh page payload and returns a raw pointer with provenance
+    /// over the entire page. Panics on allocation failure, matching the
+    /// allocate-or-abort behavior of the `Vec`/`ListVec` storage it replaces.
+    fn alloc_page(&self) -> NonNull<MaybeUninit<T>> {
+        match self.alloc.allocate(Self::PAGE_LAYOUT) {
+            Ok(ptr) => ptr.cast::<MaybeUninit<T>>(),
+            Err(_) => alloc::alloc::handle_alloc_error(Self::PAGE_LAYOUT),
+        }
+    }
+
+    /// Moves `value` into the arena and returns a stable pointer to it.
+    pub fn push(&mut self, value: T) -> NonNull<T> {
+        let need_new_page = self.pages.back().is_none_or(|page| page.len == N);
+        if need_new_page {
+            let data = self.alloc_page();
+            self.pages.push_back(Page { data, len: 0 });
+        }
+
+        // The borrow of `page` is over the metadata struct only; the payload is
+        // touched solely through the raw `page.data` pointer below.
+        let page = self
+            .pages
+            .back_mut()
+            .expect("a page exists: just pushed one if needed");
+
+        // SAFETY: `page.len < N` (a new page was pushed above when the last one
+        // was full), so the slot lies within the page allocation. The pointer
+        // is derived from `page.data`, carrying provenance over the whole page;
+        // `write` initializes the slot without forming a reference to it.
+        let slot = unsafe { page.data.as_ptr().add(page.len).cast::<T>() };
+        unsafe { slot.write(value) };
+        page.len += 1;
+
+        // SAFETY: `slot` is non-null (derived from the non-null page pointer)
+        // and now points at an initialized `T`.
+        unsafe { NonNull::new_unchecked(slot) }
+    }
+
+    /// Drops every initialized element and releases all page allocations,
+    /// leaving the arena empty and reusable.
+    pub fn clear(&mut self) {
+        // Drains the metadata list; each page's elements are dropped and its
+        // payload deallocated.
+        while let Some(page) = self.pages.pop_front() {
+            for i in 0..page.len {
+                // SAFETY: slots `0..len` are initialized; each physical slot is
+                // dropped exactly once (the arena is the sole owner of the
+                // payload — the history chains/free list only hold borrows-as
+                // -pointers into it).
+                unsafe { page.data.as_ptr().add(i).cast::<T>().drop_in_place() };
+            }
+            // SAFETY: `page.data` came from `alloc_page` with `PAGE_LAYOUT` and
+            // is freed exactly once here.
+            unsafe {
+                self.alloc
+                    .deallocate(page.data.cast::<u8>(), Self::PAGE_LAYOUT)
+            };
+        }
+    }
+}
+
+impl<T, const N: usize, A: Allocator> Drop for PtrArena<T, N, A> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::alloc::AllocError;
+    use std::alloc::Global;
+    use std::cell::Cell;
+
+    /// Allocator that forwards to `Global` but panics on any realloc, mirroring
+    /// the proving-mode allocator's allocate-only contract. `PtrArena` must
+    /// only ever `allocate` (new pages + new metadata nodes), never `grow`.
+    #[derive(Clone)]
+    struct NoGrowAlloc;
+    // SAFETY: forwards to the global allocator; blocks only resize the way the
+    // proving allocator does.
+    unsafe impl Allocator for NoGrowAlloc {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            Global.allocate(layout)
+        }
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            unsafe { Global.deallocate(ptr, layout) }
+        }
+        unsafe fn grow(
+            &self,
+            _ptr: NonNull<u8>,
+            _old: Layout,
+            _new: Layout,
+        ) -> Result<NonNull<[u8]>, AllocError> {
+            panic!("grow is not allowed (mirrors proving-mode allocator)");
+        }
+        unsafe fn grow_zeroed(
+            &self,
+            _ptr: NonNull<u8>,
+            _old: Layout,
+            _new: Layout,
+        ) -> Result<NonNull<[u8]>, AllocError> {
+            panic!("grow_zeroed is not allowed (mirrors proving-mode allocator)");
+        }
+        unsafe fn shrink(
+            &self,
+            _ptr: NonNull<u8>,
+            _old: Layout,
+            _new: Layout,
+        ) -> Result<NonNull<[u8]>, AllocError> {
+            panic!("shrink is not allowed (mirrors proving-mode allocator)");
+        }
+    }
+
+    #[test]
+    fn push_never_reallocs_across_many_pages() {
+        // Regression guard: the proving allocator forbids realloc. Spanning many
+        // pages (here 50 elems over capacity-4 pages = 13 pages) must allocate
+        // page payloads and metadata nodes only — never grow. A `Vec`-backed
+        // page list would panic here once it outgrew its capacity.
+        let mut arena = PtrArena::<usize, 4, NoGrowAlloc>::new_in(NoGrowAlloc);
+        let mut ptrs = std::vec::Vec::new();
+        for k in 0..50usize {
+            ptrs.push(arena.push(k));
+        }
+        for (k, mut p) in ptrs.iter().copied().enumerate() {
+            assert_eq!(unsafe { *p.as_ref() }, k);
+            unsafe { *p.as_mut() += 1 };
+        }
+        for (k, p) in ptrs.iter().copied().enumerate() {
+            assert_eq!(unsafe { *p.as_ref() }, k + 1);
+        }
+    }
+
+    #[test]
+    fn push_returns_stable_writable_pointers_across_pages() {
+        // Page capacity 4: 10 elements spans 3 pages with a partial last page.
+        let mut arena = PtrArena::<usize, 4, Global>::new_in(Global);
+
+        let mut ptrs = std::vec::Vec::new();
+        for k in 0..10usize {
+            ptrs.push(arena.push(k));
+        }
+
+        // Every earlier pointer (including those on now-"sealed" pages) is still
+        // valid for reads and writes after all the appends that followed it.
+        for (k, mut p) in ptrs.iter().copied().enumerate() {
+            assert_eq!(unsafe { *p.as_ref() }, k);
+            unsafe { *p.as_mut() += 100 };
+        }
+        for (k, p) in ptrs.iter().copied().enumerate() {
+            assert_eq!(unsafe { *p.as_ref() }, k + 100);
+        }
+    }
+
+    #[test]
+    fn clear_runs_destructors_exactly_once_then_reuses() {
+        // A type that bumps a shared counter on drop, to assert exactly-once.
+        struct DropCounter<'a>(&'a Cell<usize>);
+        impl Drop for DropCounter<'_> {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let drops = Cell::new(0);
+        let mut arena = PtrArena::<DropCounter, 4, Global>::new_in(Global);
+        for _ in 0..10 {
+            arena.push(DropCounter(&drops));
+        }
+
+        arena.clear();
+        assert_eq!(drops.get(), 10, "every initialized slot dropped once");
+
+        // Arena is reusable after clear.
+        let p = arena.push(DropCounter(&drops));
+        assert_eq!(drops.get(), 10);
+        drop(p);
+        drop(arena);
+        assert_eq!(
+            drops.get(),
+            11,
+            "the post-clear element dropped on arena drop"
+        );
+    }
+}

--- a/zk_ee/src/common_structs/skip_list_quasi_vec/mod.rs
+++ b/zk_ee/src/common_structs/skip_list_quasi_vec/mod.rs
@@ -68,34 +68,6 @@ impl<T: Sized, const N: usize, A: Allocator + Clone> ListVec<T, N, A> {
     pub const fn new_in(allocator: A) -> Self {
         Self(LinkedList::new_in(allocator))
     }
-
-    /// Pushes `value` and returns a mutable reference to its slot.
-    ///
-    /// Equivalent to `Stack::push` followed by `Stack::top_mut`, but uses
-    /// `LinkedList::back_mut` (O(1)) instead of `iter_mut().last()` (O(pages))
-    /// — so this is constant-time per call rather than O(pages) per call.
-    pub fn push_returning_ref(&mut self, value: T) -> &mut T {
-        let needs_new_node = self.0.back_mut().is_none_or(|node| node.is_full());
-        if needs_new_node {
-            let mut new_node: ArrayVec<T, N> = ArrayVec::new();
-            new_node.push(value);
-            self.0.push_back(new_node);
-        } else {
-            // SAFETY: `needs_new_node` is false ⇒ back is `Some` and not full.
-            unsafe {
-                self.0.back_mut().unwrap_unchecked().push(value);
-            }
-        }
-        // SAFETY: we either pushed into the existing back or appended a new
-        // node holding one element, so back is `Some` and non-empty.
-        unsafe {
-            self.0
-                .back_mut()
-                .unwrap_unchecked()
-                .last_mut()
-                .unwrap_unchecked()
-        }
-    }
 }
 
 /// Iterator over elements in a ListVec.


### PR DESCRIPTION
## What ❔

Stacked on #669. Fixes two Undefined Behaviors in the `HistoryMap` storage path, both confirmed under **Miri (Stacked _and_ Tree Borrows)** and both present on `dev` (they run in the storage-cache bookkeeping on every block):

1. **Read-only-provenance write.** `ElementPool::create_element` derived the record pointer from `assume_init_ref()` (a shared reference → read-only provenance); later `as_mut()` writes (`reuse_memory`, `rollback`, `commit`) were UB.
2. **Container-reborrow invalidation.** Record pointers (and, on this arena branch, element pointers) were handed out from `ListVec` pages, then kept across later `ListVec` ops. `Stack::push`/`top_mut` use `iter_mut().last()` and the arena used `back_mut()`; each mutably reborrows a node, which under both aliasing models acts as a foreign access and invalidates every outstanding pointer — so the next write through a stored `NonNull` was UB.

Changes:
- **`PtrArena`** (new): a paged bump arena that owns each page as a raw allocation and derives *every* slot pointer (the append write and the returned handle) from one raw page pointer — no reference is ever formed over a page payload, so appends never invalidate previously handed-out pointers. Page metadata lives in a `LinkedList`, **not** a `Vec`: the proving-mode allocator is allocate-only and rejects `realloc`/`grow` (a `Vec` panics `"grow is not allowed"` once it outgrows capacity). A regression test with a grow-rejecting allocator locks this in (the std `Global` allocator allows grow, which hid the bug from unit tests — only the RISC-V proving run caught it).
- **`ElementPool`** stores records in a `PtrArena` (replaces the `ListVec<MaybeUninit<..>>` + `assume_init_ref` dance). Records are now also dropped on `clear`/drop, fixing a latent leak of `V` destructors.
- The **element arena** uses `PtrArena` instead of `ListVec`.
- **`HistoryMapItemRefMut`** carries the canonical arena `NonNull` (the pointer the BTreeMap holds) and accesses the element through transient borrows; `update` now pushes that canonical pointer into the pending list instead of one freshly derived from `&mut *self.history`, so it stays valid for the writes performed later by `commit`/`rollback`.
- Removed the now-unused `ListVec::push_returning_ref`.

## Why ❔

These are genuine UB by Rust's aliasing rules (both Stacked and Tree Borrows agree — not Miri artifacts). The compiler is entitled to exploit `&mut`/`noalias` here; the code is benign under today's codegen but is a real latent risk in a security-critical state-transition function. The whole `history_map` suite (including the multi-page arena regression test from #669) now passes under Miri Stacked and Tree Borrows.

### Performance

A/B over all 10 block fixtures (proving-mode effective cycles), this branch vs the #669 base: **+0.01–0.02% effective cycles** (flat), delegations (blake/bigint/keccak) unchanged, proving binary ~1.6 KB smaller. The soundness fix is effectively free.

### Scope / relationship to #669

The `PtrArena` + `ElementPool` portion fixes UB #1 and the record facet of UB #2, which exist on `dev`/`draft-0.4.0` independently of the arena; it is self-contained and cherry-pickable there. The element-arena and `HistoryMapItemRefMut` portions are specific to the #669 arena variant, which is why this is stacked on #669 rather than targeting `draft-0.4.0` directly.

## Is this a breaking change?
- [ ] Yes
- [x] No

The public API of `HistoryMap`, `HistoryMapItemRef`, and `HistoryMapItemRefMut` is preserved (only private fields changed).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)