### PR TITLE
chore(zk_ee): update logger_log docs; remove stale ruint-alloc TODO

### DIFF
--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -446,9 +446,11 @@ define_subsystem!(NextTx,
 );
 
 /// Logging macros for the system.
-/// Logging is enabled on non-riscv32 targets, and also on riscv32 when `global-alloc` feature is
-/// active (debug proving mode). In production proving mode (riscv32 without `global-alloc`),
-/// logging is a no-op to avoid any heap allocation overhead.
+/// Logging is enabled on non-riscv32 targets, and also on riscv32 when the `global-alloc` feature
+/// is active (debug proving mode). In production proving mode (riscv32 without `global-alloc`),
+/// the global allocator is not present, so any heap allocation (e.g. via `alloc::format!`) would
+/// panic; logging is therefore compiled to a no-op to prevent accidental allocations and ensure
+/// correct behaviour in the proving environment.
 #[cfg(any(not(target_arch = "riscv32"), feature = "global-alloc"))]
 #[macro_export]
 macro_rules! logger_log {
@@ -457,8 +459,11 @@ macro_rules! logger_log {
     }};
 }
 
-// No-op in production proving mode (riscv32 without global allocator).
-// Format-arg expressions are never evaluated, so callers may freely use String formatting.
+// No-op in production proving mode (riscv32 without `global-alloc`).
+// Format-argument expressions (including heap-allocating ones such as `alloc::format!()` or
+// `.to_string()`) are never evaluated in this configuration, so they do not trigger any
+// allocation.  This property only holds for the no-op variant; on other targets or with
+// `global-alloc` the macro is active and format expressions are evaluated normally.
 #[cfg(all(target_arch = "riscv32", not(feature = "global-alloc")))]
 #[macro_export]
 macro_rules! logger_log {

--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -446,7 +446,9 @@ define_subsystem!(NextTx,
 );
 
 /// Logging macros for the system.
-/// TODO: debug implementation for ruint types uses global alloc, which panics in ZKsync OS
+/// Logging is enabled on non-riscv32 targets, and also on riscv32 when `global-alloc` feature is
+/// active (debug proving mode). In production proving mode (riscv32 without `global-alloc`),
+/// logging is a no-op to avoid any heap allocation overhead.
 #[cfg(any(not(target_arch = "riscv32"), feature = "global-alloc"))]
 #[macro_export]
 macro_rules! logger_log {
@@ -455,7 +457,8 @@ macro_rules! logger_log {
     }};
 }
 
-// No-op only if riscv32 AND no allocator feature
+// No-op in production proving mode (riscv32 without global allocator).
+// Format-arg expressions are never evaluated, so callers may freely use String formatting.
 #[cfg(all(target_arch = "riscv32", not(feature = "global-alloc")))]
 #[macro_export]
 macro_rules! logger_log {


### PR DESCRIPTION
## What ❔

Updates the documentation on `logger_log!` and `system_log!` macros in `zk_ee`:

- Removes a now-incorrect `TODO` that stated ruint's `Debug` implementation uses the global allocator (this was fixed when ruint was updated to v1.16 with allocation-free `Debug`).
- Replaces it with an accurate description: logging is active on non-riscv32 targets and on riscv32 when `global-alloc` is enabled; it is a no-op in production proving mode (riscv32 without `global-alloc`) to avoid any heap allocation overhead.
- Adds a note that callers may freely use heap-allocated format args (e.g. `alloc::format!`) because those expressions are never evaluated in the no-op path.

## Why ❔

The comment was left over from before the ruint v1.16 upgrade that made `Debug` allocation-free. Keeping stale TODOs misleads readers about the current state of the code and obscures the real reason the riscv32 no-op still exists (proving-mode overhead avoidance, not ruint-specific workarounds).

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

---
Rebased from #560 onto `draft-0.4.0` (original targeted `dev`). No content changes.