### PR TITLE
chore(zk_ee): introduce proving_env feature flag for conditional compilation

### DIFF
--- a/basic_bootloader/Cargo.toml
+++ b/basic_bootloader/Cargo.toml
@@ -60,3 +60,4 @@ fri_precompile = ["dep:full_statement_verifier", "system_hooks/fri_precompile"]
 # on the native resources actually consumed by validation and post-execution
 # bookkeeping that it is meant to cover.
 verify_intrinsic_native = []
+proving_env = ["zk_ee/proving_env"]

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/mod.rs
@@ -578,7 +578,7 @@ where
             .as_u64()
             .saturating_add(context.intrinsic_computational_native);
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         cycle_marker::log_marker(
             format!(
                 "Spent ergs for [process_transaction]: {}",
@@ -586,7 +586,7 @@ where
             )
             .as_str(),
         );
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         cycle_marker::log_marker(
             format!("Spent native for [process_transaction]: {computational_native_used}").as_str(),
         );

--- a/basic_system/Cargo.toml
+++ b/basic_system/Cargo.toml
@@ -33,30 +33,5 @@ paste = { workspace = true }
 testing = ["zk_ee/testing", "evm_interpreter/testing", "serde", "ruint/serde", "rand", "crypto/testing", "num-bigint", "num-traits"]
 default = ["testing"]
 cycle_marker = ["cycle_marker/log_to_file"]
-proving = ["crypto/proving"]
+proving = ["crypto/proving", "zk_ee/proving_env"]
 delegation = ["zk_ee/delegation", "evm_interpreter/delegation", "storage_models/delegation"]
-# The finish method will just return inputs, so outputs can be processed outside bootloader
-# Used for proving multi block batch within 1 run
-multiblock-batch = []
-state-diffs-pi = []
-
-[dev-dependencies]
-hex = { workspace = true }
-proptest = { workspace = true }
-crypto = { workspace = true, features = ["secp256k1-static-context", "testing"] }
-num-bigint = { workspace = true, default-features = true }
-num-traits = { workspace = true, default-features = true }
-callable_oracles = { path = "../callable_oracles" }
-oracle_provider = { path = "../oracle_provider" }
-arbitrary = { version = "1", features = ["derive"] }
-serde_json = { workspace = true }
-alloy-rpc-types-debug = { workspace = true }
-alloy = { workspace = true, features = ["rlp", "full"] }
-alloy-rlp = { workspace = true }
-alloy-primitives = { workspace = true, features = ["arbitrary"] }
-reqwest = { workspace = true, features = ["blocking", "json"] }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }

--- a/basic_system/Cargo.toml
+++ b/basic_system/Cargo.toml
@@ -35,3 +35,28 @@ default = ["testing"]
 cycle_marker = ["cycle_marker/log_to_file"]
 proving = ["crypto/proving", "zk_ee/proving_env"]
 delegation = ["zk_ee/delegation", "evm_interpreter/delegation", "storage_models/delegation"]
+# The finish method will just return inputs, so outputs can be processed outside bootloader
+# Used for proving multi block batch within 1 run
+multiblock-batch = []
+state-diffs-pi = []
+
+[dev-dependencies]
+hex = { workspace = true }
+proptest = { workspace = true }
+crypto = { workspace = true, features = ["secp256k1-static-context", "testing"] }
+num-bigint = { workspace = true, default-features = true }
+num-traits = { workspace = true, default-features = true }
+callable_oracles = { path = "../callable_oracles" }
+oracle_provider = { path = "../oracle_provider" }
+arbitrary = { version = "1", features = ["derive"] }
+serde_json = { workspace = true }
+alloy-rpc-types-debug = { workspace = true }
+alloy = { workspace = true, features = ["rlp", "full"] }
+alloy-rlp = { workspace = true }
+alloy-primitives = { workspace = true, features = ["arbitrary"] }
+reqwest = { workspace = true, features = ["blocking", "json"] }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.8.4" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }

