### PR TITLE
refactor(bootloader): eliminate duplicate hook lookup in special address routing

### DIFF
--- a/basic_bootloader/src/bootloader/runner.rs
+++ b/basic_bootloader/src/bootloader/runner.rs
@@ -267,10 +267,11 @@ impl<'external, S: EthereumLikeTypes> ExecutionContext<'_, 'external, S> {
 
         // Only calls to addresses linked to a hook are considered special.
         // Any other call can execute code following the normal flow.
-        let callee_low = external_call_launch_params.external_call.callee.as_limbs()[0] as u16;
         let hook = if external_call_launch_params.external_call.callee.as_uint()
             < SPECIAL_ADDRESS_BOUND.as_uint()
         {
+            // SPECIAL_ADDRESS_BOUND fits in u16, so the truncating cast is safe here.
+            let callee_low = external_call_launch_params.external_call.callee.as_limbs()[0] as u16;
             self.hooks.find_call_hook(callee_low)
         } else {
             None

--- a/basic_bootloader/src/bootloader/runner.rs
+++ b/basic_bootloader/src/bootloader/runner.rs
@@ -6,7 +6,7 @@ use core::fmt::Write;
 use core::mem::MaybeUninit;
 use errors::internal::InternalError;
 use ruint::aliases::B160;
-use zk_ee::common_structs::system_hooks::HooksStorage;
+use zk_ee::common_structs::system_hooks::{HooksStorage, SystemCallHook};
 use zk_ee::common_structs::CalleeAccountProperties;
 use zk_ee::error_ctx;
 use zk_ee::execution_environment_type::ExecutionEnvironmentType;
@@ -267,20 +267,22 @@ impl<'external, S: EthereumLikeTypes> ExecutionContext<'_, 'external, S> {
 
         // Only calls to addresses linked to a hook are considered special.
         // Any other call can execute code following the normal flow.
-        //
-        // TODO(EVM-1181): We should refactor the logic to avoid the duplicated lookup into the hook storage.
-        let is_call_to_special_address = external_call_launch_params.external_call.callee.as_uint()
+        let callee_low = external_call_launch_params.external_call.callee.as_limbs()[0] as u16;
+        let hook = if external_call_launch_params.external_call.callee.as_uint()
             < SPECIAL_ADDRESS_BOUND.as_uint()
-            && self.hooks.has_hook_for(
-                external_call_launch_params.external_call.callee.as_limbs()[0] as u16,
-            );
+        {
+            self.hooks.find_call_hook(callee_low)
+        } else {
+            None
+        };
 
-        if is_call_to_special_address {
+        if let Some(hook) = hook {
             // The call is targeting the "system contract" space.
             self.call_to_special_address_execute_callee_frame(
                 external_call_launch_params,
                 caller_ee_type,
                 rollback_handle,
+                hook,
             )
         } else {
             self.call_execute_callee_frame(
@@ -506,6 +508,7 @@ impl<'external, S: EthereumLikeTypes> ExecutionContext<'_, 'external, S> {
         external_call_launch_params: ExecutionEnvironmentLaunchParams<S>,
         caller_ee_type: ExecutionEnvironmentType,
         rollback_handle: SystemFrameSnapshot<S>,
+        hook: SystemCallHook<S>,
     ) -> Result<(S::Resources, CallResult<'external, S>), BootloaderSubsystemError>
     where
         S::IO: IOSubsystemExt,
@@ -531,12 +534,8 @@ impl<'external, S: EthereumLikeTypes> ExecutionContext<'_, 'external, S> {
         }
 
         let return_memory = core::mem::take(&mut self.return_memory);
-        let resources_passed = external_call_launch_params
-            .external_call
-            .available_resources
-            .clone();
-        let (res, remaining_memory) = self.hooks.try_intercept(
-            external_call_launch_params.external_call.callee.as_limbs()[0] as u16,
+        let (system_hook_run_result, remaining_memory) = self.hooks.run_call_hook(
+            hook,
             external_call_launch_params.external_call,
             caller_ee_type as u8,
             self.system,
@@ -545,57 +544,41 @@ impl<'external, S: EthereumLikeTypes> ExecutionContext<'_, 'external, S> {
         // Reclaim unused return memory
         self.return_memory = remaining_memory;
 
-        if let Some(system_hook_run_result) = res {
-            let CompletedExecution {
-                resources_returned,
-                result,
-            } = system_hook_run_result;
+        let CompletedExecution {
+            resources_returned,
+            result,
+        } = system_hook_run_result;
 
-            let reverted = result.failed();
-            let return_values = result.return_values();
+        let reverted = result.failed();
+        let return_values = result.return_values();
 
-            system_log!(
-                self.system,
-                "Call to special address returned, success = {}\n",
-                !reverted
-            );
+        system_log!(
+            self.system,
+            "Call to special address returned, success = {}\n",
+            !reverted
+        );
 
-            let returndata_slice = return_values.returndata;
-            let returndata_iter = returndata_slice.iter().copied();
-            system_log!(self.system, "Returndata = ");
-            let _ = self.system.get_logger().log_data(returndata_iter);
+        let returndata_slice = return_values.returndata;
+        let returndata_iter = returndata_slice.iter().copied();
+        system_log!(self.system, "Returndata = ");
+        let _ = self.system.get_logger().log_data(returndata_iter);
 
-            self.system
-                .finish_global_frame(if reverted {
-                    Some(&rollback_handle)
-                } else {
-                    None
-                })
-                .map_err(|_| internal_error!("must finish execution frame"))?;
+        self.system
+            .finish_global_frame(if reverted {
+                Some(&rollback_handle)
+            } else {
+                None
+            })
+            .map_err(|_| internal_error!("must finish execution frame"))?;
 
-            Ok((
-                resources_returned,
-                if reverted {
-                    CallResult::Failed { return_values }
-                } else {
-                    CallResult::Successful { return_values }
-                },
-            ))
-        } else {
-            let resources_returned = resources_passed;
-            // it's an empty account for all the purposes
-            system_log!(self.system, "Call to special address was not intercepted\n",);
-            self.system
-                .finish_global_frame(None)
-                .map_err(|_| internal_error!("must finish execution frame"))?;
-
-            Ok((
-                resources_returned,
-                CallResult::Successful {
-                    return_values: ReturnValues::empty(),
-                },
-            ))
-        }
+        Ok((
+            resources_returned,
+            if reverted {
+                CallResult::Failed { return_values }
+            } else {
+                CallResult::Successful { return_values }
+            },
+        ))
     }
 }
 

--- a/zk_ee/src/common_structs/system_hooks.rs
+++ b/zk_ee/src/common_structs/system_hooks.rs
@@ -24,6 +24,15 @@ pub struct SystemCallHook<S: SystemTypes>(
     ) -> Result<(CompletedExecution<'a, S>, &'a mut [MaybeUninit<u8>]), SystemError>,
 );
 
+// Manual impls avoid adding `S: Copy/Clone` bounds, which are not required since the
+// inner field is a bare function pointer (always Copy regardless of S).
+impl<S: SystemTypes> Copy for SystemCallHook<S> {}
+impl<S: SystemTypes> Clone for SystemCallHook<S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
 impl<S: SystemTypes> SystemCallHook<S> {
     pub fn new(
         f: for<'a> fn(
@@ -126,24 +135,18 @@ impl<S: SystemTypes, A: Allocator + Clone> HooksStorage<S, A> {
     }
 
     ///
-    /// Intercepts calls to low addresses (< 2^16) and executes hooks
-    /// stored under that address. If no hook is stored there, return `Ok(None)`.
-    /// Always return unused return_memory.
+    /// Executes the given call hook and returns the result.
+    /// Always returns unused return_memory.
     ///
-    pub fn try_intercept<'a>(
-        &mut self,
-        address_low: u16,
+    pub fn run_call_hook<'a>(
+        &self,
+        hook: SystemCallHook<S>,
         request: ExternalCallRequest<S>,
         caller_ee: u8,
         system: &mut System<S>,
         return_memory: &'a mut [MaybeUninit<u8>],
-    ) -> Result<(Option<CompletedExecution<'a, S>>, &'a mut [MaybeUninit<u8>]), SystemError> {
-        let Some(hook) = self.call_hooks.get(&address_low) else {
-            return Ok((None, return_memory));
-        };
-        let (res, remaining_memory) = hook.0(request, caller_ee, system, return_memory)?;
-
-        Ok((Some(res), remaining_memory))
+    ) -> Result<(CompletedExecution<'a, S>, &'a mut [MaybeUninit<u8>]), SystemError> {
+        hook.0(request, caller_ee, system, return_memory)
     }
 
     /// Intercepts events emitted from low addresses (< 2^32) and executes hooks
@@ -170,10 +173,10 @@ impl<S: SystemTypes, A: Allocator + Clone> HooksStorage<S, A> {
     }
 
     ///
-    /// Checks if there is a call hook stored for a given low address (<16 bits).
+    /// Returns the call hook stored for a given low address (<16 bits), or `None` if absent.
     ///
-    pub fn has_hook_for(&mut self, address_low: u16) -> bool {
-        self.call_hooks.contains_key(&address_low)
+    pub fn find_call_hook(&self, address_low: u16) -> Option<SystemCallHook<S>> {
+        self.call_hooks.get(&address_low).copied()
     }
 
     ///


### PR DESCRIPTION
## What ❔

Refactors the special-address call routing in `basic_bootloader` to perform
a single BTreeMap lookup instead of two. Previously, the code called
`hooks.has_hook_for(address_low)` (which does `contains_key`) to decide
whether to enter the special-address path, then called `hooks.try_intercept(address_low, ...)`
(which does `get`) inside that path — two lookups on the same key.

Changes:
- Added `Copy`/`Clone` impls for `SystemCallHook<S>` (manual impls to avoid
  adding `S: Copy/Clone` bounds, since the inner field is a bare function pointer).
- Replaced `has_hook_for` with `find_call_hook(&self, address_low) -> Option<SystemCallHook<S>>`
  that returns a copy of the hook in a single `get().copied()` call.
- Replaced `try_intercept` (which looked up the hook then called it) with
  `run_call_hook(&self, hook, ...)` that accepts the hook directly.
- Updated `call_to_special_address_execute_callee_frame` to accept the hook
  as a parameter and call `run_call_hook` without a second map lookup.
- Simplified `call_to_special_address_execute_callee_frame` by removing the
  now-unreachable `None` branch from the old try_intercept pattern.

## Why ❔

The double-lookup pattern was flagged in a TODO comment as a code smell.
Eliminating it makes the logic cleaner, removes the `None` branch that was
previously dead code in the special-address path (the function is only entered
when a hook was found), and clarifies the data flow.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

---
Rebased from #559 onto `draft-0.4.0` (original targeted `dev`). Clean rebase, builds + clippy clean.