### PR TITLE
fix(bootloader): revert L1 tx on initial asset tracker failure

### DIFF
--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -612,59 +612,77 @@ where
         .checked_sub(max_fee_commitment)
         .ok_or(internal_error!("td-mfc"))?;
 
-    // Transfer value from treasury to sender (the deposit minus max fee).
-    // We want to ensure that the simulation of a transaction
-    // never underestimates gas/pubdata compared to the actual execution
-    // of said transaction.
-    // During simulation the gas price is typically set to 0. So we need
-    // to be conservative about operations that incur in gas/pubdata depending
-    // on the value of the fee. For that reason, we always perform the
-    // following transfer on simulation, and avoid compressing the pubdata
-    // for the balance changes resulting from it.
-    //
-    // Mint the value portion of the deposit (total deposited minus max fee)
-    // to the sender inside the execution frame, it does not
-    // persist if the main tx body reverts.
-    //
+    // The first asset-tracker notification is part of the value-mint path,
+    // but unlike the post-execution notifications we treat its revert as an
+    // ordinary L1 transaction revert rather than a fatal bootloader error.
+    // This call is forced even when `to_transfer == 0` so the tx-level failure
+    // mode is exercised consistently for the initial notification.
     // Use with_infinite_ergs so the call cannot fail due to out-of-gas,
     // but native consumption is still tracked against the user's resources.
-    if to_transfer > U256::ZERO || Config::SIMULATION {
-        resources
-            .with_infinite_ergs(|inf_resources| {
-                mint_base_token::<S, Config>(
+    let initial_asset_tracker_reverted = resources
+        .with_infinite_ergs(|inf_resources| {
+            call_l2_asset_tracker::<S>(
+                system,
+                system_functions,
+                memories.reborrow(),
+                to_transfer,
+                l1_chain_id,
+                inf_resources,
+                tracer,
+                validator,
+            )
+        })
+        .map_err(|e| match e.root_cause() {
+            RootCause::Runtime(RuntimeError::OutOfErgs(_)) => {
+                system_log!(
                     system,
-                    system_functions,
-                    memories.reborrow(),
-                    &to_transfer,
-                    &from,
-                    l1_chain_id,
-                    inf_resources,
-                    tracer,
-                    validator,
-                )
-            })
-            .map_err(|e| match e.root_cause() {
-                RootCause::Runtime(RuntimeError::OutOfErgs(_)) => {
-                    system_log!(
-                        system,
-                        "Out of ergs on infinite ergs: inner error was {e:?}"
-                    );
-                    BootloaderSubsystemError::LeafDefect(internal_error!(
-                        "Out of ergs on infinite ergs"
-                    ))
-                }
-                _ => e,
-            })?;
-    }
+                    "Out of ergs on infinite ergs: inner error was {e:?}"
+                );
+                BootloaderSubsystemError::LeafDefect(internal_error!(
+                    "Out of ergs on infinite ergs"
+                ))
+            }
+            _ => e,
+        })?;
 
-    let resources_for_tx = resources.clone();
+    let (reverted, mut returndata) = if initial_asset_tracker_reverted {
+        system_log!(
+            system,
+            "Initial L2AssetTracker notification reverted for amount {to_transfer:?}\n"
+        );
+        system.finish_global_frame(Some(&rollback_handle))?;
+        (true, Vec::new_in(system.get_allocator()))
+    } else {
+        // Transfer value from treasury to sender (the deposit minus max fee).
+        // We want to ensure that the simulation of a transaction
+        // never underestimates gas/pubdata compared to the actual execution
+        // of said transaction.
+        // During simulation the gas price is typically set to 0. So we need
+        // to be conservative about operations that incur in gas/pubdata depending
+        // on the value of the fee. For that reason, we always perform the
+        // following transfer on simulation, and avoid compressing the pubdata
+        // for the balance changes resulting from it.
+        //
+        // Mint the value portion of the deposit (total deposited minus max fee)
+        // to the sender inside the execution frame, it does not
+        // persist if the main tx body reverts.
+        if to_transfer > U256::ZERO || Config::SIMULATION {
+            transfer_from_treasury::<S>(
+                system,
+                &to_transfer,
+                &from,
+                resources,
+                Config::SIMULATION,
+            )?;
+        }
 
-    // transaction is in managed region, so we can recast it back
-    let calldata = transaction.calldata();
+        let resources_for_tx = resources.clone();
 
-    // TODO: add support for deployment transactions,
-    // probably unify with execution logic for EOA
-    let (reverted, mut returndata) =
+        // transaction is in managed region, so we can recast it back
+        let calldata = transaction.calldata();
+
+        // TODO: add support for deployment transactions,
+        // probably unify with execution logic for EOA
         match BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
             system,
             system_functions,
@@ -697,7 +715,8 @@ where
                 system.finish_global_frame(Some(&rollback_handle))?;
                 return Err(e);
             }