--- a/evm_interpreter/src/interpreter.rs
+++ b/evm_interpreter/src/interpreter.rs
@@ -16,7 +16,7 @@ use zk_ee::system::{
 use zk_ee::system::{CallResult, IOSubsystemExt, SystemFunctions};
 use zk_ee::system_log;
 use zk_ee::types_config::SystemIOTypesConfig;
-use zk_ee::utils::cheap_clone::CheapCloneRiscV;
+use zk_ee::utils::cheap_clone::CheapCloneProvingEnv;
 
 impl<'ee, S: EthereumLikeTypes> Interpreter<'ee, S> {
     /// Keeps executing instructions (steps) from the system, until it hits a yield point -

--- a/proof_running_system/Cargo.toml
+++ b/proof_running_system/Cargo.toml
@@ -34,3 +34,32 @@ default = ["testing"]
 proving = ["crypto/proving", "basic_system/proving", "delegation", "zk_ee/proving_env", "basic_bootloader/proving_env"]
 delegation = ["u256/delegation", "zk_ee/delegation", "evm_interpreter/delegation", "basic_system/delegation", "system_hooks/delegation", "basic_bootloader/delegation"]
 fri_precompile = ["basic_bootloader/fri_precompile", "system_hooks/fri_precompile"]
+scalloc = []
+cycle_marker = ["zk_ee/cycle_marker", "evm_interpreter/cycle_marker", "basic_system/cycle_marker", "basic_bootloader/cycle_marker"]
+benchmarking = ["cycle_marker"]
+global-alloc = ["zk_ee/global-alloc"]
+error_origins = ["zk_ee/error_origins"]
+multiblock-batch = []
+state-diffs-pi = []
+
+# A feature for every specific use case
+
+# Selects the BPO2 blob-count schedule; default is base-Osaka.
+fusaka-bpo-2 = ["basic_bootloader/fusaka-bpo-2"]
+
+# Features used for production, by both the singleblock_batch and multiblock_batch binaries.
+production = ["fusaka-bpo-2"]
+
+# Features used for tests.
+# Note: cycle_marker is intentionally excluded — binaries with marker CSRs
+# cannot be proved (the transpiler replayer rejects them by design).
+for_tests = ["production", "state-diffs-pi", "basic_bootloader/eip-4844"]
+
+# Features used for eth_runner.
+eth_runner = ["basic_bootloader/disable_system_contracts", "zk_ee/prevrandao", "state-diffs-pi", "basic_bootloader/burn_base_fee", "basic_bootloader/eip-4844"]
+
+# Additional features used for eth_stf in eth_runner
+eth_stf = []
+
+# Features used for evm_tester
+evm_tester = ["basic_bootloader/disable_system_contracts", "zk_ee/prevrandao", "state-diffs-pi", "basic_bootloader/burn_base_fee", "basic_bootloader/eip-4844"]

--- a/proof_running_system/Cargo.toml
+++ b/proof_running_system/Cargo.toml
@@ -31,35 +31,6 @@ fastrand = "2.0.2"
 [features]
 testing = ["zk_ee/testing", "evm_interpreter/testing", "basic_system/testing", "basic_bootloader/testing"]
 default = ["testing"]
-proving = ["crypto/proving", "basic_system/proving", "delegation"]
+proving = ["crypto/proving", "basic_system/proving", "delegation", "zk_ee/proving_env", "basic_bootloader/proving_env"]
 delegation = ["u256/delegation", "zk_ee/delegation", "evm_interpreter/delegation", "basic_system/delegation", "system_hooks/delegation", "basic_bootloader/delegation"]
 fri_precompile = ["basic_bootloader/fri_precompile", "system_hooks/fri_precompile"]
-scalloc = []
-cycle_marker = ["zk_ee/cycle_marker", "evm_interpreter/cycle_marker", "basic_system/cycle_marker", "basic_bootloader/cycle_marker"]
-benchmarking = ["cycle_marker"]
-global-alloc = ["zk_ee/global-alloc"]
-error_origins = ["zk_ee/error_origins"]
-multiblock-batch = []
-state-diffs-pi = []
-
-# A feature for every specific use case
-
-# Selects the BPO2 blob-count schedule; default is base-Osaka.
-fusaka-bpo-2 = ["basic_bootloader/fusaka-bpo-2"]
-
-# Features used for production, by both the singleblock_batch and multiblock_batch binaries.
-production = ["fusaka-bpo-2"]
-
-# Features used for tests.
-# Note: cycle_marker is intentionally excluded — binaries with marker CSRs
-# cannot be proved (the transpiler replayer rejects them by design).
-for_tests = ["production", "state-diffs-pi", "basic_bootloader/eip-4844"]
-
-# Features used for eth_runner.
-eth_runner = ["basic_bootloader/disable_system_contracts", "zk_ee/prevrandao", "state-diffs-pi", "basic_bootloader/burn_base_fee", "basic_bootloader/eip-4844"]
-
-# Additional features used for eth_stf in eth_runner
-eth_stf = []
-
-# Features used for evm_tester
-evm_tester = ["basic_bootloader/disable_system_contracts", "zk_ee/prevrandao", "state-diffs-pi", "basic_bootloader/burn_base_fee", "basic_bootloader/eip-4844"]

--- a/system_hooks/src/call_hooks/precompiles.rs
+++ b/system_hooks/src/call_hooks/precompiles.rs
@@ -27,7 +27,7 @@ use zk_ee::{
         },
         CallModifier, Resources, System,
     },
-    utils::cheap_clone::CheapCloneRiscV as _,
+    utils::cheap_clone::CheapCloneProvingEnv as _,
 };
 
 ///

