### PR TITLE
fix(audit): address validated report findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/api/src/helpers.rs
+++ b/api/src/helpers.rs
@@ -14,6 +14,7 @@ use basic_bootloader::bootloader::constants::BOOTLOADER_FORMAL_ADDRESS;
 use basic_bootloader::bootloader::transaction::rlp_encoded::transaction_types::service_tx::SERVICE_TX_TYPE;
 use basic_bootloader::bootloader::transaction_flow::gas_helpers::{
     calculate_l2_tx_intrinsic_computational_native_resources, calculate_l2_tx_intrinsic_pubdata,
+    L2TxIntrinsicNativeInput,
 };
 use basic_system::system_implementation::flat_storage_model::bytecode_padding_len;
 use basic_system::system_implementation::flat_storage_model::AccountProperties;
@@ -397,6 +398,7 @@ pub fn validate_l2_tx_intrinsic_native_resources(
     access_list_accounts: u64,
     access_list_storage_keys: u64,
     authorization_list_num: u64,
+    blob_versioned_hashes_num: u64,
     statement_versioned_hashes_num: u64,
     max_fee_per_gas: U256,
     max_priority_fee_per_gas: U256,
@@ -409,8 +411,9 @@ pub fn validate_l2_tx_intrinsic_native_resources(
         return Err(());
     }
 
-    // following bootloader: native is unlimited on 0 base fee chains
-    if base_fee == 0 {
+    // Following the bootloader, native is unlimited either when base fee is 0
+    // or when the chain config sets native_price to 0.
+    if base_fee == 0 || native_price.is_zero() {
         return Ok(());
     }
 
@@ -421,9 +424,6 @@ pub fn validate_l2_tx_intrinsic_native_resources(
     };
 
     // native_per_gas = ceil(gas_price / native_price)
-    if native_price.is_zero() {
-        return Err(());
-    }
     let native_per_gas = u256_try_to_u64(&gas_price.div_ceil(native_price)).ok_or(())?;
 
     // native_per_pubdata = pubdata_price / native_price
@@ -443,19 +443,49 @@ pub fn validate_l2_tx_intrinsic_native_resources(
     let native_limit = native_limit.min(MAX_NATIVE_COMPUTATIONAL);
 
     // Intrinsic computational native
-    let intrinsic_computational_native = calculate_l2_tx_intrinsic_computational_native_resources(
-        calldata_length,
-        access_list_accounts,
-        access_list_storage_keys,
-        authorization_list_num,
-        statement_versioned_hashes_num,
-        false,
-        false, // not free-native (base_fee == 0 returned early above)
-    );
+    let intrinsic_computational_native =
+        calculate_l2_tx_intrinsic_computational_native_resources(&L2TxIntrinsicNativeInput {
+            calldata_byte_length: calldata_length,
+            access_list_accounts,
+            access_list_storages: access_list_storage_keys,
+            authorization_list_num,
+            blob_versioned_hashes_num,
+            statement_versioned_hashes_num,
+            is_service: false,
+            // not free-native (base_fee == 0 returned early above)
+            free_native: false,
+        });
 
     native_limit
         .checked_sub(intrinsic_computational_native)
         .ok_or(())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_l2_tx_intrinsic_native_resources;
+    use ruint::aliases::U256;
+
+    #[test]
+    fn intrinsic_native_validation_allows_zero_native_price() {
+        assert_eq!(
+            validate_l2_tx_intrinsic_native_resources(
+                U256::from(1000u64),
+                U256::ZERO,
+                U256::from(1000u64),
+                21_000,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                U256::from(1000u64),
+                U256::from(0u64),
+            ),
+            Ok(())
+        );
+    }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/receipt.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/receipt.rs
@@ -16,7 +16,7 @@ pub(crate) fn compute_receipt_hash<'events, I>(
     status: &bool,
     cumulative_gas_used: &u64,
     events: I,
-) -> Bytes32
+) -> (Bytes32, usize)
 where
     I: Iterator<
             Item = GenericEventContentRef<'events, { MAX_EVENT_TOPICS }, EthereumIOTypesConfig>,
@@ -37,9 +37,10 @@ where
         bloom.as_bytes(),
         events,
     );
+    let encoded_len = receipt_encoder.required_buffer_len();
     let mut receipt_hasher = Blake2s256::new();
     receipt_encoder.encode_into(&mut receipt_hasher);
-    Bytes32::from_array(receipt_hasher.finalize())
+    (Bytes32::from_array(receipt_hasher.finalize()), encoded_len)
 }
 
 #[cfg(test)]
@@ -97,10 +98,28 @@ mod tests {
         let status = true;
         let gas: u64 = 0x5208;
 
-        let got = compute_receipt_hash(tx_type, &status, &gas, core::iter::once(event));
+        let (got, encoded_len) = compute_receipt_hash(tx_type, &status, &gas, core::iter::once(event));
+        let mut reference_rlp = Vec::new();
+        let zero_bloom = Bloom::from_slice(&[0u8; 256]);
+        let zero_bloom_reference = ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(status),
+                cumulative_gas_used: gas,
+                logs: alloc::vec![Log::new_unchecked(
+                    Address::from([0xaau8; 20]),
+                    alloc::vec![B256::from([0x11u8; 32]), B256::from([0x22u8; 32])],
+                    Bytes::copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]),
+                )],
+            },
+            logs_bloom: zero_bloom,
+        };
+        if tx_type != 0 {
+            reference_rlp.push(tx_type);
+        }
+        zero_bloom_reference.encode(&mut reference_rlp);
+        assert_eq!(encoded_len, reference_rlp.len());
 
         // The ZK path must commit to a zero bloom...
-        let zero_bloom = Bloom::from_slice(&[0u8; 256]);
         assert_eq!(
             got.as_u8_array_ref(),
             reference_receipt_hash(tx_type, status, gas, zero_bloom).as_u8_array_ref(),

--- a/basic_bootloader/src/bootloader/block_flow/zk/receipt.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/receipt.rs
@@ -98,7 +98,8 @@ mod tests {
         let status = true;
         let gas: u64 = 0x5208;
 
-        let (got, encoded_len) = compute_receipt_hash(tx_type, &status, &gas, core::iter::once(event));
+        let (got, encoded_len) =
+            compute_receipt_hash(tx_type, &status, &gas, core::iter::once(event));
         let mut reference_rlp = Vec::new();
         let zero_bloom = Bloom::from_slice(&[0u8; 256]);
         let zero_bloom_reference = ReceiptWithBloom {

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -158,9 +158,9 @@ where
                             let computational_native_used = tx_processing_result
                                 .computational_native_used
                                 + blake2s_native_cost(receipt_rlp_len);
-                            let next_block_computational_native_used =
-                                block_data.block_computational_native_used
-                                    + computational_native_used;
+                            let next_block_computational_native_used = block_data
+                                .block_computational_native_used
+                                + computational_native_used;
 
                             // Check if the transaction made the block reach any of the limits
                             // for gas, native, pubdata or logs.

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::bootloader::{
     block_flow::tx_loop::TxLoopOp, transaction_flow::zk::ZkTransactionFlowOnlyEOA,
 };
+use basic_system::cost_constants::blake2s_native_cost;
 use zk_ee::memory::stack_trait::Stack;
 use zk_ee::system::{IOTeardown, Resource};
 
@@ -139,14 +140,27 @@ where
                             // Do not update the accumulators yet, we may need to revert the transaction
                             let next_block_gas_used =
                                 block_data.block_gas_used + tx_processing_result.gas_used;
-                            let next_block_computational_native_used = block_data
-                                .block_computational_native_used
-                                + tx_processing_result.computational_native_used;
                             let next_block_pubdata_used =
                                 block_data.block_pubdata_used + tx_processing_result.pubdata_used;
                             let block_logs_used = system.io.logs_len();
                             let next_block_blob_gas_used =
                                 block_data.block_blob_gas_used + tx_processing_result.blob_gas_used;
+                            let tx_status = matches!(
+                                &tx_processing_result.result,
+                                ExecutionResult::Success { .. }
+                            );
+                            let (receipt_hash, receipt_rlp_len) = compute_receipt_hash(
+                                tx_processing_result.tx_type,
+                                &tx_status,
+                                &next_block_gas_used,
+                                system.io.events_in_this_tx_iterator(),
+                            );
+                            let computational_native_used = tx_processing_result
+                                .computational_native_used
+                                + blake2s_native_cost(receipt_rlp_len);
+                            let next_block_computational_native_used =
+                                block_data.block_computational_native_used
+                                    + computational_native_used;
 
                             // Check if the transaction made the block reach any of the limits
                             // for gas, native, pubdata or logs.
@@ -181,17 +195,6 @@ where
                                 }
 
                                 is_first_tx = false;
-
-                                let tx_status = matches!(
-                                    &tx_processing_result.result,
-                                    ExecutionResult::Success { .. }
-                                );
-                                let receipt_hash = compute_receipt_hash(
-                                    tx_processing_result.tx_type,
-                                    &tx_status,
-                                    &next_block_gas_used,
-                                    system.io.events_in_this_tx_iterator(),
-                                );
 
                                 // Finish the frame opened before processing the tx
                                 system.finish_global_frame(None)?;
@@ -238,8 +241,7 @@ where
                                     contract_address,
                                     gas_used: tx_processing_result.gas_used,
                                     gas_refunded: tx_processing_result.gas_refunded,
-                                    computational_native_used: tx_processing_result
-                                        .computational_native_used,
+                                    computational_native_used,
                                     native_used: tx_processing_result.native_used,
                                     pubdata_used: tx_processing_result.pubdata_used,
                                 }));

