### PR TITLE
feat: atomic interop changes

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -1,5 +1,7 @@
 use super::post_tx_op::da_commitment_generator::DACommitmentGenerator;
-use crate::bootloader::block_flow::zk::post_tx_op::calculate_interop_roots_rolling_hash;
+use crate::bootloader::block_flow::zk::post_tx_op::{
+    calculate_interop_roots_rolling_hash, compute_chain_batch_root,
+};
 use crate::bootloader::block_flow::zk::post_tx_op::public_input::{BatchOutput, BatchPublicInput};
 use crate::bootloader::block_flow::{TransactionsRollingKeccakHasher, TxHashesAccumulator};
 use arrayvec::ArrayVec;
@@ -43,6 +45,10 @@ pub struct ZKBatchDataKeeper<A: alloc::alloc::Allocator, O: IOOracle> {
     multichain_root: Bytes32,
     interop_roots_rolling_hash: Bytes32,
     settlement_layer_chain_id: Option<U256>,
+    // Interop commitment tree (IMT) root snapshots committed into the chain batch root. `begin` is the
+    // root before the batch's first block ran; `end` is the root after the latest applied block.
+    commitment_tree_root_begin: Bytes32,
+    commitment_tree_root_end: Bytes32,
 }
 
 impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
@@ -65,6 +71,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
             multichain_root: Bytes32::zero(),
             interop_roots_rolling_hash: Bytes32::ZERO,
             settlement_layer_chain_id: None,
+            commitment_tree_root_begin: Bytes32::zero(),
+            commitment_tree_root_end: Bytes32::zero(),
         }
     }
 
@@ -90,6 +98,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
         interop_roots: impl Iterator<Item = &'a InteropRoot>,
         settlement_layer_chain_id: U256,
         number_of_txs_in_block: u32,
+        commitment_tree_root_begin: Bytes32,
+        commitment_tree_root_end: Bytes32,
     ) {
         if self.is_first_block {
             self.initial_state_commitment = Some(state_commitment_before);
@@ -100,6 +110,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
             self.chain_config = Some(chain_config);
             self.upgrade_tx_hash = Some(upgrade_tx_hash);
             self.settlement_layer_chain_id = Some(settlement_layer_chain_id);
+            // Only the first block's begin root is the batch-begin root.
+            self.commitment_tree_root_begin = commitment_tree_root_begin;
             self.is_first_block = false;
         } else {
             assert_eq!(
@@ -123,6 +135,8 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
         }
         // we always override multichain root with latest
         self.multichain_root = multichain_root;
+        // likewise the batch-end commitment tree root is always the latest applied block's end root
+        self.commitment_tree_root_end = commitment_tree_root_end;
 
         self.tx_count += U256::from(number_of_txs_in_block);
 
@@ -164,10 +178,15 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
         assert!(!self.is_first_block);
         let has_upgrade_tx = self.has_upgrade_tx();
 
-        let mut chain_batch_root_hasher = crypto::sha3::Keccak256::new();
-        chain_batch_root_hasher.update(Self::l2_logs_root(self.logs_storage).as_u8_ref());
-        chain_batch_root_hasher.update(self.multichain_root.as_u8_ref());
-        let chain_batch_root = chain_batch_root_hasher.finalize();
+        // Chain batch root: a fixed height-3 (8-leaf) keccak Merkle tree. The IMT roots at the batch
+        // boundaries sit in dedicated leaves so a consumer can authenticate an IMT root against the
+        // chain batch root with a few hashes. See `compute_chain_batch_root` for the leaf layout.
+        let chain_batch_root = compute_chain_batch_root(
+            Self::l2_logs_root(self.logs_storage),
+            self.multichain_root,
+            self.commitment_tree_root_begin,
+            self.commitment_tree_root_end,
+        );
 
         let (priority_operations_hash, number_of_layer_1_txs) =
             self.enforced_txs_accumulator.finish();
@@ -187,7 +206,7 @@ impl<A: alloc::alloc::Allocator, O: IOOracle> ZKBatchDataKeeper<A, O> {
             number_of_layer_1_txs,
             number_of_layer_2_txs,
             priority_operations_hash,
-            l2_logs_tree_root: chain_batch_root.into(),
+            l2_logs_tree_root: chain_batch_root,
             upgrade_tx_hash: self.upgrade_tx_hash.unwrap(),
             interop_roots_rolling_hash: self.interop_roots_rolling_hash,
             settlement_layer_chain_id: self.settlement_layer_chain_id.unwrap(),
@@ -314,6 +333,8 @@ mod tests {
             core::iter::empty(),
             U256::from(1u64),
             0,
+            Bytes32::ZERO,
+            Bytes32::ZERO,
         );
 
         // Second block continues the state chain but carries a different config.
@@ -328,6 +349,8 @@ mod tests {
             core::iter::empty(),
             U256::from(1u64),
             0,
+            Bytes32::ZERO,
+            Bytes32::ZERO,
         );
     }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/batch_data.rs
@@ -1,8 +1,8 @@
 use super::post_tx_op::da_commitment_generator::DACommitmentGenerator;
+use crate::bootloader::block_flow::zk::post_tx_op::public_input::{BatchOutput, BatchPublicInput};
 use crate::bootloader::block_flow::zk::post_tx_op::{
     calculate_interop_roots_rolling_hash, compute_chain_batch_root,
 };
-use crate::bootloader::block_flow::zk::post_tx_op::public_input::{BatchOutput, BatchPublicInput};
 use crate::bootloader::block_flow::{TransactionsRollingKeccakHasher, TxHashesAccumulator};
 use arrayvec::ArrayVec;
 use basic_system::system_implementation::flat_storage_model::{FlatStorageCommitment, TREE_HEIGHT};

--- a/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
@@ -258,7 +258,10 @@ impl<EA: TxHashesAccumulator + core::fmt::Debug, A: Allocator + Clone + Default>
                 &self.block_computational_native_used,
             )
             .field("block_blob_gas_used", &self.block_blob_gas_used)
-            .field("commitment_tree_root_begin", &self.commitment_tree_root_begin)
+            .field(
+                "commitment_tree_root_begin",
+                &self.commitment_tree_root_begin,
+            )
             .finish()
     }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/block_data.rs