--- a/zk_ee/Cargo.toml
+++ b/zk_ee/Cargo.toml
@@ -30,6 +30,10 @@ testing = ["serde"]
 default = ["serde", "error_origins", "detailed_errors"]
 cycle_marker = ["cycle_marker/log_to_file"]
 global-alloc = []
+# Indicates the crate is being built for the proving environment.
+# Use this instead of cfg(target_arch = "riscv32") when the intent is proving
+# vs forward mode, not actual RISC-V hardware detection.
+proving_env = []
 # Adds location (file, line number) where an error is raised
 error_origins = []
 detailed_errors = []

--- a/zk_ee/src/system/errors/context/contextualized.rs
+++ b/zk_ee/src/system/errors/context/contextualized.rs
@@ -7,16 +7,16 @@ pub trait Contextualized<E>: Sized {
     }
 
     #[inline(always)]
-    #[cfg_attr(target_arch = "riscv32", allow(unused))]
+    #[cfg_attr(feature = "proving_env", allow(unused))]
     fn with_context<F>(self, f: F) -> E
     where
         F: FnOnce() -> ErrorContext,
     {
-        #[cfg(target_arch = "riscv32")]
+        #[cfg(feature = "proving_env")]
         {
             self.with_context_inner(|| ErrorContext::default())
         }
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             self.with_context_inner(f)
         }

--- a/zk_ee/src/system/errors/context/empty.rs
+++ b/zk_ee/src/system/errors/context/empty.rs
@@ -1,4 +1,4 @@
-#![cfg(target_arch = "riscv32")]
+#![cfg(feature = "proving_env")]
 
 use super::{
     element::{NamedContextElement, ValueVisibility},
@@ -48,9 +48,9 @@ impl IErrorContext for ErrorContext {
     }
 }
 
-/// On RISC-V, this macro ignores all the context elements, guaranteeing that
-/// the context will not be constructed and all the expressions used to
-/// construct it will be ignored.
+/// In the proving environment, this macro ignores all the context elements,
+/// guaranteeing that the context will not be constructed and all the
+/// expressions used to construct it will be ignored.
 #[macro_export]
 macro_rules! error_ctx {
     { $($tt:tt)* } => {{

--- a/zk_ee/src/system/errors/context/mod.rs
+++ b/zk_ee/src/system/errors/context/mod.rs
@@ -17,7 +17,7 @@ use element::NamedContextElement;
 /// easier debugging.
 /// On different targets, this information is then preserved or ignored:
 ///
-/// - On RISC-V proving system, the context is ignored.
+/// - In the proving environment, the context is ignored.
 /// - In production, only the basic context will be emitted.
 /// - For debug purposes (e.g. in `anvil-zksync`), the full context should be emitted.
 ///
@@ -36,7 +36,7 @@ pub trait IErrorContext {
     fn into_vec(self) -> Option<Vec<NamedContextElement>>;
 }
 
-#[cfg(not(target_arch = "riscv32"))]
+#[cfg(not(feature = "proving_env"))]
 pub type ErrorContext = nonempty::ErrorContext;
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "proving_env")]
 pub type ErrorContext = empty::ErrorContext;

--- a/zk_ee/src/system/errors/context/nonempty.rs
+++ b/zk_ee/src/system/errors/context/nonempty.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_arch = "riscv32"))]
+#![cfg(not(feature = "proving_env"))]
 
 use core::fmt::Display;
 
