### PR TITLE
feat(basic_system): optimize ecrecover via Affine::to_xy_bytes()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,8 +76,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-codec"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -85,8 +85,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-core"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -95,8 +95,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-crypto"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -125,8 +125,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-host"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
 dependencies = [
  "airbender-codec",
  "airbender-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 [[package]]
 name = "airbender-codec"
 version = "0.2.3"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -86,7 +86,7 @@ dependencies = [
 [[package]]
 name = "airbender-core"
 version = "0.2.3"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "airbender-crypto"
 version = "0.2.3"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "airbender-host"
 version = "0.2.3"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b#bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "airbender-codec",
  "airbender-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,12 @@ full_statement_verifier = { git = "https://github.com/matter-labs/zksync-airbend
 cli = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
 gpu_prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "73d69b5" }
 
-airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6" }
-airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", default-features = false }
-airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+# TEMP: pinned to the vv/secp256k1-to-xy-bytes branch (airbender-platform#79)
+# which adds Affine::to_xy_bytes(). Revert to a released rev once #79 merges.
+airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b" }
+airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b", default-features = false }
+airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b" }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b", package = "airbender-crypto", default-features = false }
 
 seq-macro = { version = "0.3.6", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,10 +122,10 @@ gpu_prover = { git = "https://github.com/matter-labs/zksync-airbender", rev = "7
 
 # TEMP: pinned to the vv/secp256k1-to-xy-bytes branch (airbender-platform#79)
 # which adds Affine::to_xy_bytes(). Revert to a released rev once #79 merges.
-airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b" }
-airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b", default-features = false }
-airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "bd6c4a2992a0422b8f56a1dc74733e96a4a02b2b", package = "airbender-crypto", default-features = false }
+airbender-guest = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a" }
+airbender-host = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", default-features = false }
+airbender-sdk = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a" }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 
 seq-macro = { version = "0.3.6", default-features = false }
 

--- a/basic_system/src/system_functions/ecrecover.rs
+++ b/basic_system/src/system_functions/ecrecover.rs
@@ -93,13 +93,14 @@ fn ecrecover_as_system_function_inner<
 
         pk_bytes
     };
-    let bytes_ref = recovered_pubkey_bytes.as_ref();
 
     use crypto::sha3::Keccak256;
     use crypto::MiniDigest;
-    let address_hash = Keccak256::digest(&bytes_ref[1..]);
+    let address_hash = Keccak256::digest(&recovered_pubkey_bytes);
 
-    dst.try_extend(core::iter::repeat_n(0, 12).chain(address_hash.into_iter().skip(12)))
+    let mut result = [0u8; 32];
+    result[12..32].copy_from_slice(&address_hash[12..]);
+    dst.try_extend(result.iter().copied())
         .map_err(|_| out_of_return_memory!())?;
 
     Ok(())
@@ -111,7 +112,7 @@ pub fn ecrecover_inner<O: IOOracle>(
     s: &[u8; 32],
     rec_id: u8,
     oracle: Option<&mut O>,
-) -> Result<crypto::k256::EncodedPoint, ()> {
+) -> Result<[u8; 64], ()> {
     use crypto::k256::{
         ecdsa::{hazmat::bits2field, RecoveryId, Signature},
         elliptic_curve::ops::Reduce,
@@ -139,10 +140,9 @@ pub fn ecrecover_inner<O: IOOracle>(
         return Err(());
     };
 
-    // represent as bytes, and we do not need compression
-    let encoded = pk.to_encoded_point(false);
-
-    Ok(encoded)
+    // Extract x||y coordinate bytes directly, bypassing EncodedPoint construction.
+    // The infinity check is already done inside `recover`/`recover_with_hooks`.
+    Ok(pk.to_xy_bytes())
 }
 
 #[cfg(test)]

--- a/circuit_test_program/Cargo.toml
+++ b/circuit_test_program/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["blockchain", "zksync", "zk", "risc-v"]
 categories = ["cryptography"]
 
 [dependencies]
-airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["proving"] }
+airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a" }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["proving"] }