@@ -227,6 +227,10 @@ pub struct ZKBasicBlockDataKeeper<EA: TxHashesAccumulator, A: Allocator + Clone 
     pub block_computational_native_used: u64,
     /// Amount of blob gas used in the block
     pub block_blob_gas_used: u64,
+    /// Interop commitment tree (IMT) root snapshot taken before this block's transactions ran.
+    /// For the first block of a batch this is the batch-begin root, which the batch data keeper
+    /// commits into the chain batch root. Read from L2InteropCommitmentTree(0x10012) in `pre_op`.
+    pub commitment_tree_root_begin: Bytes32,
 }
 
 // Manual `Debug` (like `EthereumBasicTransactionDataKeeper`) so the allocator
@@ -254,6 +258,7 @@ impl<EA: TxHashesAccumulator + core::fmt::Debug, A: Allocator + Clone + Default>
                 &self.block_computational_native_used,
             )
             .field("block_blob_gas_used", &self.block_blob_gas_used)
+            .field("commitment_tree_root_begin", &self.commitment_tree_root_begin)
             .finish()
     }
 }
@@ -272,6 +277,7 @@ impl<EA: TxHashesAccumulator, A: Allocator + Clone + Default> ZKBasicBlockDataKe
             block_pubdata_used: 0,
             block_computational_native_used: 0,
             block_blob_gas_used: 0,
+            commitment_tree_root_begin: Bytes32::ZERO,
         }
     }
 

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -9,6 +9,7 @@ use system_hooks::addresses_constants::{
     L2_INTEROP_COMMITMENT_TREE_ADDRESS, MESSAGE_ROOT_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
 };
 use zk_ee::common_structs::interop_root_storage::InteropRoot;
+use zk_ee::common_structs::merkle_root_in_place;
 use zk_ee::memory::stack_trait::StackFactory;
 use zk_ee::oracle::IOOracle;
 use zk_ee::system::{IOSubsystem, Resource, Resources};
@@ -132,8 +133,31 @@ pub fn calculate_interop_roots_rolling_hash<'a>(
     rolling_hash
 }
 
-/// Number of leaves in the chain batch root Merkle tree (fixed height-3 tree = 8 leaves).
-pub const CHAIN_BATCH_ROOT_TREE_LEAVES: usize = 8;
+/// Height of the chain batch root Merkle tree (capacity `2^3 == 8` leaves): four live commitment
+/// leaves followed by four reserved (zero) leaves.
+pub const CHAIN_BATCH_ROOT_TREE_HEIGHT: usize = 3;
+
+/// Empty-subtree hashes for the chain batch root tree, where entry `i` is the root of an empty
+/// subtree of height `i`. The empty (reserved) leaf is `Bytes32::ZERO` and each level doubles up:
+/// `entry[i] = keccak256(entry[i - 1] || entry[i - 1])`.
+const CHAIN_BATCH_ROOT_EMPTY_SUBTREE_HASHES: [[u8; 32]; CHAIN_BATCH_ROOT_TREE_HEIGHT + 1] = [
+    [0u8; 32],
+    [
+        0xad, 0x32, 0x28, 0xb6, 0x76, 0xf7, 0xd3, 0xcd, 0x42, 0x84, 0xa5, 0x44, 0x3f, 0x17, 0xf1,
+        0x96, 0x2b, 0x36, 0xe4, 0x91, 0xb3, 0x0a, 0x40, 0xb2, 0x40, 0x58, 0x49, 0xe5, 0x97, 0xba,
+        0x5f, 0xb5,
+    ],
+    [
+        0xb4, 0xc1, 0x19, 0x51, 0x95, 0x7c, 0x6f, 0x8f, 0x64, 0x2c, 0x4a, 0xf6, 0x1c, 0xd6, 0xb2,
+        0x46, 0x40, 0xfe, 0xc6, 0xdc, 0x7f, 0xc6, 0x07, 0xee, 0x82, 0x06, 0xa9, 0x9e, 0x92, 0x41,
+        0x0d, 0x30,
+    ],
+    [
+        0x21, 0xdd, 0xb9, 0xa3, 0x56, 0x81, 0x5c, 0x3f, 0xac, 0x10, 0x26, 0xb6, 0xde, 0xc5, 0xdf,
+        0x31, 0x24, 0xaf, 0xba, 0xdb, 0x48, 0x5c, 0x9b, 0xa5, 0xa3, 0xe3, 0x39, 0x8a, 0x04, 0xb7,
+        0xba, 0x85,
+    ],
+];
 
 /// Builds the chain batch root as a fixed height-3 (8-leaf) keccak256 Merkle tree.
 ///
