### PR TITLE
docs(io): document storage model trait hierarchy and generic type parameters

### DIFF
--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -76,4 +76,18 @@ For snapshotting, it uses a [`history_map`](../../../zk_ee/src/common_structs/hi
 
 ## Storage cache
 
-The [storage cache](../../../basic_system/src/system_implementation/flat_storage_model/storage_cache.rs) is just the general cache for the slots stored in the tree. It uses the same history map implementation as the previous one for snapshotting.
+The [storage cache](../../../basic_system/src/system_implementation/flat_storage_model/storage_cache.rs) is the general cache for the slots stored in the tree. It is implemented as a thin wrapper ([`NewStorageWithAccountPropertiesUnderHash`](../../../basic_system/src/system_implementation/flat_storage_model/storage_cache.rs)) around the generic pubdata-aware cache described below.
+
+### `GenericPubdataAwarePlainStorage`
+
+[Source](../../../basic_system/src/system_implementation/caches/generic_pubdata_aware_plain_storage.rs)
+
+This is the core cache implementation, generic over key type `K`, value type `V`, allocator, and a `StorageAccessPolicy`. It handles:
+
+- **Oracle materialisation**: on the first access to a key, queries the oracle via `InitialStorageSlotQuery` to fetch the initial value. Validates that new slots (`is_new_storage_slot == true`) have a trivial (zero) initial value — a malicious oracle returning non-zero for a new slot triggers an assertion.
+- **Cold/warm tracking**: each cache element carries a `StorageElementMetadata` with the last transaction ID that touched it. The first read in a transaction is "cold" (charged extra via `StorageAccessPolicy`); subsequent reads are "warm".
+- **EVM gas refund accounting**: maintains a `NonEmptyHistoryCounter` of EVM refunds. The counter participates in frame snapshots so that refunds from reverted calls are correctly discarded.
+- **Pubdata awareness**: the storage model computes pubdata costs from the diff between initial and current values. The cache exposes `net_diffs_iter()` (changed slots) and `net_accesses_iter()` (all accessed slots) so the upper layer can derive pubdata obligations.
+- **Snapshotting**: delegates to a `HistoryMap` for cache entries and a `NonEmptyHistoryCounter` for refunds. Both are snapshotted together via `StorageSnapshotId`.
+
+The `StorageAccessPolicy` trait (parameterised by `P`) controls how gas/ergs are charged for cold and warm reads. This allows the same cache implementation to work under different pricing models.

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -4,6 +4,64 @@ As introduced in the [IO overview](./io.md), the system relies on three caches f
 
 In general, all three caches have to provide the same functionality: materializing some data from the oracle for the first interaction, save it in a cache for further reads and updates, produce a diff to be applied at the end of the transaction and be able to handle take snapshots (via frame) to revert to in case of a invalid call.
 
+## Trait hierarchy
+
+Two traits in [`storage_models/src/common_structs/traits/`](../../../storage_models/src/common_structs/traits/) define the contract for cache behaviour:
+
+```
+SnapshottableIo                         (transactional rollback: begin_new_tx, finish_tx, start_frame, finish_frame)
+    ├─ StorageCacheModel                (key-value slot reads/writes/touches + special account property access)
+    └─ PreimageCacheModel               (hash→preimage lookup and recording)
+```
+
+### `SnapshottableIo` ([source](../../../storage_models/src/common_structs/traits/snapshottable_io.rs))
+
+Base trait for any cache that participates in transaction and call-frame lifecycle:
+
+- `begin_new_tx` / `finish_tx` — transaction boundary (e.g. clears transient state).
+- `start_frame` → `StateSnapshot` — captures a snapshot before entering a call frame.
+- `finish_frame(rollback_handle)` — commits when `None`, reverts when `Some(snapshot)`.
+
+### `StorageCacheModel` ([source](../../../storage_models/src/common_structs/traits/storage_cache_model.rs))
+
+Extends `SnapshottableIo`. Provides the read/write/touch interface for storage slots,
+plus `read_special_account_property` / `write_special_account_property` for
+account-level data stored in special slots (e.g. account aggregate data hash).
+
+Implemented by: [`NewStorageWithAccountPropertiesUnderHash`](../../../basic_system/src/system_implementation/flat_storage_model/storage_cache.rs).
+
+### `PreimageCacheModel` ([source](../../../storage_models/src/common_structs/traits/preimage_cache_model.rs))
+
+Extends `SnapshottableIo`. Provides `get_preimage` (fetch by hash, hitting the oracle
+on a miss) and `record_preimage` (store a new preimage and mark it for publication).
+
+Implemented by: [`BytecodeAndAccountDataPreimagesStorage`](../../../basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs).
+
+### Account cache
+
+[`NewModelAccountCache`](../../../basic_system/src/system_implementation/flat_storage_model/account_cache.rs)
+does not implement a formal trait. It provides `start_frame`, `begin_new_tx`, and
+rollback methods directly on the struct, backed by a `HistoryMap` internally. It
+is used only by `FlatTreeWithAccountsUnderHashesStorageModel`, which coordinates
+snapshot/rollback across all three caches.
+
+### Coordination
+
+[`FlatTreeWithAccountsUnderHashesStorageModel`](../../../basic_system/src/system_implementation/flat_storage_model/mod.rs) implements
+both `StorageModel` and `SnapshottableIo`. Its snapshot type bundles one snapshot
+ID from each cache:
+
+```rust
+pub struct FlatTreeWithAccountsUnderHashesStorageModelStateSnapshot {
+    storage: StorageSnapshotId,       // storage cache
+    preimages: CacheSnapshotId,       // preimage cache
+    account_data: CacheSnapshotId,    // account cache
+}
+```
+
+On `start_frame` each cache is snapshotted independently; on `finish_frame` each
+is rolled back (or committed) using its own handle.
+
 ## Preimage cache
 
 The preimage cache is used for account properties preimages and bytecodes. It's implemented by [`BytecodeAndAccountDataPreimagesStorage`](../../../basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs) and it contains two parts: an actual mapping between hashes and preimages (`storage`) and a `publication_storage` that deals with the rollbacking logic.

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -82,12 +82,99 @@ The [storage cache](../../../basic_system/src/system_implementation/flat_storage
 
 [Source](../../../basic_system/src/system_implementation/caches/generic_pubdata_aware_plain_storage.rs)
 
-This is the core cache implementation, generic over key type `K`, value type `V`, allocator, and a `StorageAccessPolicy`. It handles:
+This is the core cache implementation, generic over key type `K`, value type `V`, allocator, and a `StorageAccessPolicy`. It is called "pubdata-aware" because it tracks three value states per storage slot — enabling precise computation of net state changes and their pubdata cost at the end of each transaction.
 
-- **Oracle materialisation**: on the first access to a key, queries the oracle via `InitialStorageSlotQuery` to fetch the initial value. Validates that new slots (`is_new_storage_slot == true`) have a trivial (zero) initial value — a malicious oracle returning non-zero for a new slot triggers an assertion.
-- **Cold/warm tracking**: each cache element carries a `StorageElementMetadata` with the last transaction ID that touched it. The first read in a transaction is "cold" (charged extra via `StorageAccessPolicy`); subsequent reads are "warm".
-- **EVM gas refund accounting**: maintains a `NonEmptyHistoryCounter` of EVM refunds. The counter participates in frame snapshots so that refunds from reverted calls are correctly discarded.
-- **Pubdata awareness**: the storage model computes pubdata costs from the diff between initial and current values. The cache exposes `net_diffs_iter()` (changed slots) and `net_accesses_iter()` (all accessed slots) so the upper layer can derive pubdata obligations.
-- **Snapshotting**: delegates to a `HistoryMap` for cache entries and a `NonEmptyHistoryCounter` for refunds. Both are snapshotted together via `StorageSnapshotId`.
+#### Oracle materialisation
 
-The `StorageAccessPolicy` trait (parameterised by `P`) controls how gas/ergs are charged for cold and warm reads. This allows the same cache implementation to work under different pricing models.
+On the first access to a key, `materialize_element()` queries the oracle via
+`InitialStorageSlotQuery` to fetch the initial value and the `is_new_storage_slot`
+flag. It validates that new slots (`is_new_storage_slot == true`) have a trivial
+(zero) initial value — a malicious oracle returning non-zero for a new slot
+triggers an assertion. The result is inserted into the `HistoryMap`-backed cache.
+
+#### Cold/warm tracking
+
+Each cache element carries a `StorageElementMetadata` recording the last
+transaction ID that touched it. On access:
+
+1. `materialize_element()` always charges a warm read first via `charge_warm_storage_read()`.
+2. If the element's `last_touched_in_tx` does not match the current transaction ID
+   (i.e. the access is "cold"), it additionally charges `charge_cold_storage_read_extra()`.
+3. `last_touched_in_tx` is updated to the current transaction ID, making all
+   subsequent accesses within the same transaction "warm".
+4. At the transaction boundary, `finish_tx()` increments the transaction ID counter,
+   resetting all elements to "cold" for the next transaction.
+
+#### EVM gas refund accounting
+
+The cache maintains a `NonEmptyHistoryCounter` of cumulative EVM refunds. Every
+`apply_write_impl()` call passes the three-value state to `refund_for_storage_write()`,
+which implements the EIP-3529 refund rules (e.g. +4800 gas when clearing a slot
+from non-zero to zero). The counter participates in frame snapshots, so refunds
+from reverted calls are correctly discarded.
+
+#### Three-value state tracking
+
+Each cached storage element tracks three values simultaneously:
+
+- **`initial`** — the value at the start of the block, loaded from the oracle.
+- **`committed`** (at transaction start) — the value at the start of the current
+  transaction, frozen by `begin_new_tx()`. This is `initial` for the first
+  transaction, or the value at the end of the previous transaction.
+- **`current`** — the latest value after all writes in the current call stack.
+
+This three-value model is essential for:
+
+1. **Storage write gas costs** — EVM `SSTORE` pricing differs depending on whether
+   the current write is "fresh" (`current == committed`) or "dirty" (`current !=
+   committed`).
+2. **EVM gas refunds** — refunds are computed from the transition between
+   `committed`, `current`, and the new value.
+3. **Pubdata cost computation** — only `committed → current` changes contribute
+   to pubdata. Changes that reset to the committed value cancel out.
+
+#### Pubdata computation
+
+At the end of each transaction, `calculate_pubdata_used_by_tx()` iterates all
+elements altered since the last commit via `iter_altered_since_commit()` and sums
+up the net pubdata bytes:
+
+1. **Deduplication** — multiple writes to the same key count once.
+2. **Skip account properties** — slots under `ACCOUNT_PROPERTIES_STORAGE_ADDRESS`
+   are published as preimages, not as storage diffs.
+3. **Elimination** — if `current == initial`, the change nets to zero and is free.
+4. **Compression** — for each net change, the cost is 32 bytes (key) plus the
+   optimally compressed value diff. Compression strategies include add/subtract
+   delta encoding and leading-zero removal, selecting whichever produces the
+   fewest bytes.
+
+The cache exposes two iterators for upper layers:
+- `net_diffs_iter()` — yields only slots where `current_value != initial_value`
+  (used for publishing state changes to the DA layer).
+- `net_accesses_iter()` — yields all accessed slots regardless of change (used
+  for Merkle proof validation, since all accessed slots need proofs).
+
+#### `StorageAccessPolicy`
+
+The [`StorageAccessPolicy`](../../../basic_system/src/system_implementation/caches/storage_access_policy.rs)
+trait (parameterised by `P`) controls how gas/ergs are charged for storage
+operations. It defines four methods:
+
+- `charge_warm_storage_read` — base cost for every storage access (EVM: 100 gas).
+- `charge_cold_storage_read_extra` — additional cost on the first access in a
+  transaction (EVM: 2000 gas, totalling 2100 for a cold read).
+- `charge_storage_write_extra` — write cost that varies based on the value
+  transition (EVM: 0 for no-change, 20000 for fresh set, 5000 for fresh reset,
+  plus 100 for cold writes).
+- `refund_for_storage_write` — EIP-3529 refund calculation.
+
+This abstraction allows the same `GenericPubdataAwarePlainStorage` to work under
+different pricing models without branching at runtime.
+
+#### Snapshotting
+
+The cache creates a composite `StorageSnapshotId` that bundles a `HistoryMap`
+snapshot and a refund counter snapshot. On `start_frame()` both are captured;
+on `finish_frame(Some(snapshot))` both are rolled back atomically. This ensures
+that a reverted `CALL` or `CREATE` discards both its storage changes and its
+accumulated gas refunds.

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -102,7 +102,7 @@ transaction ID that touched it. On access:
    (i.e. the access is "cold"), it additionally charges `charge_cold_storage_read_extra()`.
 3. `last_touched_in_tx` is updated to the current transaction ID, making all
    subsequent accesses within the same transaction "warm".
-4. At the transaction boundary, `finish_tx()` increments the transaction ID counter,
+4. At the transaction boundary, `begin_new_tx()` increments the transaction ID counter,
    resetting all elements to "cold" for the next transaction.
 
 #### EVM gas refund accounting

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -54,8 +54,8 @@ ID from each cache:
 ```rust
 pub struct FlatTreeWithAccountsUnderHashesStorageModelStateSnapshot {
     storage: StorageSnapshotId,       // storage cache
-    preimages: CacheSnapshotId,       // preimage cache
     account_data: CacheSnapshotId,    // account cache
+    preimages: CacheSnapshotId,       // preimage cache
 }
 ```
 

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -6,7 +6,7 @@ In general, all three caches have to provide the same functionality: materializi
 
 ## Trait hierarchy
 
-Two traits in [`storage_models/src/common_structs/traits/`](../../../storage_models/src/common_structs/traits/) define the contract for cache behaviour:
+Three traits in [`storage_models/src/common_structs/traits/`](../../../storage_models/src/common_structs/traits/) define the contract for cache behavior:
 
 ```
 SnapshottableIo                         (transactional rollback: begin_new_tx, finish_tx, start_frame, finish_frame)

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -135,8 +135,8 @@ This three-value model is essential for:
 
 #### Pubdata computation
 
-At the end of each transaction, `calculate_pubdata_used_by_tx()` iterates all
-elements altered since the last commit via `iter_altered_since_commit()` and sums
+At the end of each transaction, `NewStorageWithAccountPropertiesUnderHash::calculate_pubdata_used_by_tx()`
+iterates all elements altered since the last commit via `HistoryMap::iter_altered_since_commit()` and sums
 up the net pubdata bytes:
 
 1. **Deduplication** — multiple writes to the same key count once.

--- a/docs/system/io/io.md
+++ b/docs/system/io/io.md
@@ -46,6 +46,8 @@ The basic [IO subsystem implementation](../../../basic_system/src/system_impleme
 
 The basic implementation consist mostly on handling those storages and is now abstracted to work with any storage model that implements the required traits. The default main storage implementation, [`FlatTreeWithAccountsUnderHashesStorageModel`](../../../basic_system/src/system_implementation/flat_storage_model/mod.rs), is composed of a Merkle tree and 3 caches for its data. The Merkle tree uses 32-byte keys (hash of (address,key)) and 32-byte values, and is described in details in [its own page](./tree.md). Initial reads into this tree are provided by an oracle, and verified as a batch at the end of the system run. The three caches are for storage (general storage slots), account properties and preimages. The use of the last two will become clear after the next section.
 
+For a detailed explanation of the `StorageModel` trait, the generic type parameters of `FullIO`, the resource charging model, and how the `PROOF_ENV` const generic affects behaviour, see the [storage model guide](./storage_model.md).
+
 ### Storage model for accounts
 
 Each account has the following properties:

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -166,16 +166,20 @@ Resources are a dual counter pairing two independent budgets:
   analogue but must be bounded for proof generation (e.g. hash operations). This
   prevents DoS via cheap-gas but prover-heavy operations.
 
-The `Resources` trait wraps both:
+The `Resources` trait wraps both (simplified; see source for full definition):
 
 ```rust
-pub trait Resources: Sized + Clone + core::fmt::Debug {
-    const FORMAL_INFINITE: Self;  // Sentinel for unconstrained execution (system paths)
-    fn empty() -> Self;
-    fn charge(&mut self, to_charge: &Self) -> Result<(), SystemError>;
-    fn has_enough(&self, to_spend: &Self) -> bool;
-    fn reclaim(&mut self, to_reclaim: Self);
-    // ...
+pub trait Resources: 'static + Sized + Clone + Debug + PartialEq + Eq + Resource {
+    type Native: Resource + Computational;
+
+    // Constructors for homogeneous values
+    fn from_ergs(ergs: Ergs) -> Self;
+    fn from_native(native: Self::Native) -> Self;
+    fn from_ergs_and_native(ergs: Ergs, native: Self::Native) -> Self;
+
+    // Sentinel for unconstrained execution (system paths)
+    const FORMAL_INFINITE: Self;
+    // ...charge / reclaim / has_enough inherited via Resource...
 }
 ```
 
@@ -210,34 +214,36 @@ time exactly which fields are requested, avoiding over-fetching:
 pub struct AccountDataRequest<T>(PhantomData<T>);
 
 // The Maybe marker types:
-pub struct Just<T>(PhantomData<T>);  // "request this field"
-pub struct Nothing;                   // "don't request this field"
+pub struct Just<T>(pub T);  // "request this field" — carries the actual value
+pub struct Nothing;          // "don't request this field" — zero-size marker
 ```
 
 `AccountData` is parameterised over one `Maybe<T>` per field:
 
 ```rust
 pub struct AccountData<
-    EEVersion,             // Maybe<u8>
+    EEVersion,              // Maybe<u8>
     ObservableBytecodeHash,
     ObservableBytecodeLen,
-    Nonce,                 // Maybe<u64>
+    Nonce,                  // Maybe<u64>
     BytecodeHash,
-    BytecodeLen,           // Maybe<u32>
+    UnpaddedCodeLen,        // Maybe<u32>
     ArtifactsLen,
-    NominalTokenBalance,   // Maybe<U256>
-    Bytecode,              // Maybe<&'static [u8]>
+    NominalTokenBalance,    // Maybe<U256>
+    Bytecode,               // Maybe<&'static [u8]>
     CodeVersion,
-    IsDelegated,           // Maybe<bool>
+    IsDelegated,            // Maybe<bool>
 > { /* fields present only when their type is Just<T> */ }
 ```
 
 A request is built with a builder pattern:
 
 ```rust
+// with_nominal_token_balance is generic over T; the type must be made explicit
+// either via turbofish or by the calling context (e.g. read_account_properties).
 let request = AccountDataRequest::empty()
     .with_nonce()
-    .with_nominal_token_balance();
+    .with_nominal_token_balance::<U256>();
 // The return type encodes exactly these two fields as Just<_>, rest as Nothing.
 ```
 
@@ -392,9 +398,13 @@ trie node on each path), making it unsuitable for efficient proof generation.
    inside a call frame are atomically reverted when `finish_frame(Some(snapshot))`
    is called. This invariant is critical for correct EVM `CALL` reversion.
 
-3. **No panics from external input.** Deserialization of oracle responses and
-   resource charging both return `Result`. Callers must propagate errors rather
-   than `.unwrap()` them.
+3. **Error handling for external input.** Deserialization of oracle responses and
+   resource charging generally return `Result` and callers must propagate errors.
+   However, some internal oracle paths use `assert!` or `.expect()` on
+   oracle-supplied lengths or slot values where the system considers a mismatch
+   to be an unrecoverable invariant violation (e.g. the new-slot initial-value
+   assertion in the storage cache). These paths are execution-environment
+   boundaries and should be reviewed carefully when changing oracle protocols.
 
 4. **`PROOF_ENV` cannot be changed at runtime.** It is a const generic, so it
    is burned in at compile time. The sequencer binary and the prover binary are

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -189,11 +189,11 @@ that different execution environments can use different cost schedules without
 branching at runtime:
 
 ```rust
-pub trait StorageAccessPolicy<R: Resources, V> {
-    fn charge_warm_storage_read(&self, ee_type, resources) -> Result<(), SystemError>;
-    fn charge_cold_storage_read_extra(&self, ee_type, resources, is_new_slot) -> Result<(), SystemError>;
-    fn charge_storage_write_extra(&self, ee_type, initial, current, new, resources, is_warm, is_new) -> Result<(), SystemError>;
-    fn refund_for_storage_write(&self, ee_type, ..., refund_counter) -> Result<(), SystemError>;
+pub trait StorageAccessPolicy<R: Resources, V>: 'static + Sized {
+    fn charge_warm_storage_read(&self, ee_type: ExecutionEnvironmentType, resources: &mut R) -> Result<(), SystemError>;
+    fn charge_cold_storage_read_extra(&self, ee_type: ExecutionEnvironmentType, resources: &mut R, is_new_slot: bool) -> Result<(), SystemError>;
+    fn charge_storage_write_extra(&self, ee_type: ExecutionEnvironmentType, initial_value: &V, current_value: &V, new_value: &V, resources: &mut R, is_warm_access: bool, is_cold_write_charged: bool, is_new_slot: bool) -> Result<(), SystemError>;
+    fn refund_for_storage_write(&self, ee_type: ExecutionEnvironmentType, value_at_tx_start: &V, current_value: &V, new_value: &V, resources: &mut R, refund_counter: &mut R) -> Result<(), SystemError>;
 }
 ```
 

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -1,0 +1,395 @@
+# Storage Model: Traits and Generics
+
+This document explains the storage model trait hierarchy, generic type parameters,
+and supporting abstractions in ZKsync OS. It is intended to help developers and
+auditors navigate the heavily-parametrised codebase.
+
+## Motivation
+
+The IO subsystem is designed to work with multiple storage backends (different
+Merkle tree structures, different account layouts, etc.) and multiple execution
+environments (forward/sequencer mode, proving mode). Generics are used throughout
+to achieve this flexibility with zero runtime cost. Understanding the role of each
+type parameter is key to reading the code.
+
+## Trait Hierarchy
+
+```
+SnapshottableIo
+    └─ StorageModel          (persistent key-value storage + account model)
+         └─ (implemented by) FlatTreeWithAccountsUnderHashesStorageModel
+                              EthereumStorageModel
+
+IOSubsystem                  (user-facing read/write interface)
+IOSubsystemExt               (frame management, nonce/balance updates, deployment)
+IOTeardown                   (block finalization, diff iteration, commitment update)
+    └─ (implemented by) FullIO<A, R, P, SF, N, O, M, PROOF_ENV>
+```
+
+### `SnapshottableIo` ([source](../../../storage_models/src/common_structs/traits/snapshottable_io.rs))
+
+Every storage layer must support transactional rollback via this trait:
+
+```rust
+pub trait SnapshottableIo {
+    type StateSnapshot;
+
+    fn begin_new_tx(&mut self);
+    fn finish_tx(&mut self) -> Result<(), InternalError>;
+
+    fn start_frame(&mut self) -> Self::StateSnapshot;
+    fn finish_frame(&mut self, rollback_handle: Option<&Self::StateSnapshot>)
+        -> Result<(), InternalError>;
+}
+```
+
+- `start_frame` captures the current state as a snapshot.
+- `finish_frame` either commits (when `rollback_handle` is `None`) or reverts all
+  changes made since the snapshot was taken (when the handle is `Some`). This
+  maps directly onto `CALL`/`CREATE` reversion semantics.
+- `begin_new_tx` / `finish_tx` handle the transaction-level lifecycle, including
+  clearing transient storage between transactions.
+
+### `StorageModel` ([source](../../../storage_models/src/common_structs/traits/storage_model.rs))
+
+The central abstraction for persistent state. It subsumes `SnapshottableIo` and
+adds the full account+storage API used by the bootloader and EEs:
+
+**Associated types:**
+
+| Associated type        | Meaning |
+|------------------------|---------|
+| `IOTypes`              | Concrete type-level configuration (`SystemIOTypesConfig`). Fixes `Address`, `StorageKey`, `StorageValue`, etc. |
+| `Resources`            | Resource tracking type (see [Resources](#resources-and-resource-charging)). |
+| `StorageCommitment`    | The state root type (e.g. a Merkle root). Must be serialisable for oracle communication. |
+| `Allocator`            | The allocator used for internal heap allocations. In proving mode this must be a custom bump allocator. |
+| `InitData`             | Initialisation parameters (typically the `StorageAccessPolicy`). Passed once at construction. |
+| `StorageKey<'a>`       | Opaque key type used in diff iteration. |
+| `StorageDiff<'a>`      | Opaque diff entry type used in diff iteration. |
+
+**Core methods:**
+- `storage_read` / `storage_write` / `storage_touch` — slot access; all charge
+  resources via the `EE`-specific policy.
+- `read_account_properties` — reads a subset of account fields; see
+  [AccountDataRequest](#accountdatarequest-and-the-maybe-type).
+- `increment_nonce`, `update_nominal_token_value`, `transfer_nominal_token_value`
+  — account mutation helpers.
+- `deploy_code`, `set_bytecode_details`, `set_delegation` — bytecode lifecycle.
+- `mark_for_deconstruction` — SELFDESTRUCT semantics.
+- `persist_caches`, `report_new_preimages`, `update_commitment` — block
+  finalisation hooks.
+- `storage_diffs_iterator` — iterates all state changes accumulated during the
+  block; used to produce pubdata.
+
+## `FullIO` and Its Generic Parameters
+
+`FullIO` ([source](../../../basic_system/src/system_implementation/system/io_subsystem.rs))
+is the concrete IO subsystem that implements `IOSubsystem`, `IOSubsystemExt`, and
+`IOTeardown`. Its full signature is:
+
+```rust
+pub struct FullIO<
+    A: Allocator + Clone + Default,
+    R: Resources,
+    P: StorageAccessPolicy<R, Bytes32>,
+    SF: StackFactory<N>,
+    const N: usize,
+    O: IOOracle,
+    M: StorageModel<IOTypes = EthereumIOTypesConfig, Resources = R, InitData = P, Allocator = A>,
+    const PROOF_ENV: bool,
+>
+```
+
+| Parameter | Constraint | What it represents |
+|-----------|------------|--------------------|
+| `A` | `Allocator + Clone + Default` | Memory allocator. In forward mode this is the global allocator (`Global`). In proving mode it is a custom bump allocator that avoids the standard `malloc`. |
+| `R` | `Resources` | Dual resource counter (ergs + native). Tracks gas charges (`Ergs`) and prover-complexity charges (`Native`) in a single structure. |
+| `P` | `StorageAccessPolicy<R, Bytes32>` | EE-specific cost policy for storage access. Provides warm/cold read and write costs. The EVM policy lives in `basic_system`. |
+| `SF` | `StackFactory<N>` | Factory for fixed-capacity stack structures used by transient storage, event storage, log storage, etc. |
+| `N` | `const usize` | Stack depth bound (number of nested frames). |
+| `O` | `IOOracle` | Non-determinism source. In forward mode this wraps a database connection. In proving mode it uses CSR reads on the RISC-V target. |
+| `M` | `StorageModel<IOTypes = EthereumIOTypesConfig, Resources = R, InitData = P, Allocator = A>` | The pluggable persistent storage backend (e.g. `FlatTreeWithAccountsUnderHashesStorageModel`). |
+| `PROOF_ENV` | `const bool` | Compile-time flag. When `true`, the system is running inside the ZK proof (RISC-V). Enables additional proof-correctness checks such as re-hashing bytecode against the stored hash and verifying account preimage hashes. |
+
+`FullIO` owns several sub-storages in addition to the main `M`:
+- **`storage`** (`M`) — the main persistent key-value storage.
+- **`transient_storage`** — EIP-1153 transient slots, cleared after each transaction.
+- **`logs_storage`** — L2→L1 message logs.
+- **`events_storage`** — EVM event log.
+- **`interop_root_storage`** — Interop root storage for cross-chain messages.
+- **`new_settlement_layer_chain_id_storage`** — Tracks chain ID updates.
+
+## `SystemIOTypesConfig` ([source](../../../zk_ee/src/types_config/mod.rs))
+
+This trait is the type-level configuration for all IO primitive types. It decouples
+the system logic from the specific widths of addresses, keys, and values:
+
+```rust
+pub trait SystemIOTypesConfig: Sized + 'static + Send + Sync {
+    type Address;           // e.g. B160 (20-byte Ethereum address)
+    type StorageKey;        // e.g. Bytes32
+    type StorageValue;      // e.g. Bytes32
+    type NominalTokenValue; // e.g. U256
+    type BytecodeHashValue; // e.g. Bytes32
+    type EventKey;          // Topic type for event emission
+    type SignalingKey;      // Key type for L2→L1 signals
+}
+```
+
+All associated types must implement `UsizeSerializable` + `UsizeDeserializable` so
+they can be exchanged with the oracle over the `usize`-based serialisation
+interface (see [Oracle Serialisation](#oracle-serialisation)).
+
+The only concrete instantiation currently used is `EthereumIOTypesConfig`:
+
+| Type | Concrete type | Size |
+|------|---------------|------|
+| `Address` | `B160` | 20 bytes |
+| `StorageKey` | `Bytes32` | 32 bytes |
+| `StorageValue` | `Bytes32` | 32 bytes |
+| `NominalTokenValue` | `U256` | 32 bytes |
+| `BytecodeHashValue` | `Bytes32` | 32 bytes |
+| `EventKey` | `Bytes32` | 32 bytes |
+| `SignalingKey` | `Bytes32` | 32 bytes |
+
+## Resources and Resource Charging
+
+### The `Resources` Trait ([source](../../../zk_ee/src/system/resources.rs))
+
+Resources are a dual counter pairing two independent budgets:
+
+- **`Ergs`** — execution gas, charged proportionally to EVM gas consumed. Directly
+  corresponds to the user-visible gas limit.
+- **`Native`** — prover complexity budget. Tracks work that has no direct EVM gas
+  analogue but must be bounded for proof generation (e.g. hash operations). This
+  prevents DoS via cheap-gas but prover-heavy operations.
+
+The `Resources` trait wraps both:
+
+```rust
+pub trait Resources: Sized + Clone + core::fmt::Debug {
+    const FORMAL_INFINITE: Self;  // Sentinel for unconstrained execution (system paths)
+    fn empty() -> Self;
+    fn charge(&mut self, to_charge: &Self) -> Result<(), SystemError>;
+    fn has_enough(&self, to_spend: &Self) -> bool;
+    fn reclaim(&mut self, to_reclaim: Self);
+    // ...
+}
+```
+
+### `StorageAccessPolicy` ([source](../../../basic_system/src/system_implementation/caches/storage_access_policy.rs))
+
+This trait encodes EE-specific storage costs. `FullIO` is parameterised over it so
+that different execution environments can use different cost schedules without
+branching at runtime:
+
+```rust
+pub trait StorageAccessPolicy<R: Resources, V> {
+    fn charge_warm_storage_read(&self, ee_type, resources) -> Result<(), SystemError>;
+    fn charge_cold_storage_read_extra(&self, ee_type, resources, is_new_slot) -> Result<(), SystemError>;
+    fn charge_storage_write_extra(&self, ee_type, initial, current, new, resources, is_warm, is_new) -> Result<(), SystemError>;
+    fn refund_for_storage_write(&self, ee_type, ..., refund_counter) -> Result<(), SystemError>;
+}
+```
+
+For EVM: warm reads cost 100 gas, cold reads add 2100 gas, new slot writes add
+20000 gas. Gas refunds from `SSTORE` (`EIP-3529`) are tracked in the
+`refund_counter` field of `StorageModel`.
+
+## `AccountDataRequest` and the `Maybe` Type
+
+Reading account properties involves a phantom-type trick that encodes at compile
+time exactly which fields are requested, avoiding over-fetching:
+
+```rust
+// In zk_ee/src/system/io.rs
+pub struct AccountDataRequest<T>(PhantomData<T>);
+
+// The Maybe marker types:
+pub struct Just<T>(PhantomData<T>);  // "request this field"
+pub struct Nothing;                   // "don't request this field"
+```
+
+`AccountData` is parameterised over one `Maybe<T>` per field:
+
+```rust
+pub struct AccountData<
+    EEVersion,             // Maybe<u8>
+    ObservableBytecodeHash,
+    ObservableBytecodeLen,
+    Nonce,                 // Maybe<u64>
+    BytecodeHash,
+    BytecodeLen,           // Maybe<u32>
+    ArtifactsLen,
+    NominalTokenBalance,   // Maybe<U256>
+    Bytecode,              // Maybe<&'static [u8]>
+    CodeVersion,
+    IsDelegated,           // Maybe<bool>
+> { /* fields present only when their type is Just<T> */ }
+```
+
+A request is built with a builder pattern:
+
+```rust
+let request = AccountDataRequest::empty()
+    .with_nonce()
+    .with_nominal_token_balance();
+// The return type encodes exactly these two fields as Just<_>, rest as Nothing.
+```
+
+This ensures:
+1. Only the requested data is deserialised from the oracle response.
+2. Callers cannot accidentally access fields they did not request (compile error).
+3. The storage implementation fetches only what is needed (e.g. avoids loading
+   bytecode preimage when only the nonce is required).
+
+## `PROOF_ENV` Const Generic
+
+The `const PROOF_ENV: bool` parameter threads through `FullIO`, `StorageModel`
+implementations, and several helper methods. When `true`:
+
+- Bytecode hashes are **re-verified** after loading from the preimage oracle
+  (guards against a malicious oracle providing wrong bytecode).
+- Account property preimage hashes are **re-verified** against the hash stored
+  in the tree.
+- Certain internal assertions become active that are too expensive for forward
+  execution.
+
+When `false` (forward/sequencer mode):
+- The system trusts the oracle responses (the sequencer controls its own oracle).
+- Verification steps are skipped for performance.
+
+This ensures the ZK proof is sound without imposing proof-environment overhead on
+the hot path.
+
+## Oracle Serialisation
+
+All types exchanged with the oracle implement
+`UsizeSerializable` / `UsizeDeserializable`
+([source](../../../zk_ee/src/oracle/usize_serialization/mod.rs)).
+These traits serialise values as slices of `usize` words, which allows the same
+Rust code to run on both 64-bit (sequencer) and 32-bit RISC-V (prover) with
+correct packing:
+
+- On 64-bit: 1 `usize` = 8 bytes → a `U256` uses 4 words.
+- On 32-bit: 1 `usize` = 4 bytes → a `U256` uses 8 words.
+
+The trait is implemented for `u8`, `u32`, `u64`, `U256`, `B160`, `Bytes32`,
+tuples, and fixed-size arrays. Little-endian encoding is used throughout.
+
+> **Note**: Deserialization panics on values that cannot be constructed from the
+> provided word count. Callers in the oracle layer must ensure the oracle response
+> length matches the expected `USIZE_LEN` constant before invoking deserialization.
+
+## Data Flow: Storage Read
+
+```
+EE calls IOSubsystem::storage_read(ee_type, resources, address, key)
+  │
+  └─> FullIO dispatches to:
+        ├─ transient_storage  (if TRANSIENT=true)
+        └─ storage (M = StorageModel)
+              │
+              └─> StorageModel::storage_read(ee_type, resources, address, key, oracle)
+                    │
+                    ├─ StorageAccessPolicy: charge warm read cost
+                    │
+                    └─> StorageCacheModel::read(address, key)
+                          ├─ Cache hit:  return cached value
+                          └─ Cache miss:
+                                │
+                                ├─ StorageAccessPolicy: charge cold read extra cost
+                                │
+                                └─> oracle.query(INITIAL_STORAGE_SLOT_VALUE_QUERY_ID,
+                                                 (address, key))
+                                      │
+                                      └─> Deserialise → insert into cache → return
+```
+
+## Data Flow: Account Property Read
+
+```
+EE calls IOSubsystemExt::read_account_properties(request, address)
+  │
+  └─> StorageModel::read_account_properties(...)
+        │
+        ├─ Check account cache (HistoryMap keyed by address)
+        │    ├─ Cache hit:  return requested fields from AccountCacheEntry
+        │    └─ Cache miss:
+        │          │
+        │          └─> Read hash at slot (ACCOUNT_PROPERTIES_STORAGE_ADDRESS, address)
+        │                │
+        │                └─> oracle.query(GENERIC_PREIMAGE_QUERY_ID, hash)
+        │                      │
+        │                      ├─ [PROOF_ENV=true] re-verify hash of received preimage
+        │                      └─> Deserialise AccountCacheEntry → insert into cache
+        │
+        └─ Return requested fields (type-checked at compile time by AccountDataRequest)
+```
+
+## Data Flow: Block Finalisation
+
+```
+Bootloader calls IOTeardown::finish_block()
+  │
+  ├─ 1. persist_caches:       flush storage diffs to result keeper
+  ├─ 2. report_new_preimages: emit bytecodes and account structures for pubdata
+  ├─ 3. storage_diffs_iterator: iterate all (address, key, old_value, new_value)
+  ├─ 4. update_commitment:    apply diffs to Merkle tree, compute new state root
+  └─ 5. result_keeper collects:
+          - storage diffs  (→ pubdata encoding)
+          - account diffs  (nonce, balance, bytecode hash changes)
+          - preimages      (bytecodes, account structures)
+          - events / L2→L1 logs
+```
+
+## Concrete Storage Model: `FlatTreeWithAccountsUnderHashesStorageModel`
+
+The default storage model
+([source](../../../basic_system/src/system_implementation/flat_storage_model/mod.rs))
+is composed of:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `storage_cache` | `NewStorageWithAccountPropertiesUnderHash` | Caches raw storage slots; backed by the Merkle tree described in [tree.md](tree.md). |
+| `preimages_cache` | `BytecodeAndAccountDataPreimagesStorage` | Caches bytecode and serialised account property blobs, keyed by their hash. |
+| `account_data_cache` | `NewModelAccountCache` | Caches deserialized account structs for efficient per-field access. |
+
+Account properties are **not** stored directly in the tree. Instead, a
+`keccak256` hash of the serialised account struct is stored at tree slot
+`(ACCOUNT_PROPERTIES_STORAGE_ADDRESS, address)` (address `0x8003`). The preimage
+is loaded on demand through the oracle. This keeps tree leaves small and allows
+the account encoding to change without changing the tree structure.
+
+The `HistoryMap` ([source](../../../zk_ee/src/common_structs/history_map/mod.rs))
+powers all three caches. It stores a per-key chain of historical values and
+supports O(1) snapshot and rollback via a global event log plus per-entry
+version pointers.
+
+## Ethereum Storage Model: `EthereumStorageModel`
+
+An alternative storage model
+([source](../../../basic_system/src/system_implementation/ethereum_storage_model/mod.rs))
+that uses a Merkle Patricia Trie (MPT) with RLP encoding, as in mainnet Ethereum.
+It is used for Ethereum compatibility testing (EVM spec tests). It is not used in
+production: the MPT requires a large number of preimage oracle queries (one per
+trie node on each path), making it unsuitable for efficient proof generation.
+
+## Security Notes
+
+1. **Oracle responses are untrusted.** All data from the oracle must be validated
+   before use. In `PROOF_ENV=true` mode, hashes are re-derived from the received
+   preimages and compared against the tree. In forward mode the sequencer trusts
+   its own oracle, but the ZK proof provides the ultimate correctness guarantee.
+
+2. **Rollback safety.** `HistoryMap`-based caches guarantee that any changes made
+   inside a call frame are atomically reverted when `finish_frame(Some(snapshot))`
+   is called. This invariant is critical for correct EVM `CALL` reversion.
+
+3. **No panics from external input.** Deserialization of oracle responses and
+   resource charging both return `Result`. Callers must propagate errors rather
+   than `.unwrap()` them.
+
+4. **`PROOF_ENV` cannot be changed at runtime.** It is a const generic, so it
+   is burned in at compile time. The sequencer binary and the prover binary are
+   separate build artifacts.

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -287,9 +287,8 @@ The trait is implemented for `u8`, `u32`, `u64`, `U256`, `B160`, `Bytes32`,
 tuples, and fixed-size arrays. Little-endian encoding is used throughout.
 
 > **Note**: `UsizeDeserializable::from_iter` returns `Result<_, InternalError>` and
-> propagates an error when the supplied word count does not match `USIZE_LEN`.
-> Callers in the oracle layer must ensure the oracle response length matches the
-> expected `USIZE_LEN` constant.
+> propagates an error if the iterator does not yield enough words to fill `USIZE_LEN`.
+> Callers in the oracle layer must ensure responses are well-formed and consumed consistently.
 
 ## Data Flow: Storage Read
 

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -105,8 +105,8 @@ pub struct FullIO<
 | `A` | `Allocator + Clone + Default` | Memory allocator. In forward mode this is the global allocator (`Global`). In proving mode it is a custom bump allocator that avoids the standard `malloc`. |
 | `R` | `Resources` | Dual resource counter (ergs + native). Tracks gas charges (`Ergs`) and prover-complexity charges (`Native`) in a single structure. |
 | `P` | `StorageAccessPolicy<R, Bytes32>` | EE-specific cost policy for storage access. Provides warm/cold read and write costs. The EVM policy lives in `basic_system`. |
-| `SF` | `StackFactory<N>` | Factory for fixed-capacity stack structures used by transient storage, event storage, log storage, etc. |
-| `N` | `const usize` | Stack depth bound (number of nested frames). |
+| `SF` | `StackFactory<N>` | Factory for creating stack data structures. Different environments use different implementations: forward mode uses `VecStackFactory` (Vec-backed, dynamically resized), proving mode uses `LVStackFactory` (linked list of fixed-size `ArrayVec<T, N>` chunks for deterministic memory access). |
+| `N` | `const usize` | Compile-time configuration for the stack implementation. In proving mode this is the chunk capacity for skip-list nodes (e.g. `N=32`). In forward mode (Vec-backed) it is unused. |
 | `O` | `IOOracle` | Non-determinism source. In forward mode this wraps a database connection. In proving mode it uses CSR reads on the RISC-V target. |
 | `M` | `StorageModel<IOTypes = EthereumIOTypesConfig, Resources = R, InitData = P, Allocator = A>` | The pluggable persistent storage backend (e.g. `FlatTreeWithAccountsUnderHashesStorageModel`). |
 | `PROOF_ENV` | `const bool` | Compile-time flag. When `true`, the system is running inside the ZK proof (RISC-V). Enables additional proof-correctness checks such as re-hashing bytecode against the stored hash and verifying account preimage hashes. |
@@ -377,15 +377,6 @@ The `HistoryMap` ([source](../../../zk_ee/src/common_structs/history_map/mod.rs)
 powers all three caches. It stores a per-key chain of historical values and
 supports O(1) snapshot and rollback via a global event log plus per-entry
 version pointers.
-
-## Ethereum Storage Model: `EthereumStorageModel`
-
-An alternative storage model
-([source](../../../basic_system/src/system_implementation/ethereum_storage_model/mod.rs))
-that uses a Merkle Patricia Trie (MPT) with RLP encoding, as in mainnet Ethereum.
-It is used for Ethereum compatibility testing (EVM spec tests). It is not used in
-production: the MPT requires a large number of preimage oracle queries (one per
-trie node on each path), making it unsuitable for efficient proof generation.
 
 ## Security Notes
 

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -122,8 +122,7 @@ pub struct FullIO<
 ## `SystemIOTypesConfig` ([source](../../../zk_ee/src/types_config/mod.rs))
 
 This trait is the type-level configuration for all IO primitive types. It decouples
-the system logic from the specific widths of addresses, keys, and values:
-
+the system logic from the specific widths of addresses, keys, and values (simplified; see source for full definition):
 ```rust
 pub trait SystemIOTypesConfig: Sized + 'static + Send + Sync {
     type Address;           // e.g. B160 (20-byte Ethereum address)

--- a/docs/system/io/storage_model.md
+++ b/docs/system/io/storage_model.md
@@ -136,9 +136,11 @@ pub trait SystemIOTypesConfig: Sized + 'static + Send + Sync {
 }
 ```
 
-All associated types must implement `UsizeSerializable` + `UsizeDeserializable` so
+Most associated types must implement `UsizeSerializable` + `UsizeDeserializable` so
 they can be exchanged with the oracle over the `usize`-based serialisation
 interface (see [Oracle Serialisation](#oracle-serialisation)).
+`EventKey` and `SignalingKey` are write-only from the system's perspective and
+therefore only require `UsizeSerializable`.
 
 The only concrete instantiation currently used is `EthereumIOTypesConfig`:
 
@@ -192,9 +194,11 @@ pub trait StorageAccessPolicy<R: Resources, V> {
 }
 ```
 
-For EVM: warm reads cost 100 gas, cold reads add 2100 gas, new slot writes add
-20000 gas. Gas refunds from `SSTORE` (`EIP-3529`) are tracked in the
-`refund_counter` field of `StorageModel`.
+For EVM: warm reads cost 100 gas (`WARM_STORAGE_READ_COST`); cold reads charge an
+additional 2000 gas on top of the warm cost for a 2100 gas total (`COLD_SLOAD_COST`).
+New-slot writes charge an extra 19900 gas (`SSTORE_SET_EXTRA`) after the warm-read
+cost, and cold writes add another 100 gas. Gas refunds from `SSTORE` (`EIP-3529`)
+are tracked in the `refund_counter` field of `StorageModel`.
 
 ## `AccountDataRequest` and the `Maybe` Type
 
@@ -277,9 +281,10 @@ correct packing:
 The trait is implemented for `u8`, `u32`, `u64`, `U256`, `B160`, `Bytes32`,
 tuples, and fixed-size arrays. Little-endian encoding is used throughout.
 
-> **Note**: Deserialization panics on values that cannot be constructed from the
-> provided word count. Callers in the oracle layer must ensure the oracle response
-> length matches the expected `USIZE_LEN` constant before invoking deserialization.
+> **Note**: `UsizeDeserializable::from_iter` returns `Result<_, InternalError>` and
+> propagates an error when the supplied word count does not match `USIZE_LEN`.
+> Callers in the oracle layer must ensure the oracle response length matches the
+> expected `USIZE_LEN` constant.
 
 ## Data Flow: Storage Read
 
@@ -319,7 +324,7 @@ EE calls IOSubsystemExt::read_account_properties(request, address)
         │          │
         │          └─> Read hash at slot (ACCOUNT_PROPERTIES_STORAGE_ADDRESS, address)
         │                │
-        │                └─> oracle.query(GENERIC_PREIMAGE_QUERY_ID, hash)
+        │                └─> oracle.query(FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID, hash)
         │                      │
         │                      ├─ [PROOF_ENV=true] re-verify hash of received preimage
         │                      └─> Deserialise AccountCacheEntry → insert into cache
@@ -356,10 +361,11 @@ is composed of:
 | `account_data_cache` | `NewModelAccountCache` | Caches deserialized account structs for efficient per-field access. |
 
 Account properties are **not** stored directly in the tree. Instead, a
-`keccak256` hash of the serialised account struct is stored at tree slot
+`Blake2s256` hash of the serialised account struct is stored at tree slot
 `(ACCOUNT_PROPERTIES_STORAGE_ADDRESS, address)` (address `0x8003`). The preimage
-is loaded on demand through the oracle. This keeps tree leaves small and allows
-the account encoding to change without changing the tree structure.
+is loaded on demand through the oracle using `FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID`.
+This keeps tree leaves small and allows the account encoding to change without
+changing the tree structure.
 
 The `HistoryMap` ([source](../../../zk_ee/src/common_structs/history_map/mod.rs))
 powers all three caches. It stores a per-key chain of historical values and


### PR DESCRIPTION
## What ❔

Adds `docs/system/io/storage_model.md`: a new reference guide for the IO
subsystem's storage model layer. The guide covers:

- The `StorageModel` and `SnapshottableIo` trait hierarchy and their methods.
- Every generic type parameter of `FullIO<A, R, P, SF, N, O, M, PROOF_ENV>` with
  a plain-English explanation of what it represents and why it exists.
- The `SystemIOTypesConfig` / `EthereumIOTypesConfig` type-level configuration.
- The resource charging model: `Resources`, `Ergs`, `Native`, `StorageAccessPolicy`.
- The `AccountDataRequest` / `Maybe` phantom-type system for selective field reads.
- The `PROOF_ENV` const generic and how it gates proof-correctness checks.
- The `UsizeSerializable` / `UsizeDeserializable` cross-architecture serialisation
  used for oracle communication.
- Step-by-step data flow diagrams for a storage read, an account property read,
  and block finalisation.
- A comparison of the two concrete storage model implementations
  (`FlatTreeWithAccountsUnderHashesStorageModel` vs `EthereumStorageModel`).
- Security notes on oracle trust boundaries, rollback safety, and the compile-time
  nature of `PROOF_ENV`.

Also adds one sentence to the existing `docs/system/io/io.md` linking to the new
guide from the section where `FullIO` generics are first mentioned.

## Why ❔

The IO subsystem uses deeply nested generics that make the code hard to follow for
both new contributors and external auditors. The existing docs describe *what* the
system does at a high level but do not explain *why* each type parameter exists or
how the pieces fit together. This guide closes that gap without modifying any
runtime code.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

---
Rebased from #558 onto `draft-0.4.0` (original targeted `dev`). No content changes.