--- a/tests/fuzzer/fuzz/Cargo.toml
+++ b/tests/fuzzer/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ alloy = { version = "2", features = ["full", "eip712"]}
 alloy-rlp = "0.3.13"
 fuzzer = { path = "../../fuzzer"}
 rig = { path = "../../rig" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 fuzz_precompiles_forward = { path = "./wrappers/fuzz_precompiles_forward" }
 fuzz_precompiles_proving = { path = "./wrappers/fuzz_precompiles_proving" }
 basic_system_proving = { path = "./wrappers/basic_system_proving" }

--- a/tests/fuzzer/fuzz/wrappers/basic_bootloader_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_bootloader_forward/Cargo.toml
@@ -15,7 +15,7 @@ basic_system = { package = "basic_system_forward", path = "../basic_system_forwa
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 arrayvec = { version = "0.7.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 hex = {version = "*", optional = true}
 strum_macros = "0.27.1"
 paste = "1.0.15"

--- a/tests/fuzzer/fuzz/wrappers/basic_system_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_system_forward/Cargo.toml
@@ -18,7 +18,7 @@ zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward", default-features
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 evm_interpreter = { package = "evm_interpreter_forward", path = "../evm_interpreter_forward"  }
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context"] }
 arrayvec = { version = "0.7.4", default-features = false }
 either = { version = "*", default-features = false }
 storage_models = { package = "storage_models_forward", path = "../storage_models_forward", default-features = false }
@@ -50,7 +50,7 @@ state-diffs-pi = []
 [dev-dependencies]
 hex = {version = "0.4.3"}
 proptest = "1.6.0"
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "testing"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "testing"] }
 num-bigint = "*"
 num-traits = "*"
 arbitrary = { version = "1", features = ["derive"] }

--- a/tests/fuzzer/fuzz/wrappers/basic_system_proving/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/basic_system_proving/Cargo.toml
@@ -18,7 +18,7 @@ zk_ee = { package = "zk_ee_proving", path = "../zk_ee_proving", default-features
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 evm_interpreter = { package = "evm_interpreter_proving", path = "../evm_interpreter_proving"  }
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "proving"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "proving"] }
 arrayvec = { version = "0.7.4", default-features = false }
 either = { version = "*", default-features = false }
 storage_models = { package = "storage_models_proving", path = "../storage_models_proving", default-features = false }
@@ -50,7 +50,7 @@ state-diffs-pi = []
 [dev-dependencies]
 hex = {version = "0.4.3"}
 proptest = "1.6.0"
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "proving", "testing"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["secp256k1-static-context", "proving", "testing"] }
 num-bigint = "*"
 num-traits = "*"
 arbitrary = { version = "1", features = ["derive"] }

--- a/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/callable_oracles_forward/Cargo.toml
@@ -9,7 +9,7 @@ path = "../../../../../callable_oracles/src/lib.rs"
 [dependencies]
 zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 oracle_provider = { package = "oracle_provider_forward", path = "../oracle_provider_forward" }
 basic_system = { package = "basic_system_forward", path = "../basic_system_forward" }
 basic_bootloader = { package = "basic_bootloader_forward", path = "../basic_bootloader_forward", default-features = false }

--- a/tests/fuzzer/fuzz/wrappers/evm_interpreter_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/evm_interpreter_forward/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../../../../evm_interpreter/src/lib.rs"
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 zk_ee = { package = "zk_ee_forward", path = "../zk_ee_forward" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false }
 either = { version = "*", default-features = false }
 

--- a/tests/fuzzer/fuzz/wrappers/evm_interpreter_proving/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/evm_interpreter_proving/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../../../../evm_interpreter/src/lib.rs"
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 zk_ee = { package = "zk_ee_proving", path = "../zk_ee_proving" }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["proving"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["proving"] }
 arrayvec = { version = "0.7.4", default-features = false }
 either = { version = "*", default-features = false }
 