@@ -144,43 +168,20 @@ pub const CHAIN_BATCH_ROOT_TREE_LEAVES: usize = 8;
 ///   3: interop commitment tree (IMT) root at batch end
 ///   4..8: reserved (`Bytes32::ZERO`)
 ///
-/// Internal nodes are `keccak256(left || right)`; leaves are used directly (no separate leaf-hashing
-/// step), matching the existing `l2_logs_root` tree. Because the whole right subtree is zero, this is
-/// equivalent to the canonical empty-subtree convention with a zero empty leaf, so reserved leaves can
-/// later be populated in place without changing the shape.
 pub fn compute_chain_batch_root(
     l2_logs_root: Bytes32,
     multichain_root: Bytes32,
     commitment_tree_root_begin: Bytes32,
     commitment_tree_root_end: Bytes32,
 ) -> Bytes32 {
-    let mut nodes = [
+    let mut leaves = [
         l2_logs_root,
         multichain_root,
         commitment_tree_root_begin,
         commitment_tree_root_end,
-        Bytes32::ZERO,
-        Bytes32::ZERO,
-        Bytes32::ZERO,
-        Bytes32::ZERO,
     ];
-
-    // Reduce level by level in place: 8 -> 4 -> 2 -> 1. Node `i` of the next level hashes children
-    // `2*i` and `2*i + 1`; the write index is always below the read indices, so no live value is
-    // clobbered before it is consumed.
-    let mut width = CHAIN_BATCH_ROOT_TREE_LEAVES;
-    while width > 1 {
-        let half = width / 2;
-        for i in 0..half {
-            let mut hasher = crypto::sha3::Keccak256::new();
-            hasher.update(nodes[2 * i].as_u8_ref());
-            hasher.update(nodes[2 * i + 1].as_u8_ref());
-            nodes[i] = Bytes32::from_array(hasher.finalize());
-        }
-        width = half;
-    }
-
-    nodes[0]
+    let empty_subtree_hashes = CHAIN_BATCH_ROOT_EMPTY_SUBTREE_HASHES.map(Bytes32::from_array);
+    merkle_root_in_place::<crypto::sha3::Keccak256>(&mut leaves, &empty_subtree_hashes)
 }
 
 ///
@@ -274,10 +275,7 @@ const COMMITMENT_TREE_CURRENT_ROOT_SLOT: [u8; 32] = [0u8; 32];
 /// on every insert. On a chain that does not have the tree deployed (or before seeding) the read
 /// returns zero, so this yields `Bytes32::zero()`.
 ///
-/// Generic over the IO subsystem (like `read_settlement_layer_chain_id`) so it can be called both
-/// before the tx loop (batch-begin snapshot) and after it (batch-end snapshot).
-///
-pub fn read_commitment_tree_root<IO: IOSubsystem>(io: &mut IO) -> Bytes32
+pub fn read_interop_commitment_tree_root<IO: IOSubsystem>(io: &mut IO) -> Bytes32
 where
     IO::IOTypes: SystemIOTypesConfig<Address = B160, StorageKey = Bytes32, StorageValue = Bytes32>,
 {
@@ -425,6 +423,20 @@ mod tests {
         let expected = node(&l2[0], &l2[1]);
 
         assert_eq!(compute_chain_batch_root(a, b, c, d), expected);
+    }
+
+    #[test]
+    fn chain_batch_root_empty_hashes_match_recurrence() {
+        // Locks the hardcoded table: the empty-subtree recurrence over the zero leaf
+        // (`entry[i] = keccak256(entry[i - 1] || entry[i - 1])`) must reproduce it.
+        let mut prev = Bytes32::ZERO;
+        for entry in CHAIN_BATCH_ROOT_EMPTY_SUBTREE_HASHES {
+            assert_eq!(Bytes32::from_array(entry), prev);
+            let mut h = crypto::sha3::Keccak256::new();
+            h.update(prev.as_u8_ref());
+            h.update(prev.as_u8_ref());
+            prev = Bytes32::from_array(h.finalize());
+        }
     }
 
     #[test]

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -261,31 +261,18 @@ pub fn read_multichain_root<
     .expect("must read MessageRoot multichain root")
 }
 
-/// Fixed depth of the interop commitment tree's Indexed Merkle Tree. Mirrors `IMT_DEPTH` in
-/// `l1-contracts/contracts/common/libraries/IndexedMerkleTree.sol`.
-const INTEROP_COMMITMENT_TREE_IMT_DEPTH: u8 = 32;
-
-/// Storage slot of `_imt.nodes[IMT_DEPTH][0]` — the interop commitment tree's root node — in the
-/// L2InteropCommitmentTree(0x10012) contract.
-///
-/// Derived from the Solidity storage layout (verified with `forge inspect`): `_imt` sits at slot 0;
-/// inside `struct IMT` the `bytes32[IMT_DEPTH + 1] zeros` array occupies slots `0..=IMT_DEPTH`, so the
-/// `mapping(uint256 => mapping(uint256 => bytes32)) nodes` base slot is `IMT_DEPTH + 1` (= 33). For a
-/// nested mapping: `inner = keccak256(pad32(IMT_DEPTH) || pad32(33))`, then
-/// `slot = keccak256(pad32(0) || inner)`. Locked against the formula by
-/// `commitment_tree_root_slot_matches_layout` below.
-const COMMITMENT_TREE_ROOT_NODE_SLOT: [u8; 32] = [
-    0xf7, 0x00, 0x9d, 0x13, 0x71, 0x93, 0xf8, 0x68, 0x7e, 0x15, 0x07, 0x32, 0x6b, 0x04, 0x75, 0xde,
-    0xd1, 0xa0, 0xd0, 0x9a, 0xa4, 0xd4, 0x61, 0x6a, 0xc9, 0xb1, 0x95, 0xb2, 0xfb, 0x33, 0x3f, 0x81,
-];
+/// Storage slot of `_currentRoot` in the L2InteropCommitmentTree(0x10012) contract: **fixed slot 0**,
+/// a deliberate, consensus-critical storage ABI (see `L2InteropCommitmentTree.sol`). The contract
+/// caches its root there on every insert precisely because the underlying dynamic-height engine has
+/// no fixed root slot.
+const COMMITMENT_TREE_CURRENT_ROOT_SLOT: [u8; 32] = [0u8; 32];
 
 ///
 /// Reads the interop commitment tree root from the L2InteropCommitmentTree(0x10012) contract.
 ///
-/// Returns `_imt.nodes[IMT_DEPTH][0]` (the tree root node). When that node has not been written yet —
-/// an empty / freshly-seeded tree — it falls back to `_imt.zeros[IMT_DEPTH]` (the last element of the
-/// `zeros` array, at slot `IMT_DEPTH`), exactly mirroring `IndexedMerkleTreeLib.root`. On a chain that
-/// does not have the tree deployed the reads return zero, so this yields `Bytes32::zero()`.
+/// Returns the `_currentRoot` cache (slot 0), which the contract seeds in `initialize` and refreshes
+/// on every insert. On a chain that does not have the tree deployed (or before seeding) the read
+/// returns zero, so this yields `Bytes32::zero()`.
 ///
 /// Generic over the IO subsystem (like `read_settlement_layer_chain_id`) so it can be called both
 /// before the tx loop (batch-begin snapshot) and after it (batch-end snapshot).
@@ -296,31 +283,13 @@ where
 {
     let mut inf_resources = IO::Resources::FORMAL_INFINITE;
 
-    let root_node = io
-        .storage_read::<false>(
-            ExecutionEnvironmentType::NoEE,
-            &mut inf_resources,
-            &L2_INTEROP_COMMITMENT_TREE_ADDRESS,
-            &Bytes32::from_array(COMMITMENT_TREE_ROOT_NODE_SLOT),
-        )
-        .expect("must read InteropCommitmentTree root node");
-
-    if !root_node.is_zero() {
-        return root_node;
-    }
-
-    // Empty / freshly-seeded tree: the top node is unwritten, so the canonical root is
-    // `zeros[IMT_DEPTH]`, stored at slot `IMT_DEPTH` (last element of `bytes32[IMT_DEPTH + 1] zeros`,
-    // which starts at slot 0).
-    let mut zeros_root_slot = [0u8; 32];
-    zeros_root_slot[31] = INTEROP_COMMITMENT_TREE_IMT_DEPTH;
     io.storage_read::<false>(
         ExecutionEnvironmentType::NoEE,
         &mut inf_resources,
         &L2_INTEROP_COMMITMENT_TREE_ADDRESS,
-        &Bytes32::from_array(zeros_root_slot),
+        &Bytes32::from_array(COMMITMENT_TREE_CURRENT_ROOT_SLOT),
     )
-    .expect("must read InteropCommitmentTree zeros root")
+    .expect("must read InteropCommitmentTree current root")
 }
 
 ///
@@ -432,39 +401,6 @@ mod tests {
             root_slot.as_u8_array().to_vec(),
             hex::decode("35817d789b7a6dbe8b95b0f21e189fb26d3d329de699cac7a267a9568298e0a5")
                 .unwrap()
-        );
-    }
-
-    /// Recomputes the interop-commitment-tree root slot from the storage layout and locks the
-    /// hardcoded `COMMITMENT_TREE_ROOT_NODE_SLOT` against it. `_imt` is at slot 0; `IMT.zeros` is
-    /// `bytes32[IMT_DEPTH + 1]` occupying slots `0..=IMT_DEPTH`, so the `nodes` mapping base slot is
-    /// `IMT_DEPTH + 1`. Then `nodes[IMT_DEPTH][0]` follows the nested-mapping rule.
-    fn calculate_commitment_tree_root_slot() -> [u8; 32] {
-        let nodes_base_slot = INTEROP_COMMITMENT_TREE_IMT_DEPTH + 1;
-
-        let mut level = [0u8; 32];
-        level[31] = INTEROP_COMMITMENT_TREE_IMT_DEPTH;
-        let mut base = [0u8; 32];
-        base[31] = nodes_base_slot;
-        // inner mapping slot: keccak256(pad32(IMT_DEPTH) || pad32(nodes_base_slot))
-        let mut hasher = crypto::sha3::Keccak256::new();
-        hasher.update(level);
-        hasher.update(base);
-        let inner = hasher.finalize();
-
-        // element [0] of the inner mapping: keccak256(pad32(0) || inner)
-        let index = [0u8; 32];
-        let mut hasher = crypto::sha3::Keccak256::new();
-        hasher.update(index);
-        hasher.update(inner);
-        hasher.finalize()
-    }
-
-    #[test]
-    fn commitment_tree_root_slot_matches_layout() {
-        assert_eq!(
-            calculate_commitment_tree_root_slot(),
-            COMMITMENT_TREE_ROOT_NODE_SLOT
         );
     }
 

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/mod.rs
@@ -5,7 +5,9 @@ use basic_system::system_implementation::system::FullIO;
 use core::alloc::Allocator;
 use crypto::MiniDigest;
 use ruint::aliases::{B160, U256};