--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -162,6 +162,10 @@ pub const L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_AUTHORIZATION: u64 =
     133 * DYNAMIC_PART_KECCAK_COMPUTATIONAL_NATIVE_PER_BYTE * 2 + // keccak for tx signing + full hash, 133 - worst case contribution to rlp encoding (33 chain_id, 21 address, 9 nonce, 1 y_parity, 33 r, 33 s, 3 list overhead)
     ACCOUNT_PERSIST_NEW_NATIVE_COST; // delegatee persist (worst case: new account)
 
+/// L2 tx blob versioned-hash computational native cost per hash.
+pub const L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_BLOB_VERSIONED_HASH: u64 =
+    33 * DYNAMIC_PART_KECCAK_COMPUTATIONAL_NATIVE_PER_BYTE * 2; // full-hash + signing-hash RLP contribution for one 32-byte blob hash
+
 /// Native computational overhead of 7702 auth.
 pub const PER_AUTH_NATIVE_COMPUTATIONAL_OVERHEAD: u64 = 2000;
 
@@ -257,8 +261,7 @@ pub const L2_TX_INTRINSIC_PUBDATA_PER_AUTHORIZATION: u64 = // Full diff compress
     2 + // nonce
     1 + // balance
     4 + // unpadded code length
-    4 + // artifacts length
-    24 + // padded bytecode
+    23 + // unpadded delegation bytecode
     4; // observable length
 
 // Pubdata needed for the diff in balance as a result of
@@ -347,3 +350,26 @@ pub const BLOCK_INTRINSIC_PUBDATA_BYTES: u64 =
 /// from block start. Covers fixed pre-tx-loop system work — currently just
 /// the EIP-2935 historical block hash write when the feature is enabled.
 pub const BLOCK_INTRINSIC_NATIVE: u64 = EIP_2935_INTRINSIC_NATIVE;
+
+#[cfg(test)]
+mod tests {
+    use super::L2_TX_INTRINSIC_PUBDATA_PER_AUTHORIZATION;
+
+    #[test]
+    fn l2_authorization_intrinsic_pubdata_matches_published_diff() {
+        // Full diff compression publishes an EIP-7702 delegation write as:
+        //   storage key (32) + account metadata (1) + versioning data (8)
+        //   + nonce diff (2) + balance diff (1) + unpadded code length (4)
+        //   + the raw delegation designator + observable code length (4).
+        // Only the unpadded designator bytes are published (padding and
+        // artifacts are not; see `account_cache_entry.rs`). The designator is
+        // `0xef0100 || address`, i.e. a 3-byte prefix plus a 20-byte address.
+        // Deriving its length from that structure (rather than restating `23`)
+        // keeps this coupled to the actual EIP-7702 encoding.
+        const DELEGATION_DESIGNATOR_LEN: u64 = 3 /* 0xef0100 */ + 20 /* address */;
+        assert_eq!(
+            L2_TX_INTRINSIC_PUBDATA_PER_AUTHORIZATION,
+            32 + 1 + 8 + 2 + 1 + 4 + DELEGATION_DESIGNATOR_LEN + 4
+        );
+    }
+}

--- a/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/gas_helpers.rs
@@ -6,6 +6,7 @@ use crate::bootloader::constants::{
     L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_ACCESS_LIST_PER_STORAGE_KEY,
     L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_COST, L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_COST_FREE,
     L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_AUTHORIZATION,
+    L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_BLOB_VERSIONED_HASH,
     L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE, L2_TX_INTRINSIC_PUBDATA,
     L2_TX_INTRINSIC_PUBDATA_PER_AUTHORIZATION, SERVICE_TX_INTRINSIC_COMPUTATIONAL_NATIVE_COST,
     SERVICE_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE, TX_INTRINSIC_GAS,
@@ -41,15 +42,36 @@ impl<S: EthereumLikeTypes> core::fmt::Debug for ResourcesForTx<S> {
     }
 }
 