-        };
+        }
+    };
 
     system_log!(system, "Main TX body successful = {}\n", !reverted);
 
@@ -838,20 +857,64 @@ where
 /// Calls handleFinalizeBaseTokenBridgingOnL2(uint256 _fromChainId, uint256 _amount)
 /// as L2_BASE_TOKEN_ADDRESS (0x800a) to pass the onlyBaseTokenHolderOrL2BaseToken modifier.
 ///
-/// This is called separately for each token movement (value mint, operator
-/// payment, refund) so that the asset tracker's accounting stays correct even
-/// if the main transaction body reverts.
+/// This low-level helper executes a single notification call and returns
+/// whether the callee reverted. Callers decide both whether to skip zero
+/// amounts and whether a revert should be treated as fatal.
 ///
-/// Resource usage depends on the caller — value-mint tracks native against user resources;
-/// operator-fee and refund use FORMAL_INFINITE.
-///
-/// Failure halts block processing — if the asset tracker reverts, the
-/// chain's token accounting would be inconsistent, so we treat it as
-/// fatal rather than silently continuing with incorrect bookkeeping.
+/// Resource usage depends on the caller — value-mint tracks native against
+/// user resources; operator-fee and refund use FORMAL_INFINITE.
 ///
 /// If no contract is deployed at L2AssetTracker, the call succeeds silently
 /// (a call to an empty address returns success with no returndata in EVM).
 /// However, we are certain that L2AssetTracker is available after the upgrade.