-use system_hooks::addresses_constants::{MESSAGE_ROOT_ADDRESS, SYSTEM_CONTEXT_ADDRESS};
+use system_hooks::addresses_constants::{
+    L2_INTEROP_COMMITMENT_TREE_ADDRESS, MESSAGE_ROOT_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+};
 use zk_ee::common_structs::interop_root_storage::InteropRoot;
 use zk_ee::memory::stack_trait::StackFactory;
 use zk_ee::oracle::IOOracle;
@@ -130,6 +132,57 @@ pub fn calculate_interop_roots_rolling_hash<'a>(
     rolling_hash
 }
 
+/// Number of leaves in the chain batch root Merkle tree (fixed height-3 tree = 8 leaves).
+pub const CHAIN_BATCH_ROOT_TREE_LEAVES: usize = 8;
+
+/// Builds the chain batch root as a fixed height-3 (8-leaf) keccak256 Merkle tree.
+///
+/// Leaf layout — the first four carry the live commitments, the last four are reserved (zero) for now:
+///   0: l2 logs root
+///   1: multichain root
+///   2: interop commitment tree (IMT) root at batch begin
+///   3: interop commitment tree (IMT) root at batch end
+///   4..8: reserved (`Bytes32::ZERO`)
+///
+/// Internal nodes are `keccak256(left || right)`; leaves are used directly (no separate leaf-hashing
+/// step), matching the existing `l2_logs_root` tree. Because the whole right subtree is zero, this is
+/// equivalent to the canonical empty-subtree convention with a zero empty leaf, so reserved leaves can
+/// later be populated in place without changing the shape.
+pub fn compute_chain_batch_root(
+    l2_logs_root: Bytes32,
+    multichain_root: Bytes32,
+    commitment_tree_root_begin: Bytes32,
+    commitment_tree_root_end: Bytes32,
+) -> Bytes32 {
+    let mut nodes = [
+        l2_logs_root,
+        multichain_root,
+        commitment_tree_root_begin,
+        commitment_tree_root_end,
+        Bytes32::ZERO,
+        Bytes32::ZERO,
+        Bytes32::ZERO,
+        Bytes32::ZERO,
+    ];
+
+    // Reduce level by level in place: 8 -> 4 -> 2 -> 1. Node `i` of the next level hashes children
+    // `2*i` and `2*i + 1`; the write index is always below the read indices, so no live value is
+    // clobbered before it is consumed.
+    let mut width = CHAIN_BATCH_ROOT_TREE_LEAVES;
+    while width > 1 {
+        let half = width / 2;
+        for i in 0..half {
+            let mut hasher = crypto::sha3::Keccak256::new();
+            hasher.update(nodes[2 * i].as_u8_ref());
+            hasher.update(nodes[2 * i + 1].as_u8_ref());
+            nodes[i] = Bytes32::from_array(hasher.finalize());
+        }
+        width = half;
+    }
+
+    nodes[0]
+}
+
 ///
 /// Reads SL chain id from the SystemContext(0x800b) contract.
 ///