+/// Per-transaction quantities that drive the intrinsic computational-native
+/// cost. Grouping them into a struct avoids an error-prone positional argument
+/// list of same-typed `u64`/`bool` values (in particular the adjacent blob- and
+/// statement-versioned-hash counts, which would silently transpose).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct L2TxIntrinsicNativeInput {
+    pub calldata_byte_length: u64,
+    pub access_list_accounts: u64,
+    pub access_list_storages: u64,
+    pub authorization_list_num: u64,
+    pub blob_versioned_hashes_num: u64,
+    pub statement_versioned_hashes_num: u64,
+    pub is_service: bool,
+    pub free_native: bool,
+}
+
 pub fn calculate_l2_tx_intrinsic_computational_native_resources(
-    calldata_byte_length: u64,
-    access_list_accounts: u64,
-    access_list_storages: u64,
-    authorization_list_num: u64,
-    statement_versioned_hashes_num: u64,
-    is_service: bool,
-    free_native: bool,
+    input: &L2TxIntrinsicNativeInput,
 ) -> u64 {
+    let L2TxIntrinsicNativeInput {
+        calldata_byte_length,
+        access_list_accounts,
+        access_list_storages,
+        authorization_list_num,
+        blob_versioned_hashes_num,
+        statement_versioned_hashes_num,
+        is_service,
+        free_native,
+    } = *input;
+
     let mut intrinsic_computational_native_resources = if is_service {
         SERVICE_TX_INTRINSIC_COMPUTATIONAL_NATIVE_COST
     } else if free_native {
@@ -85,11 +107,42 @@ pub fn calculate_l2_tx_intrinsic_computational_native_resources(
 
     intrinsic_computational_native_resources = intrinsic_computational_native_resources
         .saturating_add(
+            blob_versioned_hashes_num
+                .saturating_mul(L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_BLOB_VERSIONED_HASH),
+        );
+
+    intrinsic_computational_native_resources = intrinsic_computational_native_resources
+        .saturating_add(
             statement_versioned_hashes_num
                 .saturating_mul(FRI_PROOF_INTRINSIC_NATIVE_COST_PER_PROOF),
         );
 
     intrinsic_computational_native_resources
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        calculate_l2_tx_intrinsic_computational_native_resources, L2TxIntrinsicNativeInput,
+    };
+    use crate::bootloader::constants::L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_BLOB_VERSIONED_HASH;
+
+    #[test]
+    fn l2_intrinsic_native_accounts_for_blob_versioned_hashes() {
+        let without_blobs = calculate_l2_tx_intrinsic_computational_native_resources(
+            &L2TxIntrinsicNativeInput::default(),
+        );
+        let with_blobs =
+            calculate_l2_tx_intrinsic_computational_native_resources(&L2TxIntrinsicNativeInput {
+                blob_versioned_hashes_num: 6,
+                ..Default::default()
+            });
+
+        assert_eq!(
+            with_blobs - without_blobs,
+            6 * L2_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_BLOB_VERSIONED_HASH
+        );
+    }
 }
 
 pub fn calculate_l1_tx_intrinsic_computational_native_resources(calldata_byte_length: u64) -> u64 {

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -279,7 +279,10 @@ where
     // These cannot fail due to resource exhaustion. Their native cost is
     // accounted for as intrinsic and is not included in
     // computational_native_used (native_used only reflects native for
-    // pubdata + native used for charged computation).
+    // pubdata + native used for charged computation). For intrinsic-native
+    // verification we add the calldata copy term separately, since that work
+    // is charged during the main execution path rather than through
+    // `inf_resources`.
     let mut inf_resources = S::Resources::FORMAL_INFINITE;
 
     let coinbase = system.get_coinbase();
@@ -369,14 +372,20 @@ where
 
     // Verify that the L1 intrinsic native formula covers the actual
     // post-execution inf_resources consumption. The formula also includes
-    // pre-budgeted costs (event log, rolling hash keccak) that are not
-    // charged to inf_resources, giving a small surplus (~4%). This matches
-    // the L2 verify_intrinsic_native pattern.
+    // the calldata-copy term, which is charged outside `inf_resources`, so we
+    // add it back explicitly here. The formula also includes pre-budgeted
+    // costs (event log, rolling hash keccak) that are not charged to
+    // `inf_resources`, giving a small surplus. This matches the L2
+    // verify_intrinsic_native pattern.
     #[cfg(feature = "verify_intrinsic_native")]
     {
         let inf_initial = S::Resources::FORMAL_INFINITE.native().as_u64();
         let inf_remaining = inf_resources.native().as_u64();
-        let actual_used = inf_initial.saturating_sub(inf_remaining);
+        let inf_resources_used = inf_initial.saturating_sub(inf_remaining);
+        let actual_used = intrinsic_native_used_for_l1_verification(
+            transaction.calldata().len() as u64,
+            inf_resources_used,
+        );
         let formula = intrinsic_computational_native;
         system_log!(
             system,
@@ -446,6 +455,17 @@ struct ResourceAndFeeInfo<S: EthereumLikeTypes> {
     /// `computational_native_used` reported at end-of-tx (since
     /// `initial_resources` is captured after the precharge).
     intrinsic_computational_native: u64,
+}
+
+#[cfg(any(feature = "verify_intrinsic_native", test))]
+fn intrinsic_native_used_for_l1_verification(
+    calldata_byte_length: u64,
+    inf_resources_used: u64,
+) -> u64 {
+    use crate::bootloader::constants::L1_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE;
+    inf_resources_used.saturating_add(
+        calldata_byte_length.saturating_mul(L1_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE),
+    )
 }
 
 ///
@@ -960,4 +980,25 @@ where
         )
         .expect("must read L2AssetTracker L1_CHAIN_ID");
     U256::from_be_bytes(chain_id.as_u8_array())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::intrinsic_native_used_for_l1_verification;
+    use crate::bootloader::constants::L1_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE;
+
+    #[test]
+    fn l1_intrinsic_native_verification_accounts_for_calldata_copy() {
+        let inf_resources_used = 123_456;
+        let calldata_len = 321;
+
+        let actual_used =
+            intrinsic_native_used_for_l1_verification(calldata_len, inf_resources_used);
+
+        assert_eq!(
+            actual_used,
+            inf_resources_used
+                + calldata_len * L1_TX_INTRINSIC_COMPUTATIONAL_NATIVE_PER_CALLDATA_BYTE
+        );
+    }
 }

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/validation_impl.rs
@@ -7,7 +7,7 @@ use crate::bootloader::transaction::rlp_encoded::AccessListForAddress;
 use crate::bootloader::transaction::{charge_keccak, Transaction};
 use crate::bootloader::transaction_flow::gas_helpers::{
     calculate_l2_tx_intrinsic_computational_native_resources, calculate_l2_tx_intrinsic_pubdata,
-    calculate_tx_intrinsic_gas, create_resources_for_tx, get_gas_price,
+    calculate_tx_intrinsic_gas, create_resources_for_tx, get_gas_price, L2TxIntrinsicNativeInput,
 };
 use crate::bootloader::BasicBootloaderExecutionConfig;
 use crate::require;
@@ -131,6 +131,7 @@ where
             .ok_or(TxError::Validation(InvalidTransaction::PubdataPriceTooHigh))?;
     let native_prepaid_from_gas = native_per_gas.saturating_mul(tx_gas_limit);
     let statement_versioned_hashes_num = transaction.statement_versioned_hashes_len();
+    let blob_versioned_hashes_num = transaction.blobs().map_or(0, |blobs| blobs.count as u64);
 
     let mut access_list_accounts = 0;
     let mut access_list_storage_keys = 0;
@@ -166,15 +167,17 @@ where
         authorization_list_num,
         statement_versioned_hashes_num,
     );
-    let intrinsic_computational_native = calculate_l2_tx_intrinsic_computational_native_resources(
-        calldata.len() as u64,
-        access_list_accounts,
-        access_list_storage_keys,
-        authorization_list_num,
-        statement_versioned_hashes_num,
-        transaction.is_service(),
-        native_per_gas == 0,
-    );
+    let intrinsic_computational_native =
+        calculate_l2_tx_intrinsic_computational_native_resources(&L2TxIntrinsicNativeInput {
+            calldata_byte_length: calldata.len() as u64,
+            access_list_accounts,
+            access_list_storages: access_list_storage_keys,
+            authorization_list_num,
+            blob_versioned_hashes_num,
+            statement_versioned_hashes_num,
+            is_service: transaction.is_service(),
+            free_native: native_per_gas == 0,
+        });
     let intrinsic_pubdata =
         calculate_l2_tx_intrinsic_pubdata(authorization_list_num, transaction.is_service());
 

--- a/basic_system/src/system_functions/bls12_381/addition.rs
+++ b/basic_system/src/system_functions/bls12_381/addition.rs
@@ -32,18 +32,18 @@ fn bls12_381_g1_add_as_system_function_inner<
     output: &mut D,
     resources: &mut R,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
+    if input.len() != G1_SERIALIZATION_LEN * 2 {
+        return Err(interface_error!(
+            Bls12PrecompileInterfaceError::InvalidInputSize
+        ));
+    }
+
     let cost_ergs = Ergs(BLS12_381_G1_ADDITION_GAS * ERGS_PER_GAS);
     let cost_native = crate::cost_constants::BLS12_381_G1ADD_NATIVE_COST;
     resources.charge(&R::from_ergs_and_native(
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-
-    if input.len() != G1_SERIALIZATION_LEN * 2 {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let p0 = parse_g1(input[0..G1_SERIALIZATION_LEN].try_into().unwrap())?;
     let p1 = parse_g1(
@@ -86,18 +86,18 @@ fn bls12_381_g2_add_as_system_function_inner<
     output: &mut D,
     resources: &mut R,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
+    if input.len() != G2_SERIALIZATION_LEN * 2 {
+        return Err(interface_error!(
+            Bls12PrecompileInterfaceError::InvalidInputSize
+        ));
+    }
+
     let cost_ergs = Ergs(BLS12_381_G2_ADDITION_GAS * ERGS_PER_GAS);
     let cost_native = crate::cost_constants::BLS12_381_G2ADD_NATIVE_COST;
     resources.charge(&R::from_ergs_and_native(
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-
-    if input.len() != G2_SERIALIZATION_LEN * 2 {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let p0 = parse_g2(input[0..G2_SERIALIZATION_LEN].try_into().unwrap())?;
     let p1 = parse_g2(

--- a/basic_system/src/system_functions/bls12_381/mappings.rs
+++ b/basic_system/src/system_functions/bls12_381/mappings.rs
@@ -31,22 +31,18 @@ fn bls12_381_map_fp_to_g1_as_system_function_inner<
     output: &mut D,
     resources: &mut R,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
-    if input.len() == 0 {
+    if input.len() != FIELD_ELEMENT_SERIALIZATION_LEN {
         return Err(interface_error!(
             Bls12PrecompileInterfaceError::InvalidInputSize
         ));
     }
+
     let cost_ergs = Ergs(BLS12_381_FIELD_TO_G1_GAS * ERGS_PER_GAS);
     let cost_native = crate::cost_constants::BLS12_381_MAP_FP_TO_G1_NATIVE_COST;
     resources.charge(&R::from_ergs_and_native(
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-    if input.len() != FIELD_ELEMENT_SERIALIZATION_LEN {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let field_element = crypto::bls12_381::eip2537::parse_fq_bytes(input.try_into().unwrap())
         .ok_or_else(|| interface_error!(Bls12PrecompileInterfaceError::InvalidFieldElement))?;
@@ -89,22 +85,18 @@ fn bls12_381_map_fp2_to_g2_as_system_function_inner<
     output: &mut D,
     resources: &mut R,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
-    if input.len() == 0 {
+    if input.len() != FIELD_EXT_ELEMENT_SERIALIZATION_LEN {
         return Err(interface_error!(
             Bls12PrecompileInterfaceError::InvalidInputSize
         ));
     }
+
     let cost_ergs = Ergs(BLS12_381_FIELD_EXT_TO_G2_GAS * ERGS_PER_GAS);
     let cost_native = crate::cost_constants::BLS12_381_MAP_FP2_TO_G2_NATIVE_COST;
     resources.charge(&R::from_ergs_and_native(
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-    if input.len() != FIELD_EXT_ELEMENT_SERIALIZATION_LEN {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let field_element = crypto::bls12_381::eip2537::parse_fq2_bytes(input.try_into().unwrap())
         .ok_or_else(|| interface_error!(Bls12PrecompileInterfaceError::InvalidFieldElement))?;

--- a/basic_system/src/system_functions/bls12_381/mod.rs
+++ b/basic_system/src/system_functions/bls12_381/mod.rs
@@ -97,3 +97,92 @@ fn write_g2<D: zk_ee::common_traits::TryExtend<u8> + ?Sized>(
         .map_err(|_| out_of_return_memory!())?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::Global;
+    use zk_ee::{
+        reference_implementations::{BaseResources, DecreasingNative},
+        system::{errors::subsystem::SubsystemError, Resource, SystemFunction},
+    };
+
+    type TestResources = BaseResources<DecreasingNative>;
+
+    fn assert_invalid_input_size_and_preserves_resources<F>(input: Vec<u8>)
+    where
+        F: SystemFunction<TestResources, Bls12PrecompileErrors>,
+    {
+        let mut output = Vec::new();
+        let mut resources = TestResources::FORMAL_INFINITE;
+        let initial_resources = resources.clone();
+
+        let err = F::execute(&input, &mut output, &mut resources, Global)
+            .expect_err("malformed input must be rejected");
+
+        assert_eq!(resources, initial_resources);
+        assert!(output.is_empty());
+        assert!(matches!(
+            err,
+            SubsystemError::LeafUsage(err)
+                if err.0 == Bls12PrecompileInterfaceError::InvalidInputSize
+        ));
+    }
+
+    #[test]
+    fn malformed_g1_addition_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G1AdditionPrecompile>(vec![
+            0u8;
+            G1_SERIALIZATION_LEN * 2 - 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_g2_addition_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G2AdditionPrecompile>(vec![
+            0u8;
+            G2_SERIALIZATION_LEN * 2 + 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_g1_mapping_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G1MappingPrecompile>(vec![
+            0u8;
+            FIELD_ELEMENT_SERIALIZATION_LEN - 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_g2_mapping_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G2MappingPrecompile>(vec![
+            0u8;
+            FIELD_EXT_ELEMENT_SERIALIZATION_LEN + 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_g1_msm_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G1MSMPrecompile>(vec![
+            0u8;
+            msm::G1_MSM_PAIR_LEN
+                + 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_g2_msm_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381G2MSMPrecompile>(vec![
+            0u8;
+            msm::G2_MSM_PAIR_LEN
+                + 1
+        ]);
+    }
+
+    #[test]
+    fn malformed_pairing_input_is_free() {
+        assert_invalid_input_size_and_preserves_resources::<Bls12381PairingCheckPrecompile>(
+            vec![0u8; pairing::BLS12_381_PAIR_LEN + 1],
+        );
+    }
+}

--- a/basic_system/src/system_functions/bls12_381/msm.rs
+++ b/basic_system/src/system_functions/bls12_381/msm.rs
@@ -195,11 +195,12 @@ fn bls12_381_g1_msm_as_system_function_inner<
     resources: &mut R,
     allocator: A,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
-    if input.len() == 0 {
+    if input.is_empty() || !input.len().is_multiple_of(G1_MSM_PAIR_LEN) {
         return Err(interface_error!(
             Bls12PrecompileInterfaceError::InvalidInputSize
         ));
     }
+
     let cost = compute_cost(
         input.len(),
         G1_MSM_PAIR_LEN,
@@ -217,12 +218,6 @@ fn bls12_381_g1_msm_as_system_function_inner<
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-
-    if !input.len().is_multiple_of(G1_MSM_PAIR_LEN) {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let num_pairs = input.len() / G1_MSM_PAIR_LEN;
     let mut scalars = Vec::with_capacity_in(num_pairs, allocator.clone());
@@ -282,11 +277,12 @@ fn bls12_381_g2_msm_as_system_function_inner<
     resources: &mut R,
     allocator: A,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
-    if input.len() == 0 {
+    if input.is_empty() || !input.len().is_multiple_of(G2_MSM_PAIR_LEN) {
         return Err(interface_error!(
             Bls12PrecompileInterfaceError::InvalidInputSize
         ));
     }
+
     let cost = compute_cost(
         input.len(),
         G2_MSM_PAIR_LEN,
@@ -304,12 +300,6 @@ fn bls12_381_g2_msm_as_system_function_inner<
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-
-    if !input.len().is_multiple_of(G2_MSM_PAIR_LEN) {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let num_pairs = input.len() / G2_MSM_PAIR_LEN;
 

--- a/basic_system/src/system_functions/bls12_381/pairing.rs
+++ b/basic_system/src/system_functions/bls12_381/pairing.rs
@@ -39,11 +39,12 @@ fn bls12_381_pairing_as_system_function_inner<
     resources: &mut R,
     allocator: A,
 ) -> Result<(), zk_ee::system::errors::subsystem::SubsystemError<Bls12PrecompileErrors>> {
-    if input.len() == 0 {
+    if input.is_empty() || !input.len().is_multiple_of(BLS12_381_PAIR_LEN) {
         return Err(interface_error!(
             Bls12PrecompileInterfaceError::InvalidInputSize
         ));
     }
+
     let num_pairs = input.len() / BLS12_381_PAIR_LEN;
     let cost_ergs = Ergs(
         ((num_pairs as u64) * BLS12_381_PAIRING_PER_PAIR_GAS + BLS12_381_PAIRING_FIXED_GAS)
@@ -56,12 +57,6 @@ fn bls12_381_pairing_as_system_function_inner<
         cost_ergs,
         <R::Native as zk_ee::system::Computational>::from_computational(cost_native),
     ))?;
-
-    if !input.len().is_multiple_of(BLS12_381_PAIR_LEN) {
-        return Err(interface_error!(
-            Bls12PrecompileInterfaceError::InvalidInputSize
-        ));
-    }
 
     let mut g1_points = Vec::with_capacity_in(num_pairs, allocator.clone());
     let mut g2_points = Vec::with_capacity_in(num_pairs, allocator.clone());

--- a/basic_system/src/system_functions/modexp/mod.rs
+++ b/basic_system/src/system_functions/modexp/mod.rs
@@ -9,11 +9,12 @@ use zk_ee::oracle::IOOracle;
 use zk_ee::system::logger::Logger;
 use zk_ee::system::SystemFunctionExt;
 use zk_ee::{
-    interface_error, internal_error, out_of_ergs_error,
+    interface_error, internal_error, out_of_ergs_error, out_of_native_resources,
+    out_of_return_memory,
     system::{
         base_system_functions::ModExpErrors,
         errors::{subsystem::SubsystemError, system::SystemError},
-        Computational, Ergs, ModExpInterfaceError,
+        Computational, Ergs, ModExpInterfaceError, Resource,
     },
 };
 
@@ -157,9 +158,11 @@ fn modexp_as_system_function_inner<
 ) -> Result<(), SubsystemError<ModExpErrors>> {
     // Check at least we have min gas
     let minimal_native = <R::Native as Computational>::from_computational(MODEXP_BASE_NATIVE_COST);
-    let minimal_resources = R::from_ergs_and_native(MODEXP_MINIMAL_COST_ERGS, minimal_native);
-    if !resources.has_enough(&minimal_resources) {
+    if !resources.ergs().has_enough(&MODEXP_MINIMAL_COST_ERGS) {
         return Err(out_of_ergs_error!().into());
+    }
+    if !resources.native().has_enough(&minimal_native) {
+        return Err(out_of_native_resources!().into());
     }
 
     // The format of input is:
@@ -249,8 +252,11 @@ fn modexp_as_system_function_inner<
     let ergs = ergs_cost(base_len as u64, exp_len as u64, mod_len as u64, &exp_highp)?;
     let conservative_native =
         native_cost::<R>(base_len as u64, exp_len as u64, mod_len as u64, &exp_highp)?;
-    if !resources.has_enough(&R::from_ergs_and_native(ergs, conservative_native)) {
+    if !resources.ergs().has_enough(&ergs) {
         return Err(out_of_ergs_error!().into());
+    }
+    if !resources.native().has_enough(&conservative_native) {
+        return Err(out_of_native_resources!().into());
     }
 
     let mut base = Vec::try_with_capacity_in(base_len, allocator.clone())
@@ -309,10 +315,10 @@ fn modexp_as_system_function_inner<
     if output.len() >= mod_len {
         // truncate
         dst.try_extend(output[(output.len() - mod_len)..].iter().copied())
-            .map_err(|_| out_of_ergs_error!())?;
+            .map_err(|_| out_of_return_memory!())?;
     } else {
         dst.try_extend(core::iter::repeat_n(0, mod_len - output.len()).chain(output))
-            .map_err(|_| out_of_ergs_error!())?;
+            .map_err(|_| out_of_return_memory!())?;
     }
 
     Ok(())
@@ -397,4 +403,161 @@ fn native_cost<R: Resources>(
     let total_ops = 2u64.saturating_mul(bit_len.saturating_sub(1));
     let cost = modexp_native_from_ops(total_ops, digits);
     Ok(<R::Native as Computational>::from_computational(cost))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::Global;
+    use zk_ee::oracle::IOOracle;
+    use zk_ee::reference_implementations::{BaseResources, DecreasingNative};
+    use zk_ee::system::{
+        errors::{
+            runtime::{FatalRuntimeError, RuntimeError},
+            subsystem::SubsystemError,
+        },
+        NullLogger, Resources,
+    };
+
+    type TestResources = BaseResources<DecreasingNative>;
+
+    struct DummyOracle;
+    struct AlwaysFailDst;
+
+    impl IOOracle for DummyOracle {
+        type RawIterator<'a> = Box<dyn ExactSizeIterator<Item = usize> + 'static>;
+
+        fn raw_query<
+            'a,
+            I: zk_ee::oracle::usize_serialization::UsizeSerializable
+                + zk_ee::oracle::usize_serialization::UsizeDeserializable,
+        >(
+            &'a mut self,
+            _query_type: u32,
+            _input: &I,
+        ) -> Result<Self::RawIterator<'a>, zk_ee::system::errors::internal::InternalError> {
+            unreachable!("oracle should not be consulted on native targets");
+        }
+    }
+
+    impl TryExtend<u8> for AlwaysFailDst {
+        type Error = ();
+
+        fn try_extend<I>(&mut self, _iter: I) -> Result<(), Self::Error>
+        where
+            I: IntoIterator<Item = u8>,
+        {
+            Err(())
+        }
+    }
+
+    fn encode_len(len: usize) -> [u8; 32] {
+        U256::from(len).to_be_bytes::<32>()
+    }
+
+    fn modexp_input(base: &[u8], exponent: &[u8], modulus: &[u8]) -> Vec<u8> {
+        let mut input = Vec::with_capacity(96 + base.len() + exponent.len() + modulus.len());
+        input.extend_from_slice(&encode_len(base.len()));
+        input.extend_from_slice(&encode_len(exponent.len()));
+        input.extend_from_slice(&encode_len(modulus.len()));
+        input.extend_from_slice(base);
+        input.extend_from_slice(exponent);
+        input.extend_from_slice(modulus);
+        input
+    }
+
+    fn assert_out_of_native(err: SubsystemError<ModExpErrors>) {
+        assert!(matches!(
+            err,
+            SubsystemError::LeafRuntime(RuntimeError::FatalRuntimeError(
+                FatalRuntimeError::OutOfNativeResources(_)
+            ))
+        ));
+    }
+
+    fn assert_out_of_return_memory(err: SubsystemError<ModExpErrors>) {
+        assert!(matches!(
+            err,
+            SubsystemError::LeafRuntime(RuntimeError::FatalRuntimeError(
+                FatalRuntimeError::OutOfReturnMemory(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn returns_out_of_native_when_minimal_native_missing() {
+        let input = modexp_input(&[2], &[1], &[3]);
+        let mut output = Vec::new();
+        let mut resources = TestResources::from_ergs_and_native(
+            MODEXP_MINIMAL_COST_ERGS,
+            DecreasingNative::from_computational(MODEXP_BASE_NATIVE_COST - 1),
+        );
+
+        let err = ModExpImpl::<false>::execute(
+            &input,
+            &mut output,
+            &mut resources,
+            &mut DummyOracle,
+            &mut NullLogger,
+            Global,
+        )
+        .expect_err("native, not ergs, should be exhausted");
+
+        assert_out_of_native(err);
+    }
+
+    #[test]
+    fn returns_out_of_native_when_conservative_native_gate_fails() {
+        let base = vec![0x11; 64];
+        let exponent = vec![0xff; 1];
+        let modulus = vec![0x33; 64];
+        let input = modexp_input(&base, &exponent, &modulus);
+        let exp_highp = U256::from_be_slice(&exponent);
+        let conservative_native = native_cost::<TestResources>(
+            base.len() as u64,
+            exponent.len() as u64,
+            modulus.len() as u64,
+            &exp_highp,
+        )
+        .expect("cost must be computable");
+        let mut output = Vec::new();
+        let mut resources = TestResources::from_ergs_and_native(
+            Ergs::FORMAL_INFINITE,
+            DecreasingNative::from_computational(conservative_native.as_u64() - 1),
+        );
+
+        let err = ModExpImpl::<false>::execute(
+            &input,
+            &mut output,
+            &mut resources,
+            &mut DummyOracle,
+            &mut NullLogger,
+            Global,
+        )
+        .expect_err("native conservative gate should fail first");
+
+        assert_out_of_native(err);
+    }
+
+    #[test]
+    fn returns_out_of_return_memory_when_output_does_not_fit() {
+        let base = [2u8];
+        let exponent = [2u8];
+        let modulus = [1u8];
+        let input = modexp_input(&base, &exponent, &modulus);
+        let mut output = AlwaysFailDst;
+        let mut resources = TestResources::FORMAL_INFINITE;
+
+        let err = ModExpImpl::<false>::execute(
+            &input,
+            &mut output,
+            &mut resources,
+            &mut DummyOracle,
+            &mut NullLogger,
+            Global,
+        )
+        .expect_err("output buffer should be the failing resource");
+
+        assert_out_of_return_memory(err);
+    }
 }

--- a/basic_system/src/system_functions/modexp/mod.rs
+++ b/basic_system/src/system_functions/modexp/mod.rs
@@ -62,6 +62,54 @@ fn modexp_native_from_ops(total_ops: u64, digits: u64) -> u64 {
         )
 }
 
+/// The delegated modexp implementation may do one quotient*modulus FMA before
+/// the exponent loop to reduce an oversized base into the modulus range.
+///
+/// A regular square/multiply step does two FMAs in the current model, so we
+/// account this standalone reduction as half of a normal per-op charge.
+fn modexp_initial_reduction_native_cost(digits: u64) -> u64 {
+    MODEXP_PER_OP_OVERHEAD_NATIVE_COST
+        .saturating_add(
+            digits
+                .saturating_mul(digits)
+                .saturating_mul(MODEXP_PER_OP_DIGIT_SQ_NATIVE_COST),
+        )
+        .div_ceil(2)
+}
+
+fn strip_leading_zeroes(bytes: &[u8]) -> &[u8] {
+    let first_nonzero = bytes
+        .iter()
+        .position(|&byte| byte != 0)
+        .unwrap_or(bytes.len());
+    &bytes[first_nonzero..]
+}
+
+/// Number of 32-byte words needed to represent the value, ignoring leading
+/// zero bytes. This mirrors `BigUint::digits` in the delegated bigint
+/// implementation (`advice/bigint.rs`), which counts significant 32-byte words.
+fn significant_word_count(bytes: &[u8]) -> u64 {
+    (strip_leading_zeroes(bytes).len() as u64).div_ceil(32)
+}
+
+/// Whether the delegated modexp implementation performs its standalone initial
+/// reduction FMA before the exponent loop.
+///
+/// That implementation gates the reduction purely on the significant 32-byte
+/// word counts of the operands (`advice/bigint.rs`: `if current.digits >=
+/// modulus.digits`) and, once the gate passes, always performs the FMA
+/// regardless of the operand values. We therefore compare word counts here too
+/// (rather than the numeric values): a base that is smaller in value than the
+/// modulus but occupies the same number of words is still reduced, and must be
+/// charged accordingly.
+fn requires_initial_reduction(base: &[u8], modulus: &[u8]) -> bool {
+    let modulus_words = significant_word_count(modulus);
+    if modulus_words == 0 {
+        return false;
+    }
+    significant_word_count(base) >= modulus_words
+}
+
 // Query ID for modular exponentiation advice from oracle
 pub const MODEXP_ADVICE_QUERY_ID: u32 = ADVICE_SUBSPACE_MASK | 0x10;
 
@@ -272,9 +320,10 @@ fn modexp_as_system_function_inner<
     read_padded(&mut modulus, &mut input, mod_len);
 
     // Charge the exact native (scans the materialized exponent's set bits).
-    // It never exceeds `conservative_native` checked above, so it cannot fail
-    // after the gate passed.
-    let native = native_cost_from_exp_data::<R>(base_len as u64, &exponent, mod_len as u64)?;
+    // `conservative_native` checked above is a true upper bound on this value
+    // (worst-case exponent, and it charges the initial reduction whenever the
+    // exact charge might), so this charge cannot fail after the gate passed.
+    let native = native_cost_from_exp_data::<R>(&base, &exponent, &modulus)?;
     resources.charge(&R::from_ergs_and_native(ergs, native))?;
 
     debug_assert_eq!(base.len(), base_len);
@@ -369,15 +418,22 @@ pub fn ergs_cost(
 
 /// Computes the native cost for modexp by scanning the exponent.
 pub fn native_cost_from_exp_data<R: Resources>(
-    base_size: u64,
+    base: &[u8],
     exp_data: &[u8],
-    mod_size: u64,
+    modulus: &[u8],
 ) -> Result<R::Native, SystemError> {
+    let base_size = base.len() as u64;
+    let mod_size = modulus.len() as u64;
     let digits = core::cmp::max(1, core::cmp::max(base_size, mod_size).div_ceil(32));
     let (bit_len, popcount) = exp_bit_len_and_popcount(exp_data);
     let squares = bit_len.saturating_sub(1);
     let multiplies = popcount.saturating_sub(1);
-    let cost = modexp_native_from_ops(squares + multiplies, digits);
+    let reduction_cost = if requires_initial_reduction(base, modulus) {
+        modexp_initial_reduction_native_cost(significant_word_count(modulus))
+    } else {
+        0
+    };
+    let cost = modexp_native_from_ops(squares + multiplies, digits).saturating_add(reduction_cost);
     Ok(<R::Native as Computational>::from_computational(cost))
 }
 
@@ -401,7 +457,19 @@ fn native_cost<R: Resources>(
     };
     // Worst case: all bits set → squares = multiplies = bit_len - 1.
     let total_ops = 2u64.saturating_mul(bit_len.saturating_sub(1));
-    let cost = modexp_native_from_ops(total_ops, digits);
+    // Conservative upper bound on the exact reduction charge. The exact charge
+    // (`native_cost_from_exp_data`) adds the reduction whenever the base has at
+    // least as many significant words as the modulus. We cannot strip leading
+    // zeroes here without materializing the operands, so we charge the reduction
+    // whenever both operands are non-empty and use `mod_size`, which upper-bounds
+    // the exact modulus word count. This keeps the gate a true upper bound.
+    let reduction_cost = if mod_size != 0 && base_size != 0 {
+        let modulus_digits = core::cmp::max(1, mod_size.div_ceil(32));
+        modexp_initial_reduction_native_cost(modulus_digits)
+    } else {
+        0
+    };
+    let cost = modexp_native_from_ops(total_ops, digits).saturating_add(reduction_cost);
     Ok(<R::Native as Computational>::from_computational(cost))
 }
 
@@ -559,5 +627,86 @@ mod tests {
         .expect_err("output buffer should be the failing resource");
 
         assert_out_of_return_memory(err);
+    }
+
+    #[test]
+    fn exact_native_cost_accounts_for_initial_reduction() {
+        let base = vec![0xff; 64];
+        let exponent = [1u8];
+        let modulus = vec![0x01; 32];
+
+        let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
+            .expect("cost must be computable");
+
+        assert_eq!(
+            native.as_u64(),
+            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(1)
+        );
+    }
+
+    #[test]
+    fn exact_native_cost_skips_initial_reduction_when_base_has_fewer_words() {
+        // Base occupies fewer 32-byte words than the modulus, so the delegated
+        // implementation does not perform the initial reduction.
+        let base = [1u8];
+        let exponent = [1u8];
+        let modulus = vec![0x01; 33]; // 2 words vs the base's 1 word
+
+        let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
+            .expect("cost must be computable");
+
+        assert_eq!(native.as_u64(), MODEXP_BASE_NATIVE_COST);
+    }
+
+    #[test]
+    fn exact_native_cost_accounts_for_reduction_when_base_and_modulus_share_word_count() {
+        // The base is numerically smaller than the modulus but occupies the same
+        // number of 32-byte words, so the delegated implementation still runs the
+        // initial reduction FMA (`current.digits >= modulus.digits`) and it must
+        // be charged. Comparing values instead of word counts would undercharge
+        // this common case (e.g. RSA verification with base < modulus).
+        let base = [1u8];
+        let exponent = [1u8];
+        let modulus = [2u8];
+
+        let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
+            .expect("cost must be computable");
+
+        assert_eq!(
+            native.as_u64(),
+            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(1)
+        );
+    }
+
+    #[test]
+    fn conservative_native_upper_bounds_exact_native() {
+        // The conservative gate must never under-approximate the exact charge,
+        // even when the modulus has leading zero bytes that the exact
+        // (materialized) charge strips away. Otherwise `resources.charge` could
+        // fail after the conservative gate already passed.
+        let cases: &[(&[u8], &[u8], &[u8])] = &[
+            (&[0x07], &[0xff], &[0x00, 0x05]), // modulus strips to fewer words
+            (&[0x01], &[0x01], &[0x02]),       // same word count, base < modulus
+            (&[0xff; 64], &[0xff; 4], &[0x01; 32]),
+            (&[0x00, 0x00, 0x01], &[0x01], &[0x00, 0x00, 0x03]),
+        ];
+        for (base, exp, modulus) in cases {
+            let exact = native_cost_from_exp_data::<TestResources>(base, exp, modulus)
+                .expect("exact cost must be computable")
+                .as_u64();
+            let exp_highp = U256::from_be_slice(exp);
+            let conservative = native_cost::<TestResources>(
+                base.len() as u64,
+                exp.len() as u64,
+                modulus.len() as u64,
+                &exp_highp,
+            )
+            .expect("conservative cost must be computable")
+            .as_u64();
+            assert!(
+                exact <= conservative,
+                "exact {exact} exceeded conservative {conservative} for base={base:?} modulus={modulus:?}"
+            );
+        }
     }
 }

--- a/basic_system/src/system_functions/modexp/mod.rs
+++ b/basic_system/src/system_functions/modexp/mod.rs
@@ -62,18 +62,23 @@ fn modexp_native_from_ops(total_ops: u64, digits: u64) -> u64 {
         )
 }
 
-/// The delegated modexp implementation may do one quotient*modulus FMA before
-/// the exponent loop to reduce an oversized base into the modulus range.
+/// The delegated modexp implementation may do one `quotient * modulus + remainder`
+/// FMA before the exponent loop to reduce an oversized base into the modulus
+/// range (`advice/bigint.rs`: `reduce_initially`).
+///
+/// That FMA is a schoolbook multiply whose delegation count scales with the
+/// product of the operand word counts — `quotient_digits * modulus_digits` (the
+/// two loops in `fma`), not `modulus_digits^2`. For an oversized base reduced by
+/// a small modulus the quotient dominates, so charging `modulus_digits^2` would
+/// undercharge. We therefore charge on the true `quotient_digits * modulus_digits`
+/// product.
 ///
 /// A regular square/multiply step does two FMAs in the current model, so we
 /// account this standalone reduction as half of a normal per-op charge.
-fn modexp_initial_reduction_native_cost(digits: u64) -> u64 {
+fn modexp_initial_reduction_native_cost(quotient_digits: u64, modulus_digits: u64) -> u64 {
+    let digit_products = quotient_digits.saturating_mul(modulus_digits);
     MODEXP_PER_OP_OVERHEAD_NATIVE_COST
-        .saturating_add(
-            digits
-                .saturating_mul(digits)
-                .saturating_mul(MODEXP_PER_OP_DIGIT_SQ_NATIVE_COST),
-        )
+        .saturating_add(digit_products.saturating_mul(MODEXP_PER_OP_DIGIT_SQ_NATIVE_COST))
         .div_ceil(2)
 }
 
@@ -102,11 +107,20 @@ fn significant_word_count(bytes: &[u8]) -> u64 {
 /// (rather than the numeric values): a base that is smaller in value than the
 /// modulus but occupies the same number of words is still reduced, and must be
 /// charged accordingly.
+///
+/// Two operand values short-circuit the delegated path *before* the reduction
+/// and so must not be charged for it:
+/// - `modulus == 0`: the implementation returns an empty result immediately.
+/// - `modulus == 1`: `modexp_inner` returns before parsing the base or calling
+///   `modpow`, so `reduce_initially` never runs (`base^exp mod 1 == 0`).
 fn requires_initial_reduction(base: &[u8], modulus: &[u8]) -> bool {
-    let modulus_words = significant_word_count(modulus);
-    if modulus_words == 0 {
+    let modulus = strip_leading_zeroes(modulus);
+    // modulus == 0 (no significant bytes) or modulus == 1 (a single 0x01 byte):
+    // the delegated path returns before any reduction.
+    if modulus.is_empty() || modulus == [1u8] {
         return false;
     }
+    let modulus_words = (modulus.len() as u64).div_ceil(32);
     significant_word_count(base) >= modulus_words
 }
 
@@ -429,7 +443,14 @@ pub fn native_cost_from_exp_data<R: Resources>(
     let squares = bit_len.saturating_sub(1);
     let multiplies = popcount.saturating_sub(1);
     let reduction_cost = if requires_initial_reduction(base, modulus) {
-        modexp_initial_reduction_native_cost(significant_word_count(modulus))
+        let modulus_digits = significant_word_count(modulus);
+        // The honest quotient q = base / modulus occupies at most
+        // `base_digits - modulus_digits + 1` words (guaranteed >= 1 here, since
+        // `requires_initial_reduction` implies `base_digits >= modulus_digits`).
+        let quotient_digits = significant_word_count(base)
+            .saturating_sub(modulus_digits)
+            .saturating_add(1);
+        modexp_initial_reduction_native_cost(quotient_digits, modulus_digits)
     } else {
         0
     };
@@ -458,14 +479,19 @@ fn native_cost<R: Resources>(
     // Worst case: all bits set → squares = multiplies = bit_len - 1.
     let total_ops = 2u64.saturating_mul(bit_len.saturating_sub(1));
     // Conservative upper bound on the exact reduction charge. The exact charge
-    // (`native_cost_from_exp_data`) adds the reduction whenever the base has at
-    // least as many significant words as the modulus. We cannot strip leading
-    // zeroes here without materializing the operands, so we charge the reduction
-    // whenever both operands are non-empty and use `mod_size`, which upper-bounds
-    // the exact modulus word count. This keeps the gate a true upper bound.
+    // (`native_cost_from_exp_data`) adds `quotient_digits * modulus_digits`,
+    // where `quotient_digits <= base_digits` and `modulus_digits` are the
+    // significant word counts. We cannot strip leading zeroes here without
+    // materializing the operands, so we upper-bound both dimensions by the
+    // header word counts (`base_size`/`mod_size`, which dominate the significant
+    // counts) and charge the reduction whenever both operands are non-empty.
+    // This keeps the gate a true upper bound (it also covers the `modulus == 1`
+    // case, which the exact charge skips). `base_words * mod_words >=
+    // quotient_digits * modulus_digits`.
     let reduction_cost = if mod_size != 0 && base_size != 0 {
-        let modulus_digits = core::cmp::max(1, mod_size.div_ceil(32));
-        modexp_initial_reduction_native_cost(modulus_digits)
+        let modulus_words = core::cmp::max(1, mod_size.div_ceil(32));
+        let base_words = core::cmp::max(1, base_size.div_ceil(32));
+        modexp_initial_reduction_native_cost(base_words, modulus_words)
     } else {
         0
     };
@@ -631,17 +657,57 @@ mod tests {
 
     #[test]
     fn exact_native_cost_accounts_for_initial_reduction() {
-        let base = vec![0xff; 64];
+        let base = vec![0xff; 64]; // 2 words
         let exponent = [1u8];
-        let modulus = vec![0x01; 32];
+        let modulus = vec![0x01; 32]; // 1 word, value != 1
 
         let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
             .expect("cost must be computable");
 
+        // quotient = base / modulus occupies at most base_digits - mod_digits + 1
+        // = 2 - 1 + 1 = 2 words; the reduction FMA is quotient_digits * mod_digits.
         assert_eq!(
             native.as_u64(),
-            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(1)
+            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(2, 1)
         );
+    }
+
+    #[test]
+    fn exact_native_cost_scales_reduction_with_quotient_for_small_modulus() {
+        // Oversized base reduced by a single-word modulus: the reduction FMA
+        // scales with the quotient (~base_digits), not modulus_digits^2. With
+        // exponent == 1 the exponent loop contributes no ops, so the reduction
+        // is the only variable cost — this is the case the old modulus_digits^2
+        // charge undercharged.
+        let base = vec![0xff; 32 * 8]; // 8 words
+        let exponent = [1u8];
+        let modulus = vec![0x03]; // 1 word, value != 1
+
+        let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
+            .expect("cost must be computable");
+
+        // quotient_digits = 8 - 1 + 1 = 8, modulus_digits = 1.
+        assert_eq!(
+            native.as_u64(),
+            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(8, 1)
+        );
+    }
+
+    #[test]
+    fn exact_native_cost_skips_initial_reduction_for_modulus_one() {
+        // `base^exp mod 1 == 0`: the delegated `modexp_inner` returns before
+        // parsing the base or calling `modpow`, so no reduction runs and none
+        // must be charged, however oversized the base is.
+        let base = vec![0xff; 32 * 8];
+        let exponent = [1u8];
+        let modulus = [1u8];
+
+        let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
+            .expect("cost must be computable");
+
+        // exponent == 1 => no square/multiply ops, and modulus == 1 => no
+        // reduction, so only the base cost remains.
+        assert_eq!(native.as_u64(), MODEXP_BASE_NATIVE_COST);
     }
 
     #[test]
@@ -672,9 +738,10 @@ mod tests {
         let native = native_cost_from_exp_data::<TestResources>(&base, &exponent, &modulus)
             .expect("cost must be computable");
 
+        // quotient_digits = 1 - 1 + 1 = 1, modulus_digits = 1.
         assert_eq!(
             native.as_u64(),
-            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(1)
+            MODEXP_BASE_NATIVE_COST + modexp_initial_reduction_native_cost(1, 1)
         );
     }
 
@@ -689,6 +756,9 @@ mod tests {
             (&[0x01], &[0x01], &[0x02]),       // same word count, base < modulus
             (&[0xff; 64], &[0xff; 4], &[0x01; 32]),
             (&[0x00, 0x00, 0x01], &[0x01], &[0x00, 0x00, 0x03]),
+            (&[0xff; 32 * 8], &[0x01], &[0x03]), // oversized base, single-word modulus
+            (&[0xff; 32 * 8], &[0xff; 4], &[0x01]), // modulus == 1: exact skips reduction
+            (&[0xff; 32 * 4], &[0xff; 8], &[0x00, 0x01]), // modulus == 1 with leading zero byte
         ];
         for (base, exp, modulus) in cases {
             let exact = native_cost_from_exp_data::<TestResources>(base, exp, modulus)

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -370,10 +370,10 @@ impl<
 
         if new != cur {
             Self::charge_account_persist_cost_if_needed(cur_tx, &mut account_data, resources)?;
-            resources.charge(&R::from_native(R::Native::from_computational(
-                WARM_ACCOUNT_CACHE_WRITE_EXTRA_NATIVE_COST,
-            )))?;
         }
+        resources.charge(&R::from_native(R::Native::from_computational(
+            WARM_ACCOUNT_CACHE_WRITE_EXTRA_NATIVE_COST,
+        )))?;
 
         account_data.update(|cache_record| {
             cache_record.update(|v, m| {
@@ -1328,3 +1328,109 @@ define_subsystem!(AccountCache,
                       EvmSubsystem(EvmSubsystemError),
                   }
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::system_implementation::caches::generic_pubdata_aware_plain_storage::GenericPubdataAwarePlainStorage;
+    use crate::system_implementation::system::EthereumLikeStorageAccessCostModel;
+    use std::alloc::Global;
+    use storage_models::common_structs::snapshottable_io::SnapshottableIo;
+    use zk_ee::internal_error;
+    use zk_ee::memory::stack_implementations::vec_stack::VecStackFactory;
+    use zk_ee::oracle::query_ids::INITIAL_STORAGE_SLOT_VALUE_QUERY_ID;
+    use zk_ee::oracle::usize_serialization::{UsizeDeserializable, UsizeSerializable};
+    use zk_ee::oracle::IOOracle;
+    use zk_ee::reference_implementations::{BaseResources, DecreasingNative};
+    use zk_ee::storage_types::InitialStorageSlotData;
+    use zk_ee::system::errors::internal::InternalError;
+    use zk_ee::system::Resource;
+    use zk_ee::types_config::EthereumIOTypesConfig;
+
+    type TestResources = BaseResources<DecreasingNative>;
+    type TestStorage = NewStorageWithAccountPropertiesUnderHash<
+        Global,
+        VecStackFactory,
+        4,
+        TestResources,
+        EthereumLikeStorageAccessCostModel,
+    >;
+    type TestAccountCache = NewModelAccountCache<
+        Global,
+        TestResources,
+        EthereumLikeStorageAccessCostModel,
+        VecStackFactory,
+        4,
+    >;
+
+    struct EmptyAccountOracle;
+
+    impl IOOracle for EmptyAccountOracle {
+        type RawIterator<'a> = Box<dyn ExactSizeIterator<Item = usize> + 'static>;
+
+        fn raw_query<'a, I: UsizeSerializable + UsizeDeserializable>(
+            &'a mut self,
+            query_type: u32,
+            _input: &I,
+        ) -> Result<Self::RawIterator<'a>, InternalError> {
+            match query_type {
+                INITIAL_STORAGE_SLOT_VALUE_QUERY_ID => {
+                    let response = InitialStorageSlotData::<EthereumIOTypesConfig> {
+                        is_new_storage_slot: true,
+                        initial_value: Bytes32::ZERO,
+                    };
+                    let values: Vec<_> = response.iter().collect();
+                    Ok(Box::new(values.into_iter()))
+                }
+                _ => Err(internal_error!("unexpected oracle query in test")),
+            }
+        }
+    }
+
+    #[test]
+    fn noop_balance_update_charges_warm_account_cache_write() {
+        let mut storage: TestStorage = NewStorageWithAccountPropertiesUnderHash(
+            GenericPubdataAwarePlainStorage::new_from_parts(
+                Global,
+                EthereumLikeStorageAccessCostModel,
+            ),
+        );
+        let mut preimages_cache =
+            BytecodeAndAccountDataPreimagesStorage::<TestResources, Global>::new_from_parts(Global);
+        let mut account_cache = TestAccountCache::new_from_parts(Global);
+        let mut oracle = EmptyAccountOracle;
+        let address = B160::from_limbs([0x1234, 0, 0]);
+
+        storage.begin_new_tx();
+        account_cache.begin_new_tx();
+
+        let mut resources = TestResources::FORMAL_INFINITE;
+        let initial_native = resources.native().as_u64();
+
+        let previous_balance = account_cache
+            .update_nominal_token_value::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut resources,
+                &address,
+                |balance| Ok(*balance),
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+                false,
+            )
+            .expect("no-op update on an empty account should succeed");
+
+        assert_eq!(previous_balance, U256::ZERO);
+
+        let charged_native = initial_native - resources.native().as_u64();
+        let expected_native = WARM_ACCOUNT_CACHE_ACCESS_NATIVE_COST
+            + WARM_STORAGE_READ_NATIVE_COST
+            + COLD_NEW_STORAGE_READ_NATIVE_COST
+            + WARM_ACCOUNT_CACHE_WRITE_EXTRA_NATIVE_COST;
+
+        assert_eq!(
+            charged_native, expected_native,
+            "no-op balance updates must still pay the warm account-cache write cost"
+        );
+    }
+}

--- a/basic_system/src/system_implementation/system/mod.rs
+++ b/basic_system/src/system_implementation/system/mod.rs
@@ -105,11 +105,12 @@ impl<R: Resources> StorageAccessPolicy<R, Bytes32> for EthereumLikeStorageAccess
         };
         // Native uses write-specific warmness: only discount if cold write extra
         // was already charged this tx. A prior SLOAD warms the access but doesn't
-        // pay for write merkle paths. No-op writes (same value) skip the charge
-        // entirely — the tree won't do any work for unchanged slots.
-        let native = if new_value == current_value {
-            R::Native::from_computational(0)
-        } else if is_cold_write_charged {
+        // pay for write merkle paths. Even no-op writes still update the
+        // in-memory cache state, so they pay the warm cache-write cost.
+        let native = if new_value == current_value || is_cold_write_charged {
+            // No-op writes still update the in-memory cache state, and a warm
+            // write after a cold write was already charged this tx, so both pay
+            // only the warm cache-write cost.
             R::Native::from_computational(
                 crate::system_implementation::flat_storage_model::cost_constants::WARM_STORAGE_WRITE_EXTRA_NATIVE_COST,
             )

--- a/bench_scripts/bench.sh
+++ b/bench_scripts/bench.sh
@@ -52,7 +52,16 @@ build_riscv_binary() {
         (cd "$REPO_ROOT/zksync_os" && ./dump_bin.sh --type for-tests-benchmarking)
     fi
     echo "==> Building RISC-V block-replay benchmarking binary..."
-    (cd "$REPO_ROOT/zksync_os" && ./dump_bin.sh --type evm-replay-benchmarking)
+    # The block fixtures are post-BPO Osaka blocks, so the replay guest needs the
+    # `fusaka-bpo-2` blob schedule (via the `evm-replay-benchmarking-fusaka` type);
+    # without it those blocks hit an unimplemented path and the RISC-V run aborts
+    # with an "Illegal instruction". Mirror the CI workflow (bench.yml): prefer the
+    # fusaka variant, fall back to the plain type on a pre-rename merge-base.
+    if grep -q "evm-replay-benchmarking-fusaka" "$REPO_ROOT/zksync_os/dump_bin.sh"; then
+        (cd "$REPO_ROOT/zksync_os" && ./dump_bin.sh --type evm-replay-benchmarking-fusaka)
+    else
+        (cd "$REPO_ROOT/zksync_os" && ./dump_bin.sh --type evm-replay-benchmarking)
+    fi
 }
 
 run_block() {

--- a/callable_oracles/src/utils/evaluate.rs
+++ b/callable_oracles/src/utils/evaluate.rs
@@ -74,10 +74,12 @@ pub fn read_memory_as_u64(
 /// The data in the memory at offset should actually be T.
 pub unsafe fn read_struct<T>(memory: &dyn RamPeek, offset: u32) -> Result<T, ()> {
     if !core::mem::size_of::<T>().is_multiple_of(4) {
-        todo!()
+        return Err(());
     }
 
-    if !(offset as usize).is_multiple_of(core::mem::align_of::<T>()) {
+    if !offset.is_multiple_of(4)
+        || !(offset as usize).is_multiple_of(core::mem::align_of::<T>())
+    {
         return Err(());
     }
 
@@ -94,4 +96,53 @@ pub unsafe fn read_struct<T>(memory: &dyn RamPeek, offset: u32) -> Result<T, ()>
 
     // Safety: have written all bytes.
     unsafe { Ok(r.assume_init()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_struct;
+    use crate::test_utils::TestMemorySource;
+
+    #[repr(C)]
+    #[derive(Debug, PartialEq, Eq)]
+    struct PackedWord(u32);
+
+    #[repr(C)]
+    #[derive(Debug, PartialEq, Eq)]
+    struct BytePair(u8, u8);
+
+    // Size is a multiple of a word (4) and alignment is 1, so neither the size
+    // check nor the type-alignment check rejects it — only the word-offset check
+    // can. This isolates the offset check that `BytePair` (size 2) would never
+    // reach, since the size check rejects it first.
+    #[repr(C)]
+    #[derive(Debug, PartialEq, Eq)]
+    struct FourBytes([u8; 4]);
+
+    #[test]
+    fn read_struct_rejects_offsets_not_aligned_to_words() {
+        let mut memory = TestMemorySource::default();
+        memory.insert_u32(0, 0xdead_beef);
+
+        let result = unsafe { read_struct::<FourBytes>(&memory, 2) };
+        assert_eq!(result, Err(()));
+    }
+
+    #[test]
+    fn read_struct_rejects_sizes_not_multiple_of_word() {
+        let mut memory = TestMemorySource::default();
+        memory.insert_u32(0, 0xdead_beef);
+
+        let result = unsafe { read_struct::<BytePair>(&memory, 0) };
+        assert_eq!(result, Err(()));
+    }
+
+    #[test]
+    fn read_struct_reads_word_aligned_values() {
+        let mut memory = TestMemorySource::default();
+        memory.insert_u32(0, 0xdead_beef);
+
+        let value = unsafe { read_struct::<PackedWord>(&memory, 0) }.unwrap();
+        assert_eq!(value, PackedWord(0xdead_beef));
+    }
 }

--- a/callable_oracles/src/utils/evaluate.rs
+++ b/callable_oracles/src/utils/evaluate.rs
@@ -77,9 +77,7 @@ pub unsafe fn read_struct<T>(memory: &dyn RamPeek, offset: u32) -> Result<T, ()>
         return Err(());
     }
 
-    if !offset.is_multiple_of(4)
-        || !(offset as usize).is_multiple_of(core::mem::align_of::<T>())
-    {
+    if !offset.is_multiple_of(4) || !(offset as usize).is_multiple_of(core::mem::align_of::<T>()) {
         return Err(());
     }
 

--- a/callable_oracles/src/utils/evaluate.rs
+++ b/callable_oracles/src/utils/evaluate.rs
@@ -73,7 +73,8 @@ pub fn read_memory_as_u64(
 /// # Safety
 /// The data in the memory at offset should actually be T.
 pub unsafe fn read_struct<T>(memory: &dyn RamPeek, offset: u32) -> Result<T, ()> {
-    if !core::mem::size_of::<T>().is_multiple_of(4) {
+    let size = core::mem::size_of::<T>();
+    if !size.is_multiple_of(4) {
         return Err(());
     }
 
@@ -81,14 +82,26 @@ pub unsafe fn read_struct<T>(memory: &dyn RamPeek, offset: u32) -> Result<T, ()>
         return Err(());
     }
 
+    // Words are read at `offset, offset + 4, ..., offset + size - 4`. Reject
+    // pointers near the top of the address space so this arithmetic cannot
+    // overflow `u32` — which would otherwise panic in debug builds and wrap
+    // into low memory in release builds. Mirrors the up-front overflow checks
+    // in `read_memory_as_u8`/`read_memory_as_u64`.
+    let size_u32 = u32::try_from(size).map_err(|_| ())?;
+    if offset.checked_add(size_u32).is_none() {
+        return Err(());
+    }
+
     let mut r = MaybeUninit::<T>::uninit();
 
     let ptr = r.as_mut_ptr();
 
-    for i in (0..core::mem::size_of::<T>()).step_by(4) {
+    for i in (0..size).step_by(4) {
         let v = memory.peek_word(offset + i as u32);
 
-        // Safety: iterating over size of T, add will not overflow.
+        // Safety: `i < size` and `offset + size` fits in `u32` (checked above),
+        // so `offset + i` cannot overflow. The destination write stays within
+        // the `size / 4` words of the allocated `T`.
         unsafe { ptr.cast::<u32>().add(i / 4).write(v) };
     }
 
@@ -116,6 +129,22 @@ mod tests {
     #[repr(C)]
     #[derive(Debug, PartialEq, Eq)]
     struct FourBytes([u8; 4]);
+
+    // A multi-word struct whose size and alignment checks both pass, so only
+    // the address-space overflow guard can reject a near-top-of-memory pointer.
+    #[repr(C)]
+    #[derive(Debug, PartialEq, Eq)]
+    struct TwoWords(u32, u32);
+
+    #[test]
+    fn read_struct_rejects_offset_overflowing_address_space() {
+        let memory = TestMemorySource::default();
+
+        // 0xffff_fffc is word-aligned and passes every other check, but reading
+        // the second word would compute 0xffff_fffc + 4 and overflow `u32`.
+        let result = unsafe { read_struct::<TwoWords>(&memory, 0xffff_fffc) };
+        assert_eq!(result, Err(()));
+    }
 
     #[test]
     fn read_struct_rejects_offsets_not_aligned_to_words() {

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,11 @@
 [advisories]
 ignore = [
-    # Pulled in transitively via `inferno` in Airbender flamegraph/diagnostic
-    # tooling. `inferno 0.12.x` pins `quick-xml = "0.39"`, so lifting these
-    # requires an upstream dependency update rather than a local lockfile bump.
+    # quick-xml < 0.41 memory-exhaustion / quadratic-parse advisories. Pulled in
+    # only transitively by `inferno` (flamegraph SVG rendering) via the
+    # git-pinned `riscv_transpiler`, whose `inferno = "^0.12"` in turn pins
+    # `quick-xml = "^0.39"`, so it cannot be bumped without moving those git
+    # revs. It is host-side benchmarking/test tooling that never parses
+    # untrusted XML and is not part of the proving runtime.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
 ]

--- a/evm_interpreter/src/instructions/environment.rs
+++ b/evm_interpreter/src/instructions/environment.rs
@@ -68,7 +68,7 @@ impl<S: EthereumLikeTypes> Interpreter<'_, S> {
     pub fn origin(&mut self, system: &mut System<S>) -> InstructionResult {
         #[cfg(feature = "eip-7645")]
         {
-            self.gas.spend_gas_and_native(0, ORIGIN_NATIVE_COST)?;
+            let _ = system;
             return self.caller();
         }
 

--- a/tests/instances/transactions/src/storage_charging.rs
+++ b/tests/instances/transactions/src/storage_charging.rs
@@ -585,15 +585,22 @@ fn test_noop_sstore_does_not_discount_next_write() {
     assert!(result_b.is_success(), "single write should succeed");
 
     // The no-op SSTORE should not have discounted the real write.
-    // Both pay cold write extra. native_a is strictly more because the
-    // no-op SSTORE's materialize warms the slot, so the real SSTORE's
-    // materialize pays only a warm read (strictly positive cost).
+    // Both pay cold write extra for the real write. The no-op itself still
+    // updates the cache, so it must add at least one warm read plus one warm
+    // storage-cache write on top of the baseline single write.
     assert!(
         result_a.computational_native_used > result_b.computational_native_used,
         "No-op SSTORE + real SSTORE (native={}) should cost strictly more than \
          single SSTORE (native={}) — no-op adds warm read but must not discount write",
         result_a.computational_native_used,
         result_b.computational_native_used
+    );
+    let extra_native = result_a.computational_native_used - result_b.computational_native_used;
+    let expected_min_extra = WARM_STORAGE_READ_NATIVE_COST + WARM_STORAGE_WRITE_EXTRA_NATIVE_COST;
+    assert!(
+        extra_native >= expected_min_extra,
+        "Expected at least {expected_min_extra} extra native from the no-op SSTORE \
+         cache update, but only observed {extra_native}"
     );
 }
 

--- a/zksync_os/Cargo.lock
+++ b/zksync_os/Cargo.lock
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What ❔

This PR addresses the validated report findings on `draft-0.4.0`.

- fix `MODEXP` resource exhaustion error mapping ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/7abbfb6a533cff94e7f4501e4413065aa70f4473))
- align intrinsic bootloader accounting for authorization pubdata and blob versioned hashes ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/5bb11b80c0f10db773bf69fe4d3fdd43a7414a44))
- charge native for zk receipt hashing ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/20dc22963e011f26cb637ff1462748b1add90aaa))
- allow zero native price in API intrinsic validation ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/8033b8824fbdb0b99f2802e3a19a0f7c0a1bea10))
- charge `MODEXP` initial reduction native cost ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/fd6fce93f2c5fe476e34085383e74ae6108bff9c))
- require word aligned callable oracle struct reads ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/a5010bf00c74acad7a7125d39106396b1b41120e))
- avoid double native charge for `ORIGIN` under `eip-7645` ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/d19110162bce96d71d0a0d2faf5e35aa5d765767))
- charge no-op account and storage cache writes at the warm write rate ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/dc998e26b9e41d1cbd631c4bc7e7a77612de6c48))
- reject malformed BLS12-381 inputs before charging ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/99e60c19f8fa9c5c421011ab9d98334b3ad0cb2c))
- include L1 calldata copy in intrinsic-native verification accounting ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/c090ec685c16a59087de846a8d8996e532d25e49))
- format the touched files after the fixes ([commit](https://github.com/antoniolocascio-bot/zksync-os/commit/a21764e46db2eb148480fac2419bc932a7f87c2b))

## Why ❔

These are the findings from the report set that were validated as real implementation issues rather than pricing policy disagreements or expected behavior. The fixes are intentionally narrow, and regression coverage was added or updated where practical, including for the intrinsic-native verification path used to catch underestimates during development.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted.