@@ -42,7 +42,7 @@ impl IErrorContext for ErrorContext {
             let value = value.to_string();
             self.values.push(NamedContextElement { name, value })
         };
-        if cfg!(not(target_arch = "riscv32")) {
+        if cfg!(not(feature = "proving_env")) {
             match visibility {
                 ValueVisibility::AnyForwardRun => perform_push_value(),
                 ValueVisibility::DetailedOnly if cfg!(feature = "detailed_errors") => {
@@ -115,7 +115,7 @@ impl IErrorContext for ErrorContext {
 ///
 ///    let _ctx4 = error_ctx! {
 ///        #[detailed] "debug" => "info",  // Only evaluated if `detailed_errors` feature is enabled
-///        "public" => "data"              // Always evaluated (but not on RISC-V)
+///        "public" => "data"              // Always evaluated (but not in proving mode)
 ///    };
 ///
 ///    let _ctx5 = error_ctx! {

--- a/zk_ee/src/system/errors/context/tests.rs
+++ b/zk_ee/src/system/errors/context/tests.rs
@@ -497,7 +497,7 @@ mod tests {
             },
         };
 
-        // Normal expressions should always be evaluated (on non-RISC-V)
+        // Normal expressions should always be evaluated (in forward mode / non-proving environment)
         #[cfg(not(feature = "proving_env"))]
         assert_eq!(NORMAL_CALL_COUNT.load(Ordering::Relaxed), 1);
 

--- a/zk_ee/src/system/errors/context/tests.rs
+++ b/zk_ee/src/system/errors/context/tests.rs
@@ -15,7 +15,7 @@ mod tests {
             "operation" => "test_operation"
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 1);
@@ -32,7 +32,7 @@ mod tests {
             "code" => 42
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 3);
@@ -58,7 +58,7 @@ mod tests {
             code
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 2);
@@ -78,7 +78,7 @@ mod tests {
             "public_info" => "safe_data"
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
 
@@ -112,7 +112,7 @@ mod tests {
             public_var
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
 
@@ -146,7 +146,7 @@ mod tests {
             #[detailed] var
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
 
@@ -194,7 +194,7 @@ mod tests {
             "formatted" => debug_format(test_val)
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 1);
@@ -210,7 +210,7 @@ mod tests {
             "test" => "value",
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 1);
@@ -225,7 +225,7 @@ mod tests {
             "test" => "value",,,
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 1);
@@ -241,14 +241,14 @@ mod tests {
             "key2" => "value2"
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             assert_eq!(ctx.get("key1"), Some(&"value1".to_string()));
             assert_eq!(ctx.get("key2"), Some(&"value2".to_string()));
             assert_eq!(ctx.get("nonexistent"), None);
         }
 
-        #[cfg(target_arch = "riscv32")]
+        #[cfg(feature = "proving_env")]
         {
             // Empty context always returns None
             assert_eq!(ctx.get("key1"), None);
@@ -265,13 +265,13 @@ mod tests {
 
         let display_str = format!("{}", ctx);
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             assert!(display_str.contains("operation => test"));
             assert!(display_str.contains("status => failed"));
         }
 
-        #[cfg(target_arch = "riscv32")]
+        #[cfg(feature = "proving_env")]
         {
             // Empty context displays as empty
             assert_eq!(display_str, "");
@@ -293,7 +293,7 @@ mod tests {
             "timestamp" => debug_format(std::time::SystemTime::now()),
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
 
@@ -345,7 +345,7 @@ mod tests {
             enabled
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 5);
@@ -375,7 +375,7 @@ mod tests {
             "key3" => "value3"
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             // Test get method
             assert_eq!(ctx.get("key1"), Some(&"value1".to_string()));
@@ -393,7 +393,7 @@ mod tests {
             assert_eq!(vec1, vec2);
         }
 
-        #[cfg(target_arch = "riscv32")]
+        #[cfg(feature = "proving_env")]
         {
             assert_eq!(ctx.get("key1"), None);
             assert_eq!(ctx.to_vec(), None);
@@ -432,7 +432,7 @@ mod tests {
             "simple" => "plain_text"
         };
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
             assert_eq!(elements.len(), 2);
@@ -454,7 +454,7 @@ mod tests {
         let ctx = error_ctx! {};
 
         // Test that empty context behaves correctly
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let vec = ctx.to_vec().unwrap();
             assert_eq!(vec.len(), 0);
@@ -465,7 +465,7 @@ mod tests {
             assert_eq!(display_str, "");
         }
 
-        #[cfg(target_arch = "riscv32")]
+        #[cfg(feature = "proving_env")]
         {
             assert_eq!(ctx.to_vec(), None);
             assert_eq!(ctx.get("any_key"), None);
@@ -498,17 +498,17 @@ mod tests {
         };
 
         // Normal expressions should always be evaluated (on non-RISC-V)
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         assert_eq!(NORMAL_CALL_COUNT.load(Ordering::Relaxed), 1);
 
-        #[cfg(target_arch = "riscv32")]
-        assert_eq!(NORMAL_CALL_COUNT.load(Ordering::Relaxed), 0); // Nothing evaluated on RISC-V
+        #[cfg(feature = "proving_env")]
+        assert_eq!(NORMAL_CALL_COUNT.load(Ordering::Relaxed), 0); // Nothing evaluated in proving env
 
         // Detailed expressions should only be evaluated when detailed_errors is enabled
-        #[cfg(all(not(target_arch = "riscv32"), feature = "detailed_errors"))]
+        #[cfg(all(not(feature = "proving_env"), feature = "detailed_errors"))]
         assert_eq!(DETAILED_CALL_COUNT.load(Ordering::Relaxed), 1);
 
-        #[cfg(not(all(not(target_arch = "riscv32"), feature = "detailed_errors")))]
+        #[cfg(not(all(not(feature = "proving_env"), feature = "detailed_errors")))]
         assert_eq!(DETAILED_CALL_COUNT.load(Ordering::Relaxed), 0);
     }
 
@@ -533,13 +533,13 @@ mod tests {
         };
 
         // Verify that expensive computation is only called when detailed_errors is enabled
-        #[cfg(all(not(target_arch = "riscv32"), feature = "detailed_errors"))]
+        #[cfg(all(not(feature = "proving_env"), feature = "detailed_errors"))]
         assert_eq!(EXPENSIVE_CALL_COUNT.load(Ordering::Relaxed), 1);
 
-        #[cfg(not(all(not(target_arch = "riscv32"), feature = "detailed_errors")))]
+        #[cfg(not(all(not(feature = "proving_env"), feature = "detailed_errors")))]
         assert_eq!(EXPENSIVE_CALL_COUNT.load(Ordering::Relaxed), 0);
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = _ctx.to_vec().unwrap();
 
@@ -582,13 +582,13 @@ mod tests {
         );
 
         // Verify the closure was called appropriately based on feature flags
-        #[cfg(all(not(target_arch = "riscv32"), feature = "detailed_errors"))]
+        #[cfg(all(not(feature = "proving_env"), feature = "detailed_errors"))]
         assert_eq!(CLOSURE_CALL_COUNT.load(Ordering::Relaxed), 1);
 
-        #[cfg(not(all(not(target_arch = "riscv32"), feature = "detailed_errors")))]
+        #[cfg(not(all(not(feature = "proving_env"), feature = "detailed_errors")))]
         assert_eq!(CLOSURE_CALL_COUNT.load(Ordering::Relaxed), 0);
 
-        #[cfg(not(target_arch = "riscv32"))]
+        #[cfg(not(feature = "proving_env"))]
         {
             let elements = ctx.to_vec().unwrap();
 

--- a/zk_ee/src/system/mod.rs
+++ b/zk_ee/src/system/mod.rs
@@ -446,8 +446,8 @@ define_subsystem!(NextTx,
 );
 
 /// Logging macros for the system.
-/// TODO: debug implementation for ruint types uses global alloc, which panics in ZKsync OS
-#[cfg(any(not(target_arch = "riscv32"), feature = "global-alloc"))]
+/// TODO: debug implementation for ruint types uses global alloc, which panics in the proving environment
+#[cfg(any(not(feature = "proving_env"), feature = "global-alloc"))]
 #[macro_export]
 macro_rules! logger_log {
     ($logger:expr, $($arg:tt)*) => {{
@@ -455,8 +455,8 @@ macro_rules! logger_log {
     }};
 }
 
-// No-op only if riscv32 AND no allocator feature
-#[cfg(all(target_arch = "riscv32", not(feature = "global-alloc")))]
+// No-op in proving environment without global allocator
+#[cfg(all(feature = "proving_env", not(feature = "global-alloc")))]
 #[macro_export]
 macro_rules! logger_log {
     ($logger:expr, $($arg:tt)*) => {{

--- a/zk_ee/src/utils/cheap_clone.rs
+++ b/zk_ee/src/utils/cheap_clone.rs
@@ -1,13 +1,13 @@
-/// Using this trait allows using Copy instead of Clone on RISCV target. It is
-/// useful for types like errors which contain less fields when compiled for
-/// RISCV
+/// Using this trait allows using Copy instead of Clone in the proving
+/// environment. It is useful for types like errors which contain less fields
+/// when compiled for proving.
 pub trait CheapCloneRiscV {
-    /// Clone for standard target, Copy if on RISC-V.
+    /// Clone for forward mode, Copy in proving environment.
     /// Used for performance on small types
     fn clone_or_copy(&self) -> Self;
 }
 
-#[cfg(target_arch = "riscv32")]
+#[cfg(feature = "proving_env")]
 impl<T> CheapCloneRiscV for T
 where
     T: Copy,
@@ -18,7 +18,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "riscv32"))]
+#[cfg(not(feature = "proving_env"))]
 impl<T> CheapCloneRiscV for T
 where
     T: Clone,

--- a/zk_ee/src/utils/cheap_clone.rs
+++ b/zk_ee/src/utils/cheap_clone.rs
@@ -1,14 +1,14 @@
 /// Using this trait allows using Copy instead of Clone in the proving
 /// environment. It is useful for types like errors which contain less fields
 /// when compiled for proving.
-pub trait CheapCloneRiscV {
-    /// Clone for forward mode, Copy in proving environment.
-    /// Used for performance on small types
+pub trait CheapCloneProvingEnv {
+    /// Clone in forward mode, Copy in proving environment.
+    /// Used for performance on small types.
     fn clone_or_copy(&self) -> Self;
 }
 
 #[cfg(feature = "proving_env")]
-impl<T> CheapCloneRiscV for T
+impl<T> CheapCloneProvingEnv for T
 where
     T: Copy,
 {
@@ -19,7 +19,7 @@ where
 }
 
 #[cfg(not(feature = "proving_env"))]
-impl<T> CheapCloneRiscV for T
+impl<T> CheapCloneProvingEnv for T
 where
     T: Clone,
 {


### PR DESCRIPTION
## What

Introduces a `proving_env` feature flag to replace `cfg(target_arch = "riscv32")` in places where the intent is "proving mode vs forward mode", not actual RISC-V hardware detection.

Changes:
- Adds `proving_env` feature to `zk_ee`, propagated through `basic_system/proving`, `basic_bootloader/proving_env`, and `proof_running_system/proving`
- Replaces `cfg(target_arch = "riscv32")` → `cfg(feature = "proving_env")` in:
  - Error context system (empty vs nonempty ErrorContext selection)
  - `CheapCloneRiscV` trait (Copy vs Clone dispatch)
  - `logger_log!` macro (active vs no-op selection)
  - `Contextualized` trait (context evaluation vs skip)
  - Bootloader transaction flow logging guards
- Updates associated doc comments and test cfg guards
- Leaves `target_arch` unchanged where it's genuinely about hardware: cycle_marker CSR assembly, delegated_u256 RISC-V instructions, no_std gating
- Leaves `target_pointer_width` unchanged for serialization/arithmetic (actual hardware concern)

## Why

The codebase uses `cfg(target_arch = "riscv32")` as a proxy for "we're in the proving environment" in many places where the actual intent is about proving vs forward mode behavior, not RISC-V hardware. This creates a semantic mismatch. Using a dedicated feature flag:

1. Makes the intent explicit at each call site
2. Enables testing proving-mode code paths on x86 by enabling the feature
3. Separates the "proving environment" concern from the "RISC-V hardware" concern
4. Follows the pattern already established by `crypto/proving` and `basic_system/proving`

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

---
Rebased from #595 onto `draft-0.4.0` (original targeted `dev`, was conflicting). Resolved feature-table conflicts in basic_bootloader/basic_system/proof_running_system Cargo.toml by keeping draft-0.4.0 features and threading in `proving_env`. Builds (default + `proving_env`) and clippy clean.