@@ -206,6 +259,68 @@ pub fn read_multichain_root<
         &root_slot,
     )
     .expect("must read MessageRoot multichain root")
+}
+
+/// Fixed depth of the interop commitment tree's Indexed Merkle Tree. Mirrors `IMT_DEPTH` in
+/// `l1-contracts/contracts/common/libraries/IndexedMerkleTree.sol`.
+const INTEROP_COMMITMENT_TREE_IMT_DEPTH: u8 = 32;
+
+/// Storage slot of `_imt.nodes[IMT_DEPTH][0]` — the interop commitment tree's root node — in the
+/// L2InteropCommitmentTree(0x10012) contract.
+///
+/// Derived from the Solidity storage layout (verified with `forge inspect`): `_imt` sits at slot 0;
+/// inside `struct IMT` the `bytes32[IMT_DEPTH + 1] zeros` array occupies slots `0..=IMT_DEPTH`, so the
+/// `mapping(uint256 => mapping(uint256 => bytes32)) nodes` base slot is `IMT_DEPTH + 1` (= 33). For a
+/// nested mapping: `inner = keccak256(pad32(IMT_DEPTH) || pad32(33))`, then
+/// `slot = keccak256(pad32(0) || inner)`. Locked against the formula by
+/// `commitment_tree_root_slot_matches_layout` below.
+const COMMITMENT_TREE_ROOT_NODE_SLOT: [u8; 32] = [
+    0xf7, 0x00, 0x9d, 0x13, 0x71, 0x93, 0xf8, 0x68, 0x7e, 0x15, 0x07, 0x32, 0x6b, 0x04, 0x75, 0xde,
+    0xd1, 0xa0, 0xd0, 0x9a, 0xa4, 0xd4, 0x61, 0x6a, 0xc9, 0xb1, 0x95, 0xb2, 0xfb, 0x33, 0x3f, 0x81,
+];
+
+///
+/// Reads the interop commitment tree root from the L2InteropCommitmentTree(0x10012) contract.
+///
+/// Returns `_imt.nodes[IMT_DEPTH][0]` (the tree root node). When that node has not been written yet —
+/// an empty / freshly-seeded tree — it falls back to `_imt.zeros[IMT_DEPTH]` (the last element of the
+/// `zeros` array, at slot `IMT_DEPTH`), exactly mirroring `IndexedMerkleTreeLib.root`. On a chain that
+/// does not have the tree deployed the reads return zero, so this yields `Bytes32::zero()`.
+///
+/// Generic over the IO subsystem (like `read_settlement_layer_chain_id`) so it can be called both
+/// before the tx loop (batch-begin snapshot) and after it (batch-end snapshot).
+///
+pub fn read_commitment_tree_root<IO: IOSubsystem>(io: &mut IO) -> Bytes32
+where
+    IO::IOTypes: SystemIOTypesConfig<Address = B160, StorageKey = Bytes32, StorageValue = Bytes32>,
+{
+    let mut inf_resources = IO::Resources::FORMAL_INFINITE;
+
+    let root_node = io
+        .storage_read::<false>(
+            ExecutionEnvironmentType::NoEE,
+            &mut inf_resources,
+            &L2_INTEROP_COMMITMENT_TREE_ADDRESS,
+            &Bytes32::from_array(COMMITMENT_TREE_ROOT_NODE_SLOT),
+        )
+        .expect("must read InteropCommitmentTree root node");
+
+    if !root_node.is_zero() {
+        return root_node;
+    }
+
+    // Empty / freshly-seeded tree: the top node is unwritten, so the canonical root is
+    // `zeros[IMT_DEPTH]`, stored at slot `IMT_DEPTH` (last element of `bytes32[IMT_DEPTH + 1] zeros`,
+    // which starts at slot 0).
+    let mut zeros_root_slot = [0u8; 32];
+    zeros_root_slot[31] = INTEROP_COMMITMENT_TREE_IMT_DEPTH;
+    io.storage_read::<false>(
+        ExecutionEnvironmentType::NoEE,
+        &mut inf_resources,
+        &L2_INTEROP_COMMITMENT_TREE_ADDRESS,
+        &Bytes32::from_array(zeros_root_slot),
+    )
+    .expect("must read InteropCommitmentTree zeros root")
 }
 
 ///