--- a/tests/fuzzer/fuzz/wrappers/zk_ee_forward/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/zk_ee_forward/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../../../../zk_ee/src/lib.rs"
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 cfg-if = "*"
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false }
 bitflags = { version = "2.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/tests/fuzzer/fuzz/wrappers/zk_ee_proving/Cargo.toml
+++ b/tests/fuzzer/fuzz/wrappers/zk_ee_proving/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../../../../zk_ee/src/lib.rs"
 ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 u256 = { path = "../../../../../supporting_crates/u256", default-features = false }
 cfg-if = "*"
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, features = ["proving"] }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, features = ["proving"] }
 arrayvec = { version = "0.7.4", default-features = false }
 bitflags = { version = "2.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/zksync_os/Cargo.lock
+++ b/zksync_os/Cargo.lock
@@ -16,8 +16,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-codec"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -25,13 +25,13 @@ dependencies = [
 
 [[package]]
 name = "airbender-core"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 
 [[package]]
 name = "airbender-crypto"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -60,8 +60,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-guest"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "airbender-codec",
  "airbender-core",
@@ -71,18 +71,18 @@ dependencies = [
 
 [[package]]
 name = "airbender-macros"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "airbender-rt"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "getrandom 0.2.17",
  "riscv_common",
@@ -90,8 +90,8 @@ dependencies = [
 
 [[package]]
 name = "airbender-sdk"
-version = "0.2.2"
-source = "git+https://github.com/matter-labs/airbender-platform?rev=80c0541f6#80c0541f62414dc7f21c200218686c4bef9458d4"
+version = "0.2.3"
+source = "git+https://github.com/matter-labs/airbender-platform?rev=7b7bd958b3abae3ba8c77e546098008b8c287b1a#7b7bd958b3abae3ba8c77e546098008b8c287b1a"
 dependencies = [
  "airbender-codec",
  "airbender-guest",
@@ -244,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -474,15 +474,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -541,9 +541,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc-traits"
@@ -775,7 +775,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -819,7 +819,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1039,7 +1039,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "modexp"
@@ -1259,7 +1259,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -1706,7 +1706,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -1784,7 +1784,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2013,9 +2013,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2055,42 +2055,42 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/zksync_os/Cargo.toml
+++ b/zksync_os/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", default-features = false, features = ["allocator-custom"] }
+airbender = { package = "airbender-sdk", git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", default-features = false, features = ["allocator-custom"] }
 proof_running_system = { path = "../proof_running_system", default-features = false }
-crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "80c0541f6", package = "airbender-crypto", default-features = false, optional = true }
+crypto = { git = "https://github.com/matter-labs/airbender-platform", rev = "7b7bd958b3abae3ba8c77e546098008b8c287b1a", package = "airbender-crypto", default-features = false, optional = true }
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
## What

`ecrecover_inner` now returns the raw `x || y` coordinate bytes (`[u8; 64]`) via `crypto::secp256k1::Affine::to_xy_bytes()` instead of constructing a 65-byte `EncodedPoint`. The address-hash output is built with direct array writes instead of an iterator chain.

## Why

The ecrecover path is one of the largest non-interpreter proving hotspots. `to_encoded_point` runs a `ConditionallySelectable` infinity check and prepends a `0x04` prefix that the caller immediately discards — both pure overhead, since point-at-infinity is already checked inside `crypto::secp256k1::recover` / `recover_with_hooks`.

This is the **re-port** of the now-closed #584 (whose branch was on a stale base) onto current `draft-0.4.0`. The crypto-side `to_xy_bytes()` was moved to airbender-crypto: **matter-labs/airbender-platform#79**.

## Temporary pin

The four `airbender-platform` deps in `Cargo.toml` are temporarily pinned to the #79 branch commit (`bd6c4a2`) so this builds and tests today. **Before merge**, this must be repointed to a released `airbender-platform` rev once #79 lands.

- [ ] matter-labs/airbender-platform#79 merged
- [ ] `airbender-platform` rev repointed off the branch commit

## Verification

`cargo test -p basic_system --lib ecrecover` passes (5/5), including `test_geth_ecrecover` (known address derivation) and `test_point_of_infinity_in_result`. Behavior is unchanged.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated. (covered by existing ecrecover tests; behavior unchanged)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)