+fn call_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a>(
+    system: &mut System<S>,
+    system_functions: &mut HooksStorage<S, S::Allocator>,
+    memories: RunnerMemoryBuffers<'a>,
+    amount: U256,
+    l1_chain_id: U256,
+    resources: &mut S::Resources,
+    tracer: &mut impl Tracer<S>,
+    validator: &mut impl TxValidator<S>,
+) -> Result<bool, BootloaderSubsystemError>
+where
+    S::IO: IOSubsystemExt,
+    S::Metadata: ZkSpecificPricingMetadata
+        + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
+{
+    // Encode calldata for handleFinalizeBaseTokenBridgingOnL2(uint256,uint256):
+    // selector 0x03117c8c + abi-encoded (fromChainId, amount)
+    let mut calldata = [0u8; 68];
+    calldata[0..4].copy_from_slice(&[0x03, 0x11, 0x7c, 0x8c]);
+    calldata[4..36].copy_from_slice(&l1_chain_id.to_be_bytes::<32>());
+    calldata[36..68].copy_from_slice(&amount.to_be_bytes::<32>());
+
+    let failed = resources.with_infinite_ergs(|inf_ergs| {
+        let CompletedExecution {
+            resources_returned,
+            result: asset_tracker_result,
+        } = BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
+            system,
+            system_functions,
+            memories,
+            &calldata,
+            &L2_BASE_TOKEN_ADDRESS,
+            &L2_ASSET_TRACKER_ADDRESS,
+            inf_ergs.clone(),
+            &U256::ZERO,
+            true, // should_make_frame - isolate state changes
+            tracer,
+            validator,
+        )?;
+        // Overwrite resources inside the closure so that
+        // with_infinite_ergs correctly restores ergs afterwards.
+        *inf_ergs = resources_returned;
+        Ok::<bool, BootloaderSubsystemError>(asset_tracker_result.failed())
+    })?;
+
+    Ok(failed)
+}
+
 fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a, Config: BasicBootloaderExecutionConfig>(
     system: &mut System<S>,
     system_functions: &mut HooksStorage<S, S::Allocator>,
@@ -868,35 +931,16 @@ where
         + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
     if amount > U256::ZERO || Config::SIMULATION {
-        // Encode calldata for handleFinalizeBaseTokenBridgingOnL2(uint256,uint256):
-        // selector 0x03117c8c + abi-encoded (fromChainId, amount)
-        let mut calldata = [0u8; 68];
-        calldata[0..4].copy_from_slice(&[0x03, 0x11, 0x7c, 0x8c]);
-        calldata[4..36].copy_from_slice(&l1_chain_id.to_be_bytes::<32>());
-        calldata[36..68].copy_from_slice(&amount.to_be_bytes::<32>());
-
-        let failed = resources.with_infinite_ergs(|inf_ergs| {
-            let CompletedExecution {
-                resources_returned,
-                result: asset_tracker_result,
-            } = BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
-                system,
-                system_functions,
-                memories,
-                &calldata,
-                &L2_BASE_TOKEN_ADDRESS,
-                &L2_ASSET_TRACKER_ADDRESS,
-                inf_ergs.clone(),
-                &U256::ZERO,
-                true, // should_make_frame - isolate state changes
-                tracer,
-                validator,
-            )?;
-            // Overwrite resources inside the closure so that
-            // with_infinite_ergs correctly restores ergs afterwards.
-            *inf_ergs = resources_returned;
-            Ok::<bool, BootloaderSubsystemError>(asset_tracker_result.failed())
-        })?;
+        let failed = call_l2_asset_tracker::<S>(
+            system,
+            system_functions,
+            memories,
+            amount,
+            l1_chain_id,
+            resources,
+            tracer,
+            validator,
+        )?;
 
         if failed {
             system_log!(

--- a/tests/instances/transactions/src/asset_tracker.rs
+++ b/tests/instances/transactions/src/asset_tracker.rs
@@ -5,8 +5,9 @@
 //! When an L1 transaction deposits base tokens (total_deposited > 0), the
 //! bootloader calls handleFinalizeBaseTokenBridgingOnL2(uint256, uint256)
 //! on the real L2AssetTracker contract up to three times — once for the
-//! value mint, once for the operator fee, and once for the refund. If any
-//! of these amounts is zero the corresponding call is skipped.
+//! value mint, once for the operator fee, and once for the refund. The
+//! initial value-mint notification is always attempted, even when its amount
+//! is zero. Later notifications are still skipped when their amount is zero.
 //!
 //! When the source chain matches `L1_CHAIN_ID` and the current settlement
 //! layer also matches `L1_CHAIN_ID`, the contract records the aggregate
@@ -74,6 +75,60 @@ fn read_l1_chain_id_tx(nonce: u64) -> ZKsyncTxEnvelope {
         input: L1_CHAIN_IDCall {}.abi_encode().into(),
     };
     ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+}
+
+fn asset_tracker_reverts_when_amount_matches(amount: U256) -> Vec<u8> {
+    BytecodeBuilder::new()
+        .push_bytes(&amount.to_be_bytes::<32>())
+        .push_u8(0x24)
+        .calldataload()
+        .eq()
+        .push_u8(0x2b)
+        .jumpi()
+        .push0()
+        .push0()
+        .return_()
+        .jumpdest()
+        .push0()
+        .push0()
+        .revert()
+        .finish()
+}
+
+fn asset_tracker_reverts_when_amount_is_zero() -> Vec<u8> {
+    asset_tracker_reverts_when_amount_matches(U256::ZERO)
+}
+
+fn asset_tracker_reverts_when_amount_is_nonzero() -> Vec<u8> {
+    BytecodeBuilder::new()
+        .push_u8(0x24)
+        .calldataload()
+        .push0()
+        .eq()
+        .push_u8(0x0b)
+        .jumpi()
+        .push0()
+        .push0()
+        .revert()
+        .jumpdest()
+        .push0()
+        .push0()
+        .return_()
+        .finish()
+}
+
+fn assert_l1_tx_reverted(output: &rig::zksync_os_interface::types::BlockOutput) {
+    assert_eq!(output.tx_results.len(), 1);
+    let tx_result = output.tx_results[0].as_ref().expect("tx should not error");
+    assert!(
+        !tx_result.is_success(),
+        "L1 tx should revert, got {tx_result:?}"
+    );
+    assert!(
+        matches!(&tx_result.execution_result, ExecutionResult::Revert(_)),
+        "L1 tx should return a revert execution result, got {:?}",
+        &tx_result.execution_result
+    );
 }
 
 fn assert_reverted_deposit_asset_tracker(
@@ -195,9 +250,9 @@ fn test_asset_tracker_predeploy_is_usable_in_l1_flow() {
     }
 }
 
-/// Verify that no deposit is recorded when total_deposited == 0.
+/// Verify that a zero-deposit L1 tx does not change recorded bridged totals.
 #[test]
-fn test_asset_tracker_not_called_without_deposit() {
+fn test_zero_deposit_does_not_change_asset_tracker_totals() {
     let from = address!("1234000000000000000000000000000000000000");
     let to = address!("abcd000000000000000000000000000000000000");
     let gas_price: u128 = 0;
@@ -339,4 +394,94 @@ fn test_asset_tracker_oog_body_still_notifies_fee_and_refund() {
 
     let output = tester.execute_block(vec![tx]);
     assert_reverted_deposit_asset_tracker(&mut tester, &output, to_mint);
+}
+
+#[test]
+fn test_asset_tracker_initial_revert_reverts_l1_tx() {
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = address!("abcd000000000000000000000000000000000000");
+    let gas_price: u128 = 1000;
+    let gas_limit: u128 = 50_000;
+    let value_mint_amount = rig::alloy::primitives::U256::from(1_000_000u64);
+    let to_mint = rig::alloy::primitives::U256::from(gas_limit * gas_price) + value_mint_amount;
+
+    let mut tester = TestingFramework::new()
+        .with_evm_contract(
+            asset_tracker_address(),
+            &asset_tracker_reverts_when_amount_matches(U256::from(1_000_000u64)),
+        )
+        .with_balance(from, U256::from(u64::MAX));
+
+    let tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .value(rig::alloy::primitives::U256::ZERO)
+        .to_mint(to_mint)
+        .build();
+
+    let output = tester.execute_block(vec![tx]);
+    assert_l1_tx_reverted(&output);
+}
+
+#[test]
+fn test_asset_tracker_zero_amount_initial_notification_is_forced() {
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = address!("abcd000000000000000000000000000000000000");
+    let gas_price: u128 = 1000;
+    let gas_limit: u128 = 50_000;
+    let to_mint = rig::alloy::primitives::U256::from(gas_limit * gas_price);
+
+    let mut tester = TestingFramework::new()
+        .with_evm_contract(
+            asset_tracker_address(),
+            &asset_tracker_reverts_when_amount_is_zero(),
+        )
+        .with_balance(from, U256::from(u64::MAX));
+
+    let tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .value(rig::alloy::primitives::U256::ZERO)
+        .to_mint(to_mint)
+        .build();
+
+    let output = tester.execute_block(vec![tx]);
+    assert_l1_tx_reverted(&output);
+}
+
+#[test]
+fn test_asset_tracker_post_execution_revert_remains_fatal() {
+    let from = address!("1234000000000000000000000000000000000000");
+    let to = address!("abcd000000000000000000000000000000000000");
+    let gas_price: u128 = 1000;
+    let gas_limit: u128 = 50_000;
+    let to_mint = rig::alloy::primitives::U256::from(gas_limit * gas_price);
+
+    let mut tester = TestingFramework::new()
+        .with_evm_contract(
+            asset_tracker_address(),
+            &asset_tracker_reverts_when_amount_is_nonzero(),
+        )
+        .with_balance(from, U256::from(u64::MAX));
+
+    let tx: ZKsyncTxEnvelope = L1TxBuilder::new()
+        .from(from)
+        .to(to)
+        .gas_price(gas_price)
+        .gas_limit(gas_limit)
+        .value(rig::alloy::primitives::U256::ZERO)
+        .to_mint(to_mint)
+        .build();
+
+    let err = tester
+        .execute_block_no_panic(vec![tx])
+        .expect_err("post-execution asset tracker revert should still fail block execution");
+    assert!(
+        format!("{err:?}").contains("L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 reverted"),
+        "unexpected error for post-execution asset tracker revert: {err:?}"
+    );
 }


### PR DESCRIPTION
## What ❔

This PR makes the initial `L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2` notification in L1 transaction processing non-fatal at the tx level:
- the first notification is now attempted even when the initial bridged amount is `0`
- if that initial notification reverts, the L1 tx returns a normal revert instead of panicking the bootloader
- post-execution operator/refund notifications keep the existing fatal behavior

It also adds targeted integration coverage for the new initial-call semantics and the preserved post-execution fatal path.

## Why ❔

The initial asset-tracker notification happens before the main L1 tx body and should not panic the bootloader when the callee reverts. Downgrading only that first revert to a tx-level revert avoids halting block execution while preserving the stronger invariant for the later accounting-sensitive notifications.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

Tested with:
- `cargo test -p transactions asset_tracker --features rig/no_print`