@@ -318,5 +433,68 @@ mod tests {
             hex::decode("35817d789b7a6dbe8b95b0f21e189fb26d3d329de699cac7a267a9568298e0a5")
                 .unwrap()
         );
+    }
+
+    /// Recomputes the interop-commitment-tree root slot from the storage layout and locks the
+    /// hardcoded `COMMITMENT_TREE_ROOT_NODE_SLOT` against it. `_imt` is at slot 0; `IMT.zeros` is
+    /// `bytes32[IMT_DEPTH + 1]` occupying slots `0..=IMT_DEPTH`, so the `nodes` mapping base slot is
+    /// `IMT_DEPTH + 1`. Then `nodes[IMT_DEPTH][0]` follows the nested-mapping rule.
+    fn calculate_commitment_tree_root_slot() -> [u8; 32] {
+        let nodes_base_slot = INTEROP_COMMITMENT_TREE_IMT_DEPTH + 1;
+
+        let mut level = [0u8; 32];
+        level[31] = INTEROP_COMMITMENT_TREE_IMT_DEPTH;
+        let mut base = [0u8; 32];
+        base[31] = nodes_base_slot;
+        // inner mapping slot: keccak256(pad32(IMT_DEPTH) || pad32(nodes_base_slot))
+        let mut hasher = crypto::sha3::Keccak256::new();
+        hasher.update(level);
+        hasher.update(base);
+        let inner = hasher.finalize();
+
+        // element [0] of the inner mapping: keccak256(pad32(0) || inner)
+        let index = [0u8; 32];
+        let mut hasher = crypto::sha3::Keccak256::new();
+        hasher.update(index);
+        hasher.update(inner);
+        hasher.finalize()
+    }
+
+    #[test]
+    fn commitment_tree_root_slot_matches_layout() {
+        assert_eq!(
+            calculate_commitment_tree_root_slot(),
+            COMMITMENT_TREE_ROOT_NODE_SLOT
+        );
+    }
+
+    #[test]
+    fn chain_batch_root_is_height3_merkle() {
+        fn node(a: &Bytes32, b: &Bytes32) -> Bytes32 {
+            let mut h = crypto::sha3::Keccak256::new();
+            h.update(a.as_u8_ref());
+            h.update(b.as_u8_ref());
+            Bytes32::from_array(h.finalize())
+        }
+
+        let a = Bytes32::from_byte_fill(1);
+        let b = Bytes32::from_byte_fill(2);
+        let c = Bytes32::from_byte_fill(3);
+        let d = Bytes32::from_byte_fill(4);
+        let z = Bytes32::ZERO;
+
+        // Independent recomputation of the height-3 tree with the last four leaves zero.
+        let l1 = [node(&a, &b), node(&c, &d), node(&z, &z), node(&z, &z)];
+        let l2 = [node(&l1[0], &l1[1]), node(&l1[2], &l1[3])];
+        let expected = node(&l2[0], &l2[1]);
+
+        assert_eq!(compute_chain_batch_root(a, b, c, d), expected);
+    }
+
+    #[test]
+    fn chain_batch_root_all_zero_is_deterministic() {
+        // Sanity: an all-zero input (empty batch) is well defined and non-trivial (non-zero).
+        let z = Bytes32::ZERO;
+        assert_ne!(compute_chain_batch_root(z, z, z, z), Bytes32::ZERO);
     }
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -115,8 +115,11 @@ where
         io.logs_storage
             .apply_to_array_vec(&mut batch_data.logs_storage);
 
+        let commitment_tree_root_begin = block_data.commitment_tree_root_begin;
         let upgrade_tx_hash = block_data.upgrade_tx_recorder.finish();
         let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
+        // Batch-end IMT root snapshot, taken after this block's transactions (see `read_commitment_tree_root`).
+        let commitment_tree_root_end = read_commitment_tree_root(&mut io);
 
         let (mut state_commitment, last_block_timestamp) = {
             let proof_data: ProofData<FlatStorageCommitment<TREE_HEIGHT>> =
@@ -190,6 +193,8 @@ where
             io.interop_root_storage.iter(),
             settlement_layer_chain_id,
             block_data.current_transaction_number,
+            commitment_tree_root_begin,
+            commitment_tree_root_end,
         );
 
         Ok(io.oracle)

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_multiblock_batch.rs
@@ -118,8 +118,8 @@ where
         let commitment_tree_root_begin = block_data.commitment_tree_root_begin;
         let upgrade_tx_hash = block_data.upgrade_tx_recorder.finish();
         let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
-        // Batch-end IMT root snapshot, taken after this block's transactions (see `read_commitment_tree_root`).
-        let commitment_tree_root_end = read_commitment_tree_root(&mut io);
+        // Batch-end IMT root snapshot, taken after this block's transactions (see `read_interop_commitment_tree_root`).
+        let commitment_tree_root_end = read_interop_commitment_tree_root(&mut io);
 
         let (mut state_commitment, last_block_timestamp) = {
             let proof_data: ProofData<FlatStorageCommitment<TREE_HEIGHT>> =

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -107,10 +107,17 @@ where
         });
 
         let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
+        // IMT root snapshots: `begin` was taken in `pre_op` (before the block), `end` is taken now
+        // (after the block). Committed into the chain batch root below, matching the multiblock keeper's
+        // ordering (logs root, multichain root, IMT begin, IMT end).
+        let commitment_tree_root_begin = block_data.commitment_tree_root_begin;
+        let commitment_tree_root_end = read_commitment_tree_root(&mut io);
 
         let mut full_root_hasher = crypto::sha3::Keccak256::new();
         full_root_hasher.update(io.logs_storage.tree_root().as_u8_ref());
         full_root_hasher.update(multichain_root.as_u8_ref());
+        full_root_hasher.update(commitment_tree_root_begin.as_u8_ref());
+        full_root_hasher.update(commitment_tree_root_end.as_u8_ref());
         let full_l2_to_l1_logs_root = full_root_hasher.finalize().into();
 
         let (priority_operations_hash, number_of_layer_1_txs) =

--- a/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/post_tx_op/post_tx_op_proving_singleblock_batch.rs
@@ -108,17 +108,19 @@ where
 
         let (multichain_root, settlement_layer_chain_id) = read_batch_context_inputs(&mut io);
         // IMT root snapshots: `begin` was taken in `pre_op` (before the block), `end` is taken now
-        // (after the block). Committed into the chain batch root below, matching the multiblock keeper's
-        // ordering (logs root, multichain root, IMT begin, IMT end).
+        // (after the block).
         let commitment_tree_root_begin = block_data.commitment_tree_root_begin;
-        let commitment_tree_root_end = read_commitment_tree_root(&mut io);
+        let commitment_tree_root_end = read_interop_commitment_tree_root(&mut io);
 
-        let mut full_root_hasher = crypto::sha3::Keccak256::new();
-        full_root_hasher.update(io.logs_storage.tree_root().as_u8_ref());
-        full_root_hasher.update(multichain_root.as_u8_ref());
-        full_root_hasher.update(commitment_tree_root_begin.as_u8_ref());
-        full_root_hasher.update(commitment_tree_root_end.as_u8_ref());
-        let full_l2_to_l1_logs_root = full_root_hasher.finalize().into();
+        // Chain batch root: a fixed height-3 (8-leaf) keccak Merkle tree, computed identically to the
+        // multiblock keeper (see `ZKBatchDataKeeper::into_public_input_and_output` and
+        // `compute_chain_batch_root` for the leaf layout) so both proving paths agree on the value.
+        let chain_batch_root = compute_chain_batch_root(
+            io.logs_storage.tree_root(),
+            multichain_root,
+            commitment_tree_root_begin,
+            commitment_tree_root_end,
+        );
 
         let (priority_operations_hash, number_of_layer_1_txs) =
             block_data.enforced_transaction_hashes_accumulator.finish();
@@ -211,7 +213,7 @@ where
             number_of_layer_1_txs: U256::try_from(number_of_layer_1_txs).unwrap(),
             number_of_layer_2_txs: U256::from(number_of_layer_2_txs),
             priority_operations_hash,
-            l2_logs_tree_root: full_l2_to_l1_logs_root,
+            l2_logs_tree_root: chain_batch_root,
             upgrade_tx_hash,
             interop_roots_rolling_hash,
             settlement_layer_chain_id,

--- a/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
@@ -24,7 +24,7 @@ where
         // Snapshot the interop commitment tree (IMT) root before any transaction runs. For the first
         // block of a batch this is the batch-begin root; the batch data keeper commits it (alongside
         // the batch-end root read in `post_op`) into the chain batch root.
-        block_data.commitment_tree_root_begin = read_commitment_tree_root(&mut system.io);
+        block_data.commitment_tree_root_begin = read_interop_commitment_tree_root(&mut system.io);
 
         // EIP-2935: store parent block hash in history storage contract
         {

--- a/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
@@ -21,6 +21,11 @@ where
         block_data.block_computational_native_used = BLOCK_INTRINSIC_NATIVE;
         block_data.block_pubdata_used = BLOCK_INTRINSIC_PUBDATA_BYTES;
 
+        // Snapshot the interop commitment tree (IMT) root before any transaction runs. For the first
+        // block of a batch this is the batch-begin root; the batch data keeper commits it (alongside
+        // the batch-end root read in `post_op`) into the chain batch root.
+        block_data.commitment_tree_root_begin = read_commitment_tree_root(&mut system.io);
+
         // EIP-2935: store parent block hash in history storage contract
         {
             use crate::bootloader::block_flow::eip_2935_historical_block_hash::eip2935_system_part;

--- a/system_hooks/src/addresses_constants.rs
+++ b/system_hooks/src/addresses_constants.rs
@@ -53,6 +53,11 @@ pub const L2_INTEROP_CENTER_ADDRESS: B160 =
 // L2 asset tracker contract
 pub const L2_ASSET_TRACKER_ADDRESS: B160 = B160::from_limbs([0x1000f, 0, 0]);
 
+// L2 interop commitment tree (Indexed Merkle Tree of atomic-interop commit values) system contract
+pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW: u32 = 0x10012;
+pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS: B160 =
+    B160::from_limbs([L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW as u64, 0, 0]);
+
 // Treasury contract used for "minting" base tokens on L2
 pub const BASE_TOKEN_HOLDER_ADDRESS_LOW: u32 = 0x10011;
 pub const BASE_TOKEN_HOLDER_ADDRESS: B160 =

--- a/system_hooks/src/addresses_constants.rs
+++ b/system_hooks/src/addresses_constants.rs
@@ -53,15 +53,15 @@ pub const L2_INTEROP_CENTER_ADDRESS: B160 =
 // L2 asset tracker contract
 pub const L2_ASSET_TRACKER_ADDRESS: B160 = B160::from_limbs([0x1000f, 0, 0]);
 
-// L2 interop commitment tree (Indexed Merkle Tree of atomic-interop commit values) system contract
-pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW: u32 = 0x10012;
-pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS: B160 =
-    B160::from_limbs([L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW as u64, 0, 0]);
-
 // Treasury contract used for "minting" base tokens on L2
 pub const BASE_TOKEN_HOLDER_ADDRESS_LOW: u32 = 0x10011;
 pub const BASE_TOKEN_HOLDER_ADDRESS: B160 =
     B160::from_limbs([BASE_TOKEN_HOLDER_ADDRESS_LOW as u64, 0, 0]);
+
+// L2 interop commitment tree (Indexed Merkle Tree of atomic-interop commit values) system contract
+pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW: u32 = 0x10012;
+pub const L2_INTEROP_COMMITMENT_TREE_ADDRESS: B160 =
+    B160::from_limbs([L2_INTEROP_COMMITMENT_TREE_ADDRESS_LOW as u64, 0, 0]);
 
 // ERA VM system contracts (in fact we need implement only the methods that should be available for user contracts)
 // TODO: may be better to implement as ifs inside EraVM EE


### PR DESCRIPTION
## What ❔

  - Change the chain batch root structure to a fixed height-3 keccak Merkle tree (shared `compute_chain_batch_root`)
  - Include the interop commitment tree (IMT) roots in it: the IMT root at batch begin and at batch end occupy dedicated leaves, read from the `L2InteropCommitmentTree` `_currentRoot` cache


## Why ❔

 Needed for atomic interop: committing the IMT roots at the batch boundaries into the chain batch root lets consumers authenticate IMT roots at the destination chain and the fixed tree layout leaves room to add more interop commitments later without changing its shape.

## Is this a breaking change?
- [x] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.