### PR TITLE
perf(io): bound flat preimage-cache retention

### DIFF
--- a/basic_bootloader/src/bootloader/block_flow/ethereum/pre_tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/ethereum/pre_tx_loop.rs
@@ -12,6 +12,8 @@ where
 
     fn pre_op(
         system: &mut System<S>,
+        _system_functions: &mut HooksStorage<S, S::Allocator>,
+        _memories: RunnerMemoryBuffers<'_>,
         _result_keeper: &mut impl IOResultKeeper<EthereumIOTypesConfig>,
     ) -> Result<Self::PreTxLoopResult, BootloaderSubsystemError> {
         // EIP-4788

--- a/basic_bootloader/src/bootloader/block_flow/pre_tx_loop_op.rs
+++ b/basic_bootloader/src/bootloader/block_flow/pre_tx_loop_op.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::bootloader::errors::BootloaderSubsystemError;
+use crate::bootloader::runner::RunnerMemoryBuffers;
+use zk_ee::common_structs::system_hooks::HooksStorage;
 use zk_ee::system::IOResultKeeper;
 
 /// Trait for operations performed before the transaction processing loop begins.
@@ -13,6 +15,8 @@ where
     /// Performs pre-transaction-loop setup
     fn pre_op(
         system: &mut System<S>,
+        system_functions: &mut HooksStorage<S, S::Allocator>,
+        memories: RunnerMemoryBuffers<'_>,
         result_keeper: &mut impl IOResultKeeper<S::IOTypes>,
     ) -> Result<Self::PreTxLoopResult, BootloaderSubsystemError>;
 }

--- a/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/pre_tx_loop.rs
@@ -1,3 +1,5 @@
+use zk_ee::system::metadata::basic_metadata::{BasicMetadata, ZkSpecificMetadata};
+use zk_ee::system::metadata::zk_metadata::TxLevelMetadata;
 use zk_ee::system::IOResultKeeper;
 
 use super::*;
@@ -9,11 +11,15 @@ use crate::bootloader::{
 impl<S: EthereumLikeTypes, EA: TxHashesAccumulator> PreTxLoopOp<S> for ZKHeaderStructurePreTxOp<EA>
 where
     S::IO: IOSubsystemExt,
+    S::Metadata: ZkSpecificMetadata
+        + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
     type PreTxLoopResult = ZKBasicBlockDataKeeper<EA, S::Allocator>;
 
     fn pre_op(
         system: &mut System<S>,
+        system_functions: &mut HooksStorage<S, S::Allocator>,
+        memories: RunnerMemoryBuffers<'_>,
         _result_keeper: &mut impl IOResultKeeper<EthereumIOTypesConfig>,
     ) -> Result<Self::PreTxLoopResult, BootloaderSubsystemError> {
         // Create data keeper and seed block intrinsic constants
@@ -26,6 +32,10 @@ where
             use crate::bootloader::block_flow::eip_2935_historical_block_hash::eip2935_system_part;
             eip2935_system_part(system)?;
         }
+
+        crate::bootloader::transaction_flow::zk::process_l1_transaction::prewarm_l1_postprocessing::<
+            S,
+        >(system, system_functions, memories)?;
 
         Ok(block_data)
     }

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -105,6 +105,28 @@ where
 
                     tracer.finish_tx();
 
+                    if system
+                        .io
+                        .transaction_cache_memory_limit_hit_for_current_tx()
+                    {
+                        system_log!(
+                            system,
+                            "Tx exhausted its preimage-cache memory budget (OON)\n",
+                        );
+                    }
+
+                    // Raw preimages are retained for the whole block and are
+                    // intentionally not part of frame rollback. If this tx
+                    // encountered their hard memory cap, treat it like any
+                    // other block limit before fees or tx effects can commit.
+                    if system.io.block_scoped_cache_limit_hit_for_current_tx() {
+                        system_log!(system, "Tx reached block-scoped cache limit\n",);
+                        system.finish_global_frame(Some(&pre_tx_rollback_handle))?;
+                        result_keeper
+                            .tx_processed(Err(InvalidTransaction::BlockNativeLimitReached));
+                        continue;
+                    }
+
                     match tx_result {
                         Err(TxError::Internal(err)) => {
                             system_log!(system, "Tx execution result: Internal error = {err:?}\n",);
@@ -122,6 +144,20 @@ where
                             result_keeper.tx_processed(Err(err));
                         }
                         Ok(tx_processing_result) => {
+                            // Account snapshots are inserted only during block
+                            // finalization. Check their exact pending cache
+                            // footprint before accepting this transaction.
+                            if system.io.deferred_cache_writes_exceed_block_limit() {
+                                system_log!(
+                                    system,
+                                    "Tx reached block-scoped cache limit through deferred writes\n",
+                                );
+                                system.finish_global_frame(Some(&pre_tx_rollback_handle))?;
+                                result_keeper
+                                    .tx_processed(Err(InvalidTransaction::BlockNativeLimitReached));
+                                continue;
+                            }
+
                             system_log!(
                                 system,
                                 "Tx execution result = {:?}\n",

--- a/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
+++ b/basic_bootloader/src/bootloader/block_flow/zk/tx_loop.rs
@@ -144,20 +144,6 @@ where
                             result_keeper.tx_processed(Err(err));
                         }
                         Ok(tx_processing_result) => {
-                            // Account snapshots are inserted only during block
-                            // finalization. Check their exact pending cache
-                            // footprint before accepting this transaction.
-                            if system.io.deferred_cache_writes_exceed_block_limit() {
-                                system_log!(
-                                    system,
-                                    "Tx reached block-scoped cache limit through deferred writes\n",
-                                );
-                                system.finish_global_frame(Some(&pre_tx_rollback_handle))?;
-                                result_keeper
-                                    .tx_processed(Err(InvalidTransaction::BlockNativeLimitReached));
-                                continue;
-                            }
-
                             system_log!(
                                 system,
                                 "Tx execution result = {:?}\n",

--- a/basic_bootloader/src/bootloader/constants.rs
+++ b/basic_bootloader/src/bootloader/constants.rs
@@ -359,9 +359,13 @@ pub const BLOCK_INTRINSIC_PUBDATA_BYTES: u64 =
     1 + 32 + 8 + BLOCK_SERIALIZATION_COUNTERS_PUBDATA_BYTES + EIP_2935_INTRINSIC_PUBDATA;
 
 /// Intrinsic per-block native overhead, applied to block-limit enforcement
-/// from block start. Covers fixed pre-tx-loop system work — currently just
-/// the EIP-2935 historical block hash write when the feature is enabled.
-pub const BLOCK_INTRINSIC_NATIVE: u64 = EIP_2935_INTRINSIC_NATIVE;
+/// from block start. Covers fixed pre-tx-loop system work: the EIP-2935
+/// historical block hash write, the direct L2ChainAssetHandler prewarm, and
+/// the rolled-back, non-zero L2AssetTracker notification that admits mandatory
+/// L1-finalization preimages. Conservatively charge each synthetic call as one
+/// cold AssetTracker notification.
+pub const BLOCK_INTRINSIC_NATIVE: u64 =
+    EIP_2935_INTRINSIC_NATIVE + 2 * L1_TX_ASSET_TRACKER_COLD_NOTIFICATION_NATIVE_COST;
 
 #[cfg(test)]
 mod tests {

--- a/basic_bootloader/src/bootloader/mod.rs
+++ b/basic_bootloader/src/bootloader/mod.rs
@@ -111,7 +111,7 @@ where
         let mut return_data =
             Box::new_uninit_slice_in(MAX_RETURN_BUFFER_SIZE, system.get_allocator());
 
-        let memories = RunnerMemoryBuffers {
+        let mut memories = RunnerMemoryBuffers {
             heaps: &mut heaps,
             return_data: &mut return_data,
         };
@@ -119,8 +119,12 @@ where
         cycle_marker::end!("system_init");
 
         // Pre-op
-        let mut block_data_keeper =
-            <S::PreTxLoopOp as PreTxLoopOp<S>>::pre_op(&mut system, result_keeper)?;
+        let mut block_data_keeper = <S::PreTxLoopOp as PreTxLoopOp<S>>::pre_op(
+            &mut system,
+            &mut system_functions,
+            memories.reborrow(),
+            result_keeper,
+        )?;
 
         // TX loop
         <S::TxLoopOp as TxLoopOp<S>>::loop_op::<Config>(

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -27,8 +27,8 @@ use zk_ee::system::errors::runtime::RuntimeError;
 use zk_ee::system::errors::subsystem::SubsystemError;
 use zk_ee::system::metadata::basic_metadata::{BasicMetadata, ZkSpecificMetadata};
 use zk_ee::system::metadata::zk_metadata::TxLevelMetadata;
-use zk_ee::system::tracer::Tracer;
-use zk_ee::system::validator::TxValidator;
+use zk_ee::system::tracer::{NopTracer, Tracer};
+use zk_ee::system::validator::{NopTxValidator, TxValidator};
 use zk_ee::system::Resource;
 use zk_ee::system::System;
 use zk_ee::system::{AccountDataRequest, CompletedExecution, Computational};
@@ -41,7 +41,7 @@ use zk_ee::{interface_error, internal_error, wrap_error};
 
 use system_hooks::addresses_constants::{
     BASE_TOKEN_HOLDER_ADDRESS, L2_ASSET_TRACKER_ADDRESS, L2_BASE_TOKEN_ADDRESS,
-    L2_CHAIN_ASSET_HANDLER_ADDRESS, L2_NATIVE_TOKEN_VAULT_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+    L2_CHAIN_ASSET_HANDLER_ADDRESS,
 };
 
 use super::validation_impl::compute_calldata_tokens;
@@ -594,10 +594,121 @@ struct L1ExecutionOutcome<S: EthereumLikeTypes> {
     resources_before_refund: S::Resources,
 }
 
-/// Materializes every account preimage used by mandatory L1 post-processing
-/// before attacker-controlled execution can exhaust the transaction-local
-/// preimage-cache budget.
-fn prewarm_l1_postprocessing_accounts<S: EthereumLikeTypes>(
+/// Executes the mandatory non-zero L1 finalization path once before the first
+/// transaction and then rolls all of its state changes back.
+///
+/// This runs before `begin_new_tx`, so every proxy, implementation, and
+/// transitive callee preimage loaded by the real execution path is admitted as
+/// block-level `Accepted`. Raw preimages intentionally survive frame rollback;
+/// storage, events, logs, and messages do not.
+pub(crate) fn prewarm_l1_postprocessing<S: EthereumLikeTypes>(
+    system: &mut System<S>,
+    system_functions: &mut HooksStorage<S, S::Allocator>,
+    mut memories: RunnerMemoryBuffers<'_>,
+) -> Result<(), BootloaderSubsystemError>
+where
+    S::IO: IOSubsystemExt,
+    S::Metadata: ZkSpecificMetadata
+        + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
+{
+    let mut resources = S::Resources::FORMAL_INFINITE;
+    let rollback_handle = system.start_global_frame()?;
+    let l1_chain_id = read_l1_chain_id(system);
+    let chain_id = U256::from(system.get_chain_id());
+    let mut tracer = NopTracer::default();
+    let mut validator = NopTxValidator;
+
+    // AssetTracker only reads the chain migration number when the saved asset
+    // migration number is zero and the base-token total supply is zero. The
+    // total supply may change during an L1 transaction, so execute this
+    // conditional dependency unconditionally before transaction-local cache
+    // metering starts.
+    // Keep both synthetic calls in one fallible operation so a subsystem
+    // failure short-circuits further execution, but defer propagating it until
+    // after the outer frame has been rolled back.
+    let prewarm_result = (|| {
+        prewarm_l2_chain_asset_handler::<S>(
+            system,
+            system_functions,
+            memories.reborrow(),
+            chain_id,
+            &mut resources,
+            &mut tracer,
+            &mut validator,
+        )?;
+
+        notify_l2_asset_tracker::<S>(
+            system,
+            system_functions,
+            memories,
+            U256::from(1),
+            l1_chain_id,
+            &mut resources,
+            &mut tracer,
+            &mut validator,
+        )
+    })();
+
+    // The synthetic call must never change block state.
+    system.finish_global_frame(Some(&rollback_handle))?;
+    prewarm_result
+}
+
+/// Unconditionally admits the preimages behind
+/// `L2ChainAssetHandler.migrationNumber(block.chainid)`.
+///
+/// The real AssetTracker call reaches this getter only when both the saved
+/// asset migration number and base-token supply are zero. Calling it directly
+/// removes that state-dependent branch from transaction-local cache
+/// accounting. An EVM-level revert is harmless: the proxy and implementation
+/// preimages loaded before the revert have already been admitted, while
+/// subsystem failures still propagate.
+fn prewarm_l2_chain_asset_handler<'a, S: EthereumLikeTypes + 'a>(
+    system: &mut System<S>,
+    system_functions: &mut HooksStorage<S, S::Allocator>,
+    memories: RunnerMemoryBuffers<'a>,
+    chain_id: U256,
+    resources: &mut S::Resources,
+    tracer: &mut impl Tracer<S>,
+    validator: &mut impl TxValidator<S>,
+) -> Result<(), BootloaderSubsystemError>
+where
+    S::IO: IOSubsystemExt,
+    S::Metadata: ZkSpecificMetadata
+        + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
+{
+    // migrationNumber(uint256): selector 0xb2157716 + ABI-encoded chain ID.
+    let mut calldata = [0u8; 36];
+    calldata[0..4].copy_from_slice(&[0xb2, 0x15, 0x77, 0x16]);
+    calldata[4..36].copy_from_slice(&chain_id.to_be_bytes::<32>());
+
+    resources.with_infinite_ergs(|inf_ergs| {
+        let CompletedExecution {
+            resources_returned,
+            result: _,
+        } = BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
+            system,
+            system_functions,
+            memories,
+            &calldata,
+            &L2_ASSET_TRACKER_ADDRESS,
+            &L2_CHAIN_ASSET_HANDLER_ADDRESS,
+            inf_ergs.clone(),
+            &U256::ZERO,
+            true, // should_make_frame - isolate an EVM-level revert
+            tracer,
+            validator,
+        )?;
+        *inf_ergs = resources_returned;
+        Ok::<(), BootloaderSubsystemError>(())
+    })
+}
+
+/// Materializes the account preimages used by mandatory balance updates before
+/// attacker-controlled execution can exhaust the transaction-local cache
+/// budget. Contract preimages are admitted at block level by
+/// `prewarm_l1_postprocessing`.
+fn prewarm_l1_postprocessing_balance_accounts<S: EthereumLikeTypes>(
     system: &mut System<S>,
     refund_recipient: B160,
 ) -> Result<(), BootloaderSubsystemError>
@@ -606,48 +717,7 @@ where
 {
     let mut resources = S::Resources::FORMAL_INFINITE;
 
-    // L2 base token is the caller of the AssetTracker notification, and the
-    // notification may call back into it to read totalSupply().
-    system.io.read_account_properties(
-        ExecutionEnvironmentType::NoEE,
-        &mut resources,
-        &L2_BASE_TOKEN_ADDRESS,
-        AccountDataRequest::empty()
-            .with_ee_version()
-            .with_bytecode(),
-    )?;
-
-    // AssetTracker is the callee, so its bytecode preimage is needed as well.
-    system.io.read_account_properties(
-        ExecutionEnvironmentType::EVM,
-        &mut resources,
-        &L2_ASSET_TRACKER_ADDRESS,
-        AccountDataRequest::empty().with_bytecode(),
-    )?;
-
-    // AssetTracker's positive-amount path reads SystemContext and may query the
-    // chain asset handler while initializing migration state. The native token
-    // vault is only reached if the base token registration invariant is broken,
-    // but warming it keeps mandatory post-processing safe in that state too.
-    for address in [
-        SYSTEM_CONTEXT_ADDRESS,
-        L2_CHAIN_ASSET_HANDLER_ADDRESS,
-        L2_NATIVE_TOKEN_VAULT_ADDRESS,
-    ] {
-        system.io.read_account_properties(
-            ExecutionEnvironmentType::EVM,
-            &mut resources,
-            &address,
-            AccountDataRequest::empty().with_bytecode(),
-        )?;
-    }
-
-    // The remaining mandatory operations only read or update nominal balances.
-    for address in [
-        BASE_TOKEN_HOLDER_ADDRESS,
-        system.get_coinbase(),
-        refund_recipient,
-    ] {
+    for address in [BASE_TOKEN_HOLDER_ADDRESS, refund_recipient] {
         system.io.read_account_properties(
             ExecutionEnvironmentType::EVM,
             &mut resources,
@@ -713,7 +783,7 @@ where
         .ok_or(internal_error!("td-mfc"))?;
 
     let refund_recipient = u256_to_b160_checked(transaction.reserved[1].read());
-    prewarm_l1_postprocessing_accounts(system, refund_recipient)?;
+    prewarm_l1_postprocessing_balance_accounts(system, refund_recipient)?;
 
     // Transfer value from treasury to sender (the deposit minus max fee).
     // Run this even for a zero amount so that every preimage needed by the

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -40,7 +40,8 @@ use zk_ee::utils::{u256_to_b160_checked, Bytes32};
 use zk_ee::{interface_error, internal_error, wrap_error};
 
 use system_hooks::addresses_constants::{
-    L2_ASSET_TRACKER_ADDRESS, L2_BASE_TOKEN_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+    BASE_TOKEN_HOLDER_ADDRESS, L2_ASSET_TRACKER_ADDRESS, L2_BASE_TOKEN_ADDRESS,
+    L2_CHAIN_ASSET_HANDLER_ADDRESS, L2_NATIVE_TOKEN_VAULT_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
 };
 
 use super::validation_impl::compute_calldata_tokens;
@@ -593,6 +594,71 @@ struct L1ExecutionOutcome<S: EthereumLikeTypes> {
     resources_before_refund: S::Resources,
 }
 
+/// Materializes every account preimage used by mandatory L1 post-processing
+/// before attacker-controlled execution can exhaust the transaction-local
+/// preimage-cache budget.
+fn prewarm_l1_postprocessing_accounts<S: EthereumLikeTypes>(
+    system: &mut System<S>,
+    refund_recipient: B160,
+) -> Result<(), BootloaderSubsystemError>
+where
+    S::IO: IOSubsystemExt,
+{
+    let mut resources = S::Resources::FORMAL_INFINITE;
+
+    // L2 base token is the caller of the AssetTracker notification, and the
+    // notification may call back into it to read totalSupply().
+    system.io.read_account_properties(
+        ExecutionEnvironmentType::NoEE,
+        &mut resources,
+        &L2_BASE_TOKEN_ADDRESS,
+        AccountDataRequest::empty()
+            .with_ee_version()
+            .with_bytecode(),
+    )?;
+
+    // AssetTracker is the callee, so its bytecode preimage is needed as well.
+    system.io.read_account_properties(
+        ExecutionEnvironmentType::EVM,
+        &mut resources,
+        &L2_ASSET_TRACKER_ADDRESS,
+        AccountDataRequest::empty().with_bytecode(),
+    )?;
+
+    // AssetTracker's positive-amount path reads SystemContext and may query the
+    // chain asset handler while initializing migration state. The native token
+    // vault is only reached if the base token registration invariant is broken,
+    // but warming it keeps mandatory post-processing safe in that state too.
+    for address in [
+        SYSTEM_CONTEXT_ADDRESS,
+        L2_CHAIN_ASSET_HANDLER_ADDRESS,
+        L2_NATIVE_TOKEN_VAULT_ADDRESS,
+    ] {
+        system.io.read_account_properties(
+            ExecutionEnvironmentType::EVM,
+            &mut resources,
+            &address,
+            AccountDataRequest::empty().with_bytecode(),
+        )?;
+    }
+
+    // The remaining mandatory operations only read or update nominal balances.
+    for address in [
+        BASE_TOKEN_HOLDER_ADDRESS,
+        system.get_coinbase(),
+        refund_recipient,
+    ] {
+        system.io.read_account_properties(
+            ExecutionEnvironmentType::EVM,
+            &mut resources,
+            &address,
+            AccountDataRequest::empty().with_nominal_token_balance(),
+        )?;
+    }
+
+    Ok(())
+}
+
 fn execute_l1_transaction_and_notify_result<
     'a,
     S: EthereumLikeTypes + 'a,
@@ -646,6 +712,9 @@ where
         .checked_sub(max_fee_commitment)
         .ok_or(internal_error!("td-mfc"))?;
 
+    let refund_recipient = u256_to_b160_checked(transaction.reserved[1].read());
+    prewarm_l1_postprocessing_accounts(system, refund_recipient)?;
+
     // Transfer value from treasury to sender (the deposit minus max fee).
     // Run this even for a zero amount so that every preimage needed by the
     // mandatory post-execution mint is admitted before user execution can
@@ -685,32 +754,6 @@ where
             }
             _ => e,
         })?;
-
-    // The refund recipient may differ from both the sender and the coinbase.
-    // Admit its account preimage before user execution so that the mandatory
-    // refund cannot be the first operation to materialize it after the user
-    // has exhausted the transaction-local preimage-cache budget.
-    let refund_recipient = u256_to_b160_checked(transaction.reserved[1].read());
-    let mut prewarm_resources = S::Resources::FORMAL_INFINITE;
-    system.io.read_account_properties(
-        ExecutionEnvironmentType::EVM,
-        &mut prewarm_resources,
-        &refund_recipient,
-        AccountDataRequest::empty().with_nominal_token_balance(),
-    )?;
-
-    // A zero-amount AssetTracker notification returns before its call to
-    // SystemContext, while positive post-execution notifications take that
-    // branch. Materialize SystemContext's account and bytecode explicitly so
-    // the zero-amount pre-execution path still covers the positive path's
-    // preimages. Its native cost is already conservatively included in the L1
-    // intrinsic budget's cold AssetTracker notification.
-    system.io.read_account_properties(
-        ExecutionEnvironmentType::EVM,
-        &mut prewarm_resources,
-        &SYSTEM_CONTEXT_ADDRESS,
-        AccountDataRequest::empty().with_bytecode(),
-    )?;
 
     let resources_for_tx = resources.clone();
 
@@ -809,7 +852,7 @@ where
     S::Metadata: ZkSpecificMetadata
         + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
-    notify_l2_asset_tracker::<S, Config>(
+    notify_l2_asset_tracker::<S>(
         system,
         system_functions,
         memories,
@@ -843,7 +886,7 @@ where
         "Transferring {nominal_token_value:?} tokens from treasury to {to:?}\n"
     );
 
-    let treasury_address = &system_hooks::addresses_constants::BASE_TOKEN_HOLDER_ADDRESS;
+    let treasury_address = &BASE_TOKEN_HOLDER_ADDRESS;
 
     let _ = system
         .io
@@ -907,7 +950,7 @@ where
 /// If no contract is deployed at L2AssetTracker, the call succeeds silently
 /// (a call to an empty address returns success with no returndata in EVM).
 /// However, we are certain that L2AssetTracker is available after the upgrade.
-fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a, Config: BasicBootloaderExecutionConfig>(
+fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a>(
     system: &mut System<S>,
     system_functions: &mut HooksStorage<S, S::Allocator>,
     memories: RunnerMemoryBuffers<'a>,

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -31,7 +31,7 @@ use zk_ee::system::tracer::Tracer;
 use zk_ee::system::validator::TxValidator;
 use zk_ee::system::Resource;
 use zk_ee::system::System;
-use zk_ee::system::{CompletedExecution, Computational};
+use zk_ee::system::{AccountDataRequest, CompletedExecution, Computational};
 use zk_ee::system::{EthereumLikeTypes, Resources};
 #[allow(unused_imports)]
 use zk_ee::system::{IOSubsystem, IOSubsystemExt, MAX_NATIVE_COMPUTATIONAL};
@@ -39,7 +39,9 @@ use zk_ee::system_log;
 use zk_ee::utils::{u256_to_b160_checked, Bytes32};
 use zk_ee::{interface_error, internal_error, wrap_error};
 
-use system_hooks::addresses_constants::{L2_ASSET_TRACKER_ADDRESS, L2_BASE_TOKEN_ADDRESS};
+use system_hooks::addresses_constants::{
+    L2_ASSET_TRACKER_ADDRESS, L2_BASE_TOKEN_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+};
 
 use super::validation_impl::compute_calldata_tokens;
 use super::{ZkTransactionFlowOnlyEOA, ZkTxResult};
@@ -645,14 +647,11 @@ where
         .ok_or(internal_error!("td-mfc"))?;
 
     // Transfer value from treasury to sender (the deposit minus max fee).
-    // We want to ensure that the simulation of a transaction
-    // never underestimates gas/pubdata compared to the actual execution
-    // of said transaction.
-    // During simulation the gas price is typically set to 0. So we need
-    // to be conservative about operations that incur in gas/pubdata depending
-    // on the value of the fee. For that reason, we always perform the
-    // following transfer on simulation, and avoid compressing the pubdata
-    // for the balance changes resulting from it.
+    // Run this even for a zero amount so that every preimage needed by the
+    // mandatory post-execution mint is admitted before user execution can
+    // exhaust the transaction-local preimage-cache budget. In simulation we
+    // additionally avoid compressing the pubdata for the resulting balance
+    // changes.
     //
     // Mint the value portion of the deposit (total deposited minus max fee)
     // to the sender inside the execution frame, it does not
@@ -660,34 +659,58 @@ where
     //
     // Use with_infinite_ergs so the call cannot fail due to out-of-gas,
     // but native consumption is still tracked against the user's resources.
-    if to_transfer > U256::ZERO || Config::SIMULATION {
-        resources
-            .with_infinite_ergs(|inf_resources| {
-                mint_base_token::<S, Config>(
+    resources
+        .with_infinite_ergs(|inf_resources| {
+            mint_base_token::<S, Config>(
+                system,
+                system_functions,
+                memories.reborrow(),
+                &to_transfer,
+                &from,
+                l1_chain_id,
+                inf_resources,
+                tracer,
+                validator,
+            )
+        })
+        .map_err(|e| match e.root_cause() {
+            RootCause::Runtime(RuntimeError::OutOfErgs(_)) => {
+                system_log!(
                     system,
-                    system_functions,
-                    memories.reborrow(),
-                    &to_transfer,
-                    &from,
-                    l1_chain_id,
-                    inf_resources,
-                    tracer,
-                    validator,
-                )
-            })
-            .map_err(|e| match e.root_cause() {
-                RootCause::Runtime(RuntimeError::OutOfErgs(_)) => {
-                    system_log!(
-                        system,
-                        "Out of ergs on infinite ergs: inner error was {e:?}"
-                    );
-                    BootloaderSubsystemError::LeafDefect(internal_error!(
-                        "Out of ergs on infinite ergs"
-                    ))
-                }
-                _ => e,
-            })?;
-    }
+                    "Out of ergs on infinite ergs: inner error was {e:?}"
+                );
+                BootloaderSubsystemError::LeafDefect(internal_error!(
+                    "Out of ergs on infinite ergs"
+                ))
+            }
+            _ => e,
+        })?;
+
+    // The refund recipient may differ from both the sender and the coinbase.
+    // Admit its account preimage before user execution so that the mandatory
+    // refund cannot be the first operation to materialize it after the user
+    // has exhausted the transaction-local preimage-cache budget.
+    let refund_recipient = u256_to_b160_checked(transaction.reserved[1].read());
+    let mut prewarm_resources = S::Resources::FORMAL_INFINITE;
+    system.io.read_account_properties(
+        ExecutionEnvironmentType::EVM,
+        &mut prewarm_resources,
+        &refund_recipient,
+        AccountDataRequest::empty().with_nominal_token_balance(),
+    )?;
+
+    // A zero-amount AssetTracker notification returns before its call to
+    // SystemContext, while positive post-execution notifications take that
+    // branch. Materialize SystemContext's account and bytecode explicitly so
+    // the zero-amount pre-execution path still covers the positive path's
+    // preimages. Its native cost is already conservatively included in the L1
+    // intrinsic budget's cold AssetTracker notification.
+    system.io.read_account_properties(
+        ExecutionEnvironmentType::EVM,
+        &mut prewarm_resources,
+        &SYSTEM_CONTEXT_ADDRESS,
+        AccountDataRequest::empty().with_bytecode(),
+    )?;
 
     let resources_for_tx = resources.clone();
 
@@ -899,56 +922,56 @@ where
     S::Metadata: ZkSpecificMetadata
         + BasicMetadata<S::IOTypes, TransactionMetadata = TxLevelMetadata<S::IOTypes>>,
 {
-    if amount > U256::ZERO || Config::SIMULATION {
-        let notify_native_before = resources.native().as_u64();
-        // Encode calldata for handleFinalizeBaseTokenBridgingOnL2(uint256,uint256):
-        // selector 0x03117c8c + abi-encoded (fromChainId, amount)
-        let mut calldata = [0u8; 68];
-        calldata[0..4].copy_from_slice(&[0x03, 0x11, 0x7c, 0x8c]);
-        calldata[4..36].copy_from_slice(&l1_chain_id.to_be_bytes::<32>());
-        calldata[36..68].copy_from_slice(&amount.to_be_bytes::<32>());
+    // Run the notification even for a zero amount. Besides keeping the call
+    // path uniform, this admits the base-token caller and asset-tracker
+    // account/bytecode preimages before user execution.
+    let notify_native_before = resources.native().as_u64();
+    // Encode calldata for handleFinalizeBaseTokenBridgingOnL2(uint256,uint256):
+    // selector 0x03117c8c + abi-encoded (fromChainId, amount)
+    let mut calldata = [0u8; 68];
+    calldata[0..4].copy_from_slice(&[0x03, 0x11, 0x7c, 0x8c]);
+    calldata[4..36].copy_from_slice(&l1_chain_id.to_be_bytes::<32>());
+    calldata[36..68].copy_from_slice(&amount.to_be_bytes::<32>());
 
-        let failed = resources.with_infinite_ergs(|inf_ergs| {
-            let CompletedExecution {
-                resources_returned,
-                result: asset_tracker_result,
-            } = BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
-                system,
-                system_functions,
-                memories,
-                &calldata,
-                &L2_BASE_TOKEN_ADDRESS,
-                &L2_ASSET_TRACKER_ADDRESS,
-                inf_ergs.clone(),
-                &U256::ZERO,
-                true, // should_make_frame - isolate state changes
-                tracer,
-                validator,
-            )?;
-            // Overwrite resources inside the closure so that
-            // with_infinite_ergs correctly restores ergs afterwards.
-            *inf_ergs = resources_returned;
-            Ok::<bool, BootloaderSubsystemError>(asset_tracker_result.failed())
-        })?;
+    let failed = resources.with_infinite_ergs(|inf_ergs| {
+        let CompletedExecution {
+            resources_returned,
+            result: asset_tracker_result,
+        } = BasicBootloader::<S, ZkTransactionFlowOnlyEOA<S>>::run_single_interaction(
+            system,
+            system_functions,
+            memories,
+            &calldata,
+            &L2_BASE_TOKEN_ADDRESS,
+            &L2_ASSET_TRACKER_ADDRESS,
+            inf_ergs.clone(),
+            &U256::ZERO,
+            true, // should_make_frame - isolate state changes
+            tracer,
+            validator,
+        )?;
+        // Overwrite resources inside the closure so that
+        // with_infinite_ergs correctly restores ergs afterwards.
+        *inf_ergs = resources_returned;
+        Ok::<bool, BootloaderSubsystemError>(asset_tracker_result.failed())
+    })?;
 
-        let notify_native_used = notify_native_before - resources.native().as_u64();
+    let notify_native_used = notify_native_before - resources.native().as_u64();
+    system_log!(
+        system,
+        "L1 notify_l2_asset_tracker native: {notify_native_used}\n"
+    );
+
+    if failed {
         system_log!(
             system,
-            "L1 notify_l2_asset_tracker native: {notify_native_used}\n"
+            "L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 failed for amount {amount:?}\n"
         );
-
-        if failed {
-            system_log!(
-                system,
-                "L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 failed for amount {amount:?}\n"
-            );
-            // A revert here means the chain's token accounting would be inconsistent.
-            // Treated as a fatal system error — block processing cannot continue.
-            return Err(internal_error!(
-                "L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 reverted"
-            )
-            .into());
-        }
+        // A revert here means the chain's token accounting would be inconsistent.
+        // Treated as a fatal system error — block processing cannot continue.
+        return Err(
+            internal_error!("L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 reverted").into(),
+        );
     }
     Ok(())
 }

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -57,6 +57,10 @@ pub type BitsOrd160 = BitsOrd<{ B160::BITS }, { B160::LIMBS }>;
 #[derive(Default, Clone)]
 pub struct AccountPropertiesMetadata {
     pub basic: BasicAccountPropertiesMetadata,
+    /// Whether this account's block-start properties preimage was admitted to
+    /// the transaction-local preimage budget. This is rollback-aware because
+    /// the decoded account-cache entry itself survives a dropped transaction.
+    pub initial_preimage_admitted: bool,
     /// Special flag that allows avoiding publishing bytecode for deployed account.
     /// In practice, it can be set to `true` only during special protocol upgrade txs.
     /// For protocol upgrades it's ensured by governance that bytecodes are already published separately.
@@ -353,6 +357,24 @@ impl<
                     x.element_properties_mut().mark_value_as_observed();
                 }
                 if is_warm == false {
+                    // The initial account-cache record survives a dropped
+                    // candidate. If it represents an existing account, the
+                    // decoded value can bypass `get_preimage` on the next
+                    // candidate, so explicitly re-admit its backing preimage.
+                    // This keeps the per-transaction cache budget identical to
+                    // proving, where the dropped candidate never populated
+                    // either cache.
+                    let existing_account = !x.element_properties().is_new_element();
+                    if !is_missing
+                        && existing_account
+                        && !x.current().metadata().initial_preimage_admitted
+                    {
+                        let initial_preimage_hash = x.initial().value().compute_hash();
+                        preimages_cache.admit_cached_preimage_for_current_tx(
+                            &initial_preimage_hash,
+                            AccountProperties::ENCODED_SIZE,
+                        )?;
+                    }
                     Self::charge_ergs_for_cold_access(
                         ee_type,
                         resources,
@@ -378,6 +400,9 @@ impl<
                             m.basic.last_touched_in_tx = Some(self.current_tx_id);
                             if charge_as_new {
                                 m.basic.new_read_extra_charged = true;
+                            }
+                            if existing_account {
+                                m.initial_preimage_admitted = true;
                             }
                             Ok(())
                         })
@@ -1380,6 +1405,7 @@ mod tests {
     use crate::system_implementation::caches::generic_pubdata_aware_plain_storage::GenericPubdataAwarePlainStorage;
     use crate::system_implementation::system::EthereumLikeStorageAccessCostModel;
     use std::alloc::Global;
+    use std::mem::size_of;
     use storage_models::common_structs::snapshottable_io::SnapshottableIo;
     use zk_ee::internal_error;
     use zk_ee::memory::stack_implementations::vec_stack::VecStackFactory;
@@ -1426,6 +1452,57 @@ mod tests {
                     };
                     let values: Vec<_> = response.iter().collect();
                     Ok(Box::new(values.into_iter()))
+                }
+                _ => Err(internal_error!("unexpected oracle query in test")),
+            }
+        }
+    }
+
+    struct ExistingAccountOracle {
+        account_hash: Bytes32,
+        preimage_words: Vec<usize>,
+        preimage_queries: usize,
+    }
+
+    impl ExistingAccountOracle {
+        fn new(account: &AccountProperties) -> Self {
+            let encoded = account.encoding();
+            let mut padded = encoded.to_vec();
+            let word_size = size_of::<usize>();
+            padded.resize(encoded.len().div_ceil(word_size) * word_size, 0);
+            let preimage_words = padded
+                .chunks_exact(word_size)
+                .map(|chunk| usize::from_ne_bytes(chunk.try_into().unwrap()))
+                .collect();
+
+            Self {
+                account_hash: account.compute_hash(),
+                preimage_words,
+                preimage_queries: 0,
+            }
+        }
+    }
+
+    impl IOOracle for ExistingAccountOracle {
+        type RawIterator<'a> = Box<dyn ExactSizeIterator<Item = usize> + 'static>;
+
+        fn raw_query<'a, I: UsizeSerializable + UsizeDeserializable>(
+            &'a mut self,
+            query_type: u32,
+            _input: &I,
+        ) -> Result<Self::RawIterator<'a>, InternalError> {
+            match query_type {
+                INITIAL_STORAGE_SLOT_VALUE_QUERY_ID => {
+                    let response = InitialStorageSlotData::<EthereumIOTypesConfig> {
+                        is_new_storage_slot: false,
+                        initial_value: self.account_hash,
+                    };
+                    let values: Vec<_> = response.iter().collect();
+                    Ok(Box::new(values.into_iter()))
+                }
+                crate::system_implementation::flat_storage_model::preimage_cache::FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID => {
+                    self.preimage_queries += 1;
+                    Ok(Box::new(self.preimage_words.clone().into_iter()))
                 }
                 _ => Err(internal_error!("unexpected oracle query in test")),
             }
@@ -1505,5 +1582,166 @@ mod tests {
             initial_retained_bytes + reserved_entry_bytes,
             "an already cached account must not reserve twice"
         );
+    }
+
+    #[test]
+    fn cached_account_from_invalidated_tx_readmits_its_preimage() {
+        let mut storage: TestStorage = NewStorageWithAccountPropertiesUnderHash(
+            GenericPubdataAwarePlainStorage::new_from_parts(
+                Global,
+                EthereumLikeStorageAccessCostModel,
+            ),
+        );
+        let mut preimages_cache =
+            BytecodeAndAccountDataPreimagesStorage::<TestResources, Global>::new_from_parts(Global);
+        let mut account_cache = TestAccountCache::new_from_parts(Global);
+        let account = AccountProperties {
+            balance: U256::from(1u64),
+            ..AccountProperties::default()
+        };
+        let mut oracle = ExistingAccountOracle::new(&account);
+        let address = B160::from_limbs([0x5678, 0, 0]);
+        let estimated_entry_bytes =
+            BytecodeAndAccountDataPreimagesStorage::<TestResources, Global>::estimated_entry_bytes(
+                AccountProperties::ENCODED_SIZE,
+            )
+            .unwrap();
+
+        storage.begin_new_tx();
+        preimages_cache.begin_new_tx();
+        account_cache.begin_new_tx();
+        let storage_rollback = storage.start_frame();
+        let preimage_rollback = preimages_cache.start_frame();
+        let account_rollback = account_cache.start_frame();
+
+        let mut first_resources = TestResources::FORMAL_INFINITE;
+        account_cache
+            .touch_account::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut first_resources,
+                &address,
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+            )
+            .unwrap();
+        assert_eq!(
+            preimages_cache.estimated_bytes_added_in_current_tx(),
+            estimated_entry_bytes
+        );
+
+        storage.finish_frame(Some(&storage_rollback)).unwrap();
+        preimages_cache
+            .finish_frame(Some(&preimage_rollback))
+            .unwrap();
+        account_cache.finish_frame(Some(&account_rollback)).unwrap();
+        let retained_bytes = preimages_cache.estimated_retained_bytes();
+        assert!(
+            !account_cache
+                .cache
+                .get((&address).into())
+                .unwrap()
+                .current()
+                .metadata()
+                .initial_preimage_admitted
+        );
+
+        // Do not finish the first candidate: it was dropped. Its initial
+        // account-cache record and raw preimage survive, but neither is part of
+        // the proving run for the next candidate.
+        storage.begin_new_tx();
+        preimages_cache.begin_new_tx();
+        account_cache.begin_new_tx();
+        assert_eq!(preimages_cache.estimated_bytes_added_in_current_tx(), 0);
+        let tx_limit = crate::system_implementation::flat_storage_model::preimage_cache::MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX;
+        let over_limit_bytes = tx_limit - estimated_entry_bytes + 1;
+        preimages_cache.set_estimated_bytes_added_in_current_tx(over_limit_bytes);
+
+        let mut second_resources = TestResources::FORMAL_INFINITE;
+        assert!(account_cache
+            .touch_account::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut second_resources,
+                &address,
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+            )
+            .is_err());
+
+        assert_eq!(
+            oracle.preimage_queries, 1,
+            "decoded account should be reused"
+        );
+        assert!(preimages_cache.tx_limit_hit_for_current_tx());
+        assert!(!preimages_cache.block_limit_hit_for_current_tx());
+        assert_eq!(
+            preimages_cache.estimated_bytes_added_in_current_tx(),
+            over_limit_bytes,
+            "failed re-admission must not partially update the counter"
+        );
+        assert_eq!(preimages_cache.estimated_retained_bytes(), retained_bytes);
+
+        // At the exact boundary, the same account-cache hit must succeed and
+        // consume all remaining transaction-local budget without querying the
+        // oracle or retaining another physical entry.
+        storage.begin_new_tx();
+        preimages_cache.begin_new_tx();
+        account_cache.begin_new_tx();
+        preimages_cache.set_estimated_bytes_added_in_current_tx(tx_limit - estimated_entry_bytes);
+
+        let mut third_resources = TestResources::FORMAL_INFINITE;
+        account_cache
+            .touch_account::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut third_resources,
+                &address,
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+            )
+            .unwrap();
+
+        assert_eq!(
+            preimages_cache.estimated_bytes_added_in_current_tx(),
+            tx_limit,
+            "the surviving account cache must not bypass preimage admission"
+        );
+        assert_eq!(oracle.preimage_queries, 1);
+        assert_eq!(preimages_cache.estimated_retained_bytes(), retained_bytes);
+        assert!(
+            account_cache
+                .cache
+                .get((&address).into())
+                .unwrap()
+                .current()
+                .metadata()
+                .initial_preimage_admitted
+        );
+
+        account_cache.finish_tx(&mut storage).unwrap();
+        storage.finish_tx().unwrap();
+        preimages_cache.finish_tx().unwrap();
+        storage.begin_new_tx();
+        preimages_cache.begin_new_tx();
+        account_cache.begin_new_tx();
+
+        let mut fourth_resources = TestResources::FORMAL_INFINITE;
+        account_cache
+            .touch_account::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut fourth_resources,
+                &address,
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+            )
+            .unwrap();
+        assert_eq!(
+            preimages_cache.estimated_bytes_added_in_current_tx(),
+            0,
+            "an accepted account preimage must not be charged again"
+        );
+        assert_eq!(oracle.preimage_queries, 1);
     }
 }

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -57,10 +57,6 @@ pub type BitsOrd160 = BitsOrd<{ B160::BITS }, { B160::LIMBS }>;
 #[derive(Default, Clone)]
 pub struct AccountPropertiesMetadata {
     pub basic: BasicAccountPropertiesMetadata,
-    /// Whether this account's block-start properties preimage was admitted to
-    /// the transaction-local preimage budget. This is rollback-aware because
-    /// the decoded account-cache entry itself survives a dropped transaction.
-    pub initial_preimage_admitted: bool,
     /// Special flag that allows avoiding publishing bytecode for deployed account.
     /// In practice, it can be set to `true` only during special protocol upgrade txs.
     /// For protocol upgrades it's ensured by governance that bytecodes are already published separately.
@@ -358,18 +354,22 @@ impl<
                 }
                 if is_warm == false {
                     // The initial account-cache record survives a dropped
-                    // candidate. If it represents an existing account, the
-                    // decoded value can bypass `get_preimage` on the next
-                    // candidate, so explicitly re-admit its backing preimage.
-                    // This keeps the per-transaction cache budget identical to
-                    // proving, where the dropped candidate never populated
-                    // either cache.
+                    // candidate, including accesses made before the
+                    // transaction rollback frame was opened. If it represents
+                    // an existing account and was already cached, the decoded
+                    // value bypasses `get_preimage`, so explicitly resolve its
+                    // backing preimage's admission on every cold cache hit.
+                    // The preimage cache's accepted-candidate bitmap, rather
+                    // than rollback placement, decides whether this tx pays.
                     let existing_account = !x.element_properties().is_new_element();
-                    if !is_missing
-                        && existing_account
-                        && !x.current().metadata().initial_preimage_admitted
-                    {
-                        let initial_preimage_hash = x.initial().value().compute_hash();
+                    if !is_missing && existing_account {
+                        let initial_preimage_hash = storage
+                            .initial_account_properties_hash(address)
+                            .ok_or_else(|| {
+                                internal_error!(
+                                    "Materialized account is missing its initial storage hash"
+                                )
+                            })?;
                         preimages_cache.admit_cached_preimage_for_current_tx(
                             &initial_preimage_hash,
                             AccountProperties::ENCODED_SIZE,
@@ -400,9 +400,6 @@ impl<
                             m.basic.last_touched_in_tx = Some(self.current_tx_id);
                             if charge_as_new {
                                 m.basic.new_read_extra_charged = true;
-                            }
-                            if existing_account {
-                                m.initial_preimage_admitted = true;
                             }
                             Ok(())
                         })
@@ -1610,10 +1607,9 @@ mod tests {
         storage.begin_new_tx();
         preimages_cache.begin_new_tx();
         account_cache.begin_new_tx();
-        let storage_rollback = storage.start_frame();
-        let preimage_rollback = preimages_cache.start_frame();
-        let account_rollback = account_cache.start_frame();
 
+        // Match tx_loop's coinbase warm-up: materialize the account before the
+        // transaction rollback handle exists.
         let mut first_resources = TestResources::FORMAL_INFINITE;
         account_cache
             .touch_account::<false>(
@@ -1630,21 +1626,15 @@ mod tests {
             estimated_entry_bytes
         );
 
+        let storage_rollback = storage.start_frame();
+        let preimage_rollback = preimages_cache.start_frame();
+        let account_rollback = account_cache.start_frame();
         storage.finish_frame(Some(&storage_rollback)).unwrap();
         preimages_cache
             .finish_frame(Some(&preimage_rollback))
             .unwrap();
         account_cache.finish_frame(Some(&account_rollback)).unwrap();
         let retained_bytes = preimages_cache.estimated_retained_bytes();
-        assert!(
-            !account_cache
-                .cache
-                .get((&address).into())
-                .unwrap()
-                .current()
-                .metadata()
-                .initial_preimage_admitted
-        );
 
         // Do not finish the first candidate: it was dropped. Its initial
         // account-cache record and raw preimage survive, but neither is part of
@@ -1709,15 +1699,6 @@ mod tests {
         );
         assert_eq!(oracle.preimage_queries, 1);
         assert_eq!(preimages_cache.estimated_retained_bytes(), retained_bytes);
-        assert!(
-            account_cache
-                .cache
-                .get((&address).into())
-                .unwrap()
-                .current()
-                .metadata()
-                .initial_preimage_admitted
-        );
 
         account_cache.finish_tx(&mut storage).unwrap();
         storage.finish_tx().unwrap();

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -222,7 +222,7 @@ impl<
         resources: &mut R,
         address: &B160,
         storage: &mut NewStorageWithAccountPropertiesUnderHash<A, SF, M, R, P>,
-        preimages_cache: &mut impl PreimageCacheModel<Resources = R, PreimageRequest = PreimageRequest>,
+        preimages_cache: &mut BytecodeAndAccountDataPreimagesStorage<R, A>,
         oracle: &mut impl IOOracle,
         is_selfdestruct: bool,
         observe: bool,
@@ -255,13 +255,16 @@ impl<
         // rollback-aware, so the gate is identical across sequencer and proving and
         // never depends on cache-entry presence.
         let current_tx_id = self.current_tx_id;
-        let is_cold = match self.cache.get(address.into()) {
-            Some(item) => !item
-                .current()
-                .metadata()
-                .basic
-                .considered_warm(current_tx_id),
-            None => true,
+        let (is_cold, is_missing) = match self.cache.get(address.into()) {
+            Some(item) => (
+                !item
+                    .current()
+                    .metadata()
+                    .basic
+                    .considered_warm(current_tx_id),
+                false,
+            ),
+            None => (true, true),
         };
         if is_cold {
             let mut probe = resources.clone();
@@ -276,6 +279,14 @@ impl<
                 &mut probe,
                 AccountProperties::ENCODED_SIZE,
             )?;
+        }
+
+        // Every cached account can produce at most one final account snapshot.
+        // Precharge it before materialization so raw entries retained by this or
+        // later invalid candidates can never consume finalization headroom.
+        if is_missing {
+            preimages_cache
+                .reserve_preimage_for_block_finalization(AccountProperties::ENCODED_SIZE)?;
         }
 
         self.cache
@@ -383,7 +394,7 @@ impl<
         address: &B160,
         update_fn: impl FnOnce(&U256) -> Result<U256, BalanceSubsystemError>,
         storage: &mut NewStorageWithAccountPropertiesUnderHash<A, SF, M, R, P>,
-        preimages_cache: &mut impl PreimageCacheModel<Resources = R, PreimageRequest = PreimageRequest>,
+        preimages_cache: &mut BytecodeAndAccountDataPreimagesStorage<R, A>,
         oracle: &mut impl IOOracle,
         is_selfdestruct: bool,
         fee_payment_in_simulation: bool,
@@ -431,7 +442,7 @@ impl<
         to: &B160,
         amount: &U256,
         storage: &mut NewStorageWithAccountPropertiesUnderHash<A, SF, M, R, P>,
-        preimages_cache: &mut impl PreimageCacheModel<Resources = R, PreimageRequest = PreimageRequest>,
+        preimages_cache: &mut BytecodeAndAccountDataPreimagesStorage<R, A>,
         oracle: &mut impl IOOracle,
         is_selfdestruct: bool,
     ) -> Result<(), BalanceSubsystemError> {
@@ -471,17 +482,6 @@ impl<
         )?;
 
         Ok(())
-    }
-
-    /// Returns an upper bound on raw-cache space needed for final account snapshots.
-    /// Every cached account can add at most one fixed-size entry. Counting all cached
-    /// accounts avoids rehashing every changed account after every transaction.
-    pub fn max_pending_preimage_bytes(&self) -> usize {
-        let entry_bytes = BytecodeAndAccountDataPreimagesStorage::<R, A>::estimated_entry_bytes(
-            AccountProperties::ENCODED_SIZE,
-        )
-        .expect("fixed account encoding size must fit in usize");
-        self.cache.iter().len().saturating_mul(entry_bytes)
     }
 
     // special method, not part of the trait as it's not overly generic
@@ -1451,6 +1451,7 @@ mod tests {
 
         let mut resources = TestResources::FORMAL_INFINITE;
         let initial_native = resources.native().as_u64();
+        let initial_retained_bytes = preimages_cache.estimated_retained_bytes();
 
         let previous_balance = account_cache
             .update_nominal_token_value::<false>(
@@ -1476,6 +1477,33 @@ mod tests {
         assert_eq!(
             charged_native, expected_native,
             "no-op balance updates must still pay the warm account-cache write cost"
+        );
+
+        let reserved_entry_bytes =
+            BytecodeAndAccountDataPreimagesStorage::<TestResources, Global>::estimated_entry_bytes(
+                AccountProperties::ENCODED_SIZE,
+            )
+            .unwrap();
+        assert_eq!(
+            preimages_cache.estimated_retained_bytes(),
+            initial_retained_bytes + reserved_entry_bytes,
+            "first materialization must precharge one final account snapshot"
+        );
+
+        account_cache
+            .touch_account::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &mut resources,
+                &address,
+                &mut storage,
+                &mut preimages_cache,
+                &mut oracle,
+            )
+            .unwrap();
+        assert_eq!(
+            preimages_cache.estimated_retained_bytes(),
+            initial_retained_bytes + reserved_entry_bytes,
+            "an already cached account must not reserve twice"
         );
     }
 }

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -370,10 +370,8 @@ impl<
                                     "Materialized account is missing its initial storage hash"
                                 )
                             })?;
-                        preimages_cache.admit_cached_preimage_for_current_tx(
-                            &initial_preimage_hash,
-                            AccountProperties::ENCODED_SIZE,
-                        )?;
+                        preimages_cache
+                            .admit_cached_preimage_for_current_tx(&initial_preimage_hash)?;
                     }
                     Self::charge_ergs_for_cold_access(
                         ee_type,

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache.rs
@@ -473,6 +473,17 @@ impl<
         Ok(())
     }
 
+    /// Returns an upper bound on raw-cache space needed for final account snapshots.
+    /// Every cached account can add at most one fixed-size entry. Counting all cached
+    /// accounts avoids rehashing every changed account after every transaction.
+    pub fn max_pending_preimage_bytes(&self) -> usize {
+        let entry_bytes = BytecodeAndAccountDataPreimagesStorage::<R, A>::estimated_entry_bytes(
+            AccountProperties::ENCODED_SIZE,
+        )
+        .expect("fixed account encoding size must fit in usize");
+        self.cache.iter().len().saturating_mul(entry_bytes)
+    }
+
     // special method, not part of the trait as it's not overly generic
     pub fn persist_changes(
         &self,
@@ -492,8 +503,7 @@ impl<
             // Not part of a transaction, should be included in other costs.
             let mut inf_resources = R::FORMAL_INFINITE;
 
-            let _ = preimages_cache.record_preimage::<false>(
-                ExecutionEnvironmentType::NoEE,
+            let _ = preimages_cache.record_preimage_for_block_finalization(
                 &(PreimageRequest {
                     hash: properties_hash,
                     expected_preimage_len_in_bytes: AccountProperties::ENCODED_SIZE as u32,

--- a/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/account_cache_entry.rs
@@ -455,6 +455,7 @@ mod tests {
     use crypto::MiniDigest;
     use ruint::aliases::U256;
     use std::alloc::Global;
+    use storage_models::common_structs::snapshottable_io::SnapshottableIo;
     use storage_models::common_structs::PreimageCacheModel;
     use zk_ee::common_structs::PreimageType;
     use zk_ee::execution_environment_type::ExecutionEnvironmentType;
@@ -559,6 +560,7 @@ mod tests {
         let mut preimages_cache: BytecodeAndAccountDataPreimagesStorage<
             BaseResources<DecreasingNative>,
         > = BytecodeAndAccountDataPreimagesStorage::new_from_parts(Global);
+        preimages_cache.begin_new_tx();
         let mut resources: BaseResources<DecreasingNative> = BaseResources::FORMAL_INFINITE;
         preimages_cache
             .record_preimage::<false>(
@@ -648,6 +650,7 @@ mod tests {
         let mut preimages_cache: BytecodeAndAccountDataPreimagesStorage<
             BaseResources<DecreasingNative>,
         > = BytecodeAndAccountDataPreimagesStorage::new_from_parts(Global);
+        preimages_cache.begin_new_tx();
         let mut resources: BaseResources<DecreasingNative> = BaseResources::FORMAL_INFINITE;
         preimages_cache
             .record_preimage::<false>(

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -120,6 +120,21 @@ impl<
             + self.storage_cache.calculate_pubdata_used_by_tx()
     }
 
+    fn block_scoped_cache_limit_hit_for_current_tx(&self) -> bool {
+        self.preimages_cache.block_limit_hit_for_current_tx()
+    }
+
+    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
+        let pending_account_preimage_bytes = self.account_data_cache.max_pending_preimage_bytes();
+        !self
+            .preimages_cache
+            .can_retain_additional_bytes(pending_account_preimage_bytes)
+    }
+
+    fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {
+        self.preimages_cache.tx_limit_hit_for_current_tx()
+    }
+
     fn storage_read(
         &mut self,
         ee_type: ExecutionEnvironmentType,

--- a/basic_system/src/system_implementation/flat_storage_model/mod.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/mod.rs
@@ -124,13 +124,6 @@ impl<
         self.preimages_cache.block_limit_hit_for_current_tx()
     }
 
-    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
-        let pending_account_preimage_bytes = self.account_data_cache.max_pending_preimage_bytes();
-        !self
-            .preimages_cache
-            .can_retain_additional_bytes(pending_account_preimage_bytes)
-    }
-
     fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {
         self.preimages_cache.tx_limit_hit_for_current_tx()
     }

--- a/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
@@ -6,6 +6,7 @@ use zk_ee::{
     execution_environment_type::ExecutionEnvironmentType,
     internal_error,
     oracle::query_ids::PREIMAGE_SUBSPACE_MASK,
+    out_of_native_resources,
     system::{
         errors::{internal::InternalError, system::SystemError},
         IOResultKeeper, Resources,
@@ -22,6 +23,22 @@ use crate::cost_constants::blake2s_native_cost;
 pub const FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID: u32 =
     PREIMAGE_SUBSPACE_MASK | FLAT_STORAGE_SUBSPACE_MASK;
 
+/// `UsizeAlignedByteBox` rounds allocations to pairs of native words. Sixteen
+/// bytes covers that rounding on both 32- and 64-bit targets without making
+/// resource charging architecture-dependent.
+const PREIMAGE_CACHE_ALLOCATION_ALIGNMENT: usize = 16;
+/// Conservative allowance for the key, value, B-tree node, and allocator
+/// metadata retained by each raw cache entry.
+const PREIMAGE_CACHE_ENTRY_MEMORY_OVERHEAD: usize = 256;
+/// The raw preimage cache may retain at most 256 MiB, including conservative
+/// per-entry map and allocator overhead.
+pub const MAX_PREIMAGE_CACHE_RETAINED_BYTES: usize = 256 * 1024 * 1024;
+/// A single transaction may add at most half of the block cache limit.
+pub const MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX: usize = MAX_PREIMAGE_CACHE_RETAINED_BYTES / 2;
+
+const _: () =
+    assert!(MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX * 2 == MAX_PREIMAGE_CACHE_RETAINED_BYTES);
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
 pub struct PreimageRequest {
@@ -30,10 +47,26 @@ pub struct PreimageRequest {
     pub preimage_type: PreimageType,
 }
 
+/// Block-scoped cache whose raw entries survive transaction and frame rollback.
+///
+/// Cache hits do not consume either memory budget. Before allocating a miss,
+/// the cache checks both the bytes added by the current transaction and the
+/// total bytes retained by the block. Counters are updated only after a
+/// successful insertion.
+///
+/// Exceeding the transaction budget returns ordinary OON. Exceeding the block
+/// cap sets `block_limit_hit_for_current_tx`; the bootloader then rolls the
+/// transaction back as `BlockNativeLimitReached` without committing effects or
+/// fees. `begin_new_tx` resets transaction-local accounting and flags, but the
+/// raw entries and block-retained byte counter deliberately remain.
 pub struct BytecodeAndAccountDataPreimagesStorage<R: Resources, A: Allocator + Clone = Global> {
     pub(crate) storage: BTreeMap<Bytes32, UsizeAlignedByteBox<A>, A>,
     pub(crate) publication_storage: NewPreimagesPublicationStorage<A>,
     pub(crate) allocator: A,
+    estimated_retained_bytes: usize,
+    estimated_bytes_added_in_current_tx: usize,
+    tx_limit_hit_for_current_tx: bool,
+    block_limit_hit_for_current_tx: bool,
     _marker: PhantomData<R>,
 }
 
@@ -44,8 +77,82 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             storage: BTreeMap::new_in(allocator.clone()),
             publication_storage,
             allocator,
+            estimated_retained_bytes: 0,
+            estimated_bytes_added_in_current_tx: 0,
+            tx_limit_hit_for_current_tx: false,
+            block_limit_hit_for_current_tx: false,
             _marker: PhantomData,
         }
+    }
+
+    /// Used only to log ordinary OON caused by the transaction memory budget.
+    pub fn tx_limit_hit_for_current_tx(&self) -> bool {
+        self.tx_limit_hit_for_current_tx
+    }
+
+    /// Checked after execution so a block cap hit invalidates the transaction
+    /// before any of its effects or fees are committed.
+    pub fn block_limit_hit_for_current_tx(&self) -> bool {
+        self.block_limit_hit_for_current_tx
+    }
+
+    /// Estimates the bytes a new entry would retain, including allocation
+    /// rounding and conservative map/allocator overhead.
+    pub(super) fn estimated_entry_bytes(preimage_len: usize) -> Option<usize> {
+        let aligned_allocation = preimage_len
+            .checked_add(PREIMAGE_CACHE_ALLOCATION_ALIGNMENT - 1)?
+            / PREIMAGE_CACHE_ALLOCATION_ALIGNMENT
+            * PREIMAGE_CACHE_ALLOCATION_ALIGNMENT;
+        aligned_allocation.checked_add(PREIMAGE_CACHE_ENTRY_MEMORY_OVERHEAD)
+    }
+
+    /// Checks a cache miss against the transaction budget and then the block
+    /// cap. The caller commits the returned totals only after insertion.
+    fn next_estimated_byte_totals(
+        &mut self,
+        estimated_entry_bytes: usize,
+        apply_transaction_budget: bool,
+    ) -> Result<(usize, usize), SystemError> {
+        let next_tx_bytes = if apply_transaction_budget {
+            let Some(next_tx_bytes) = self
+                .estimated_bytes_added_in_current_tx
+                .checked_add(estimated_entry_bytes)
+            else {
+                self.tx_limit_hit_for_current_tx = true;
+                return Err(out_of_native_resources!().into());
+            };
+            if next_tx_bytes > MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX {
+                self.tx_limit_hit_for_current_tx = true;
+                return Err(out_of_native_resources!().into());
+            }
+            next_tx_bytes
+        } else {
+            self.estimated_bytes_added_in_current_tx
+        };
+
+        let Some(next_retained_bytes) = self
+            .estimated_retained_bytes
+            .checked_add(estimated_entry_bytes)
+        else {
+            self.block_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        };
+
+        if next_retained_bytes > MAX_PREIMAGE_CACHE_RETAINED_BYTES {
+            self.block_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        }
+
+        Ok((next_tx_bytes, next_retained_bytes))
+    }
+
+    /// Returns whether `additional_bytes` fit under the block-wide retained
+    /// cache cap. This is used to reserve room for deferred account snapshots
+    /// before a transaction is accepted.
+    pub(super) fn can_retain_additional_bytes(&self, additional_bytes: usize) -> bool {
+        self.estimated_retained_bytes
+            .checked_add(additional_bytes)
+            .is_some_and(|total| total <= MAX_PREIMAGE_CACHE_RETAINED_BYTES)
     }
 
     pub fn report_new_preimages(
@@ -68,15 +175,17 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         Ok(())
     }
 
+    /// Charges decommitment work when a caller performs the cache lookup with
+    /// separate, formally infinite resources to keep charging deterministic.
     pub fn charge_decommitment_native_cost(
         resources: &mut R,
         preimage_len: usize,
     ) -> Result<(), SystemError> {
         use zk_ee::system::Computational;
+
         let native_cost =
             PREIMAGE_CACHE_GET_NATIVE_COST.saturating_add(blake2s_native_cost(preimage_len));
-        resources.charge(&R::from_native(R::Native::from_computational(native_cost)))?;
-        Ok(())
+        resources.charge(&R::from_native(R::Native::from_computational(native_cost)))
     }
 
     #[must_use]
@@ -105,6 +214,17 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
                 Ok(cached)
             }
         } else {
+            let estimated_entry_bytes =
+                match Self::estimated_entry_bytes(expected_preimage_len_in_bytes) {
+                    Some(estimated_bytes) => estimated_bytes,
+                    None => {
+                        self.tx_limit_hit_for_current_tx = true;
+                        return Err(out_of_native_resources!().into());
+                    }
+                };
+            let (next_tx_bytes, next_retained_bytes) =
+                self.next_estimated_byte_totals(estimated_entry_bytes, true)?;
+
             // We do not charge for gas in this concrete implementation and
             // expect higher-level model to do so.
             // We charge for native.
@@ -170,6 +290,8 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             }
 
             let inserted = self.storage.entry(*hash).or_insert(buffered);
+            self.estimated_bytes_added_in_current_tx = next_tx_bytes;
+            self.estimated_retained_bytes = next_retained_bytes;
             // Safety: IO implementer that will use it is expected to live beyond any frame (as it's part of the OS),
             // so we can extend the lifetime
             unsafe {
@@ -180,21 +302,79 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         }
     }
 
-    fn insert_verified_preimage(
+    /// Records an account snapshot during block finalization.
+    ///
+    /// Transactions have already been accepted at this point, so this skips
+    /// the transaction-local budget. The block-wide retained-memory cap still
+    /// applies, and room for these snapshots is checked before each candidate
+    /// transaction is accepted.
+    pub(super) fn record_preimage_for_block_finalization(
         &mut self,
-        preimage_type: PreimageType,
-        hash: &Bytes32,
-        preimage: UsizeAlignedByteBox<A>,
+        preimage_type: &PreimageRequest,
+        resources: &mut R,
+        preimage: &[&[u8]],
     ) -> Result<&'static [u8], SystemError> {
-        self.publication_storage
-            .add_preimage(hash, preimage.len(), preimage_type)?;
-        let inserted = self.storage.entry(*hash).or_insert(preimage);
+        self.record_preimage_inner(preimage_type, resources, preimage, false)
+    }
 
-        unsafe {
-            let cached: &'static [u8] = core::mem::transmute(inserted.as_slice());
+    fn record_preimage_inner(
+        &mut self,
+        preimage_type: &PreimageRequest,
+        resources: &mut R,
+        preimage: &[&[u8]],
+        apply_transaction_budget: bool,
+    ) -> Result<&'static [u8], SystemError> {
+        use crate::system_implementation::flat_storage_model::cost_constants::PREIMAGE_CACHE_SET_NATIVE_COST;
+        use zk_ee::system::Computational;
 
-            Ok(cached)
+        let PreimageRequest {
+            hash,
+            expected_preimage_len_in_bytes,
+            preimage_type,
+        } = preimage_type;
+
+        let preimage_len = preimage.iter().try_fold(0usize, |acc, chunk| {
+            acc.checked_add(chunk.len())
+                .ok_or_else(|| internal_error!("Preimage length overflow"))
+        })?;
+        if preimage_len != *expected_preimage_len_in_bytes as usize {
+            return Err(internal_error!("Unexpected preimage length").into());
         }
+
+        let estimated_entry_bytes = match Self::estimated_entry_bytes(preimage_len) {
+            Some(estimated_bytes) => estimated_bytes,
+            None => {
+                if apply_transaction_budget {
+                    self.tx_limit_hit_for_current_tx = true;
+                } else {
+                    self.block_limit_hit_for_current_tx = true;
+                }
+                return Err(out_of_native_resources!().into());
+            }
+        };
+        resources.charge(&R::from_native(R::Native::from_computational(
+            PREIMAGE_CACHE_SET_NATIVE_COST,
+        )))?;
+
+        if self.storage.contains_key(hash) {
+            self.publication_storage
+                .add_preimage(hash, preimage_len, *preimage_type)?;
+            let cached = self.storage.get(hash).expect("preimage was found above");
+            // Safety: the cache is part of the OS and lives beyond every frame.
+            return Ok(unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) });
+        }
+
+        let (next_tx_bytes, next_retained_bytes) =
+            self.next_estimated_byte_totals(estimated_entry_bytes, apply_transaction_budget)?;
+        let boxed_data = UsizeAlignedByteBox::from_slices_in(preimage, self.allocator.clone());
+        self.publication_storage
+            .add_preimage(hash, preimage_len, *preimage_type)?;
+        let inserted = self.storage.entry(*hash).or_insert(boxed_data);
+        self.estimated_bytes_added_in_current_tx = next_tx_bytes;
+        self.estimated_retained_bytes = next_retained_bytes;
+
+        // Safety: the cache is part of the OS and lives beyond every frame.
+        Ok(unsafe { core::mem::transmute::<&[u8], &'static [u8]>(inserted.as_slice()) })
     }
 }
 
@@ -237,24 +417,8 @@ impl<R: Resources, A: Allocator + Clone> PreimageCacheModel
         resources: &mut Self::Resources,
         preimage: &[&[u8]],
     ) -> Result<&'static [u8], SystemError> {
-        use crate::system_implementation::flat_storage_model::cost_constants::PREIMAGE_CACHE_SET_NATIVE_COST;
-        use zk_ee::system::Computational;
         // we will NOT charge ergs for preimages in here, but instead higher-level model should do it
-        resources.charge(&R::from_native(R::Native::from_computational(
-            PREIMAGE_CACHE_SET_NATIVE_COST,
-        )))?;
-
-        let PreimageRequest {
-            hash,
-            expected_preimage_len_in_bytes,
-            preimage_type,
-        } = preimage_type;
-
-        let preimage_len = preimage.iter().fold(0, |acc, chunk| acc + chunk.len());
-        let boxed_data = UsizeAlignedByteBox::from_slices_in(preimage, self.allocator.clone());
-
-        assert_eq!(*expected_preimage_len_in_bytes, preimage_len as u32);
-        self.insert_verified_preimage(*preimage_type, hash, boxed_data)
+        self.record_preimage_inner(preimage_type, resources, preimage, true)
     }
 }
 
@@ -264,6 +428,9 @@ impl<R: Resources, A: Allocator + Clone> SnapshottableIo
     type StateSnapshot = CacheSnapshotId;
 
     fn begin_new_tx(&mut self) {
+        self.estimated_bytes_added_in_current_tx = 0;
+        self.tx_limit_hit_for_current_tx = false;
+        self.block_limit_hit_for_current_tx = false;
         self.publication_storage.begin_new_tx();
     }
 
@@ -281,5 +448,325 @@ impl<R: Resources, A: Allocator + Clone> SnapshottableIo
         rollback_handle: Option<&Self::StateSnapshot>,
     ) -> Result<(), InternalError> {
         self.publication_storage.finish_frame(rollback_handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::{blake2s::Blake2s256, MiniDigest};
+    use std::alloc::Global;
+    use zk_ee::{
+        common_structs::PreimageType,
+        oracle::{
+            usize_serialization::{UsizeDeserializable, UsizeSerializable},
+            IOOracle,
+        },
+        reference_implementations::{BaseResources, DecreasingNative},
+        system::Computational,
+    };
+
+    type TestResources = BaseResources<DecreasingNative>;
+    type TestCache = BytecodeAndAccountDataPreimagesStorage<TestResources>;
+
+    #[derive(Default)]
+    struct TestOracle {
+        words: Vec<usize>,
+        queries: usize,
+    }
+
+    impl IOOracle for TestOracle {
+        type RawIterator<'a> = std::vec::IntoIter<usize>;
+
+        fn raw_query<'a, I: UsizeSerializable + UsizeDeserializable>(
+            &'a mut self,
+            _query_type: u32,
+            _input: &I,
+        ) -> Result<Self::RawIterator<'a>, InternalError> {
+            self.queries += 1;
+            Ok(self.words.clone().into_iter())
+        }
+    }
+
+    fn request_and_oracle() -> (PreimageRequest, TestOracle) {
+        let word = 0x0102_0304usize;
+        let bytes = word.to_ne_bytes();
+        let hash = Bytes32::from_array(Blake2s256::digest(bytes));
+        (
+            PreimageRequest {
+                hash,
+                expected_preimage_len_in_bytes: bytes.len() as u32,
+                preimage_type: PreimageType::Bytecode,
+            },
+            TestOracle {
+                words: vec![word],
+                queries: 0,
+            },
+        )
+    }
+
+    fn resources_with_native(native: u64) -> TestResources {
+        TestResources::from_native(DecreasingNative::from_computational(native))
+    }
+
+    fn decommitment_native_cost(preimage_len: usize) -> u64 {
+        PREIMAGE_CACHE_GET_NATIVE_COST + blake2s_native_cost(preimage_len)
+    }
+
+    fn record_native_cost() -> u64 {
+        super::cost_constants::PREIMAGE_CACHE_SET_NATIVE_COST
+    }
+
+    #[test]
+    fn cache_hit_and_miss_charge_the_same_native() {
+        let (request, mut oracle) = request_and_oracle();
+        let native_cost = decommitment_native_cost(request.expected_preimage_len_in_bytes as usize);
+        let mut cache = TestCache::new_from_parts(Global);
+
+        let mut miss_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut miss_resources,
+                &mut oracle,
+            )
+            .unwrap();
+        let retained_bytes_after_miss = cache.estimated_retained_bytes;
+
+        let mut hit_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut hit_resources,
+                &mut oracle,
+            )
+            .unwrap();
+
+        assert_eq!(miss_resources.native().as_u64(), 0);
+        assert_eq!(hit_resources.native().as_u64(), 0);
+        assert_eq!(oracle.queries, 1);
+        assert_eq!(cache.estimated_retained_bytes, retained_bytes_after_miss);
+        assert_eq!(
+            cache.estimated_bytes_added_in_current_tx,
+            retained_bytes_after_miss
+        );
+    }
+
+    #[test]
+    fn insufficient_native_fails_before_query_or_retention() {
+        let (request, mut oracle) = request_and_oracle();
+        let native_cost = decommitment_native_cost(request.expected_preimage_len_in_bytes as usize);
+        let mut resources = resources_with_native(native_cost - 1);
+        let mut cache = TestCache::new_from_parts(Global);
+
+        assert!(cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut resources,
+                &mut oracle,
+            )
+            .is_err());
+        assert_eq!(oracle.queries, 0);
+        assert_eq!(cache.estimated_retained_bytes, 0);
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, 0);
+        assert!(cache.storage.is_empty());
+        assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+    }
+
+    #[test]
+    fn block_cap_fails_before_query_and_sets_only_block_flag() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage_len).unwrap();
+        let initial_retained_bytes = MAX_PREIMAGE_CACHE_RETAINED_BYTES - estimated_entry_bytes + 1;
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.estimated_retained_bytes = initial_retained_bytes;
+        let mut resources = resources_with_native(decommitment_native_cost(preimage_len));
+
+        assert!(cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut resources,
+                &mut oracle,
+            )
+            .is_err());
+        assert_eq!(oracle.queries, 0);
+        assert!(cache.storage.is_empty());
+        assert_eq!(cache.estimated_retained_bytes, initial_retained_bytes);
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, 0);
+        assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(cache.block_limit_hit_for_current_tx());
+
+        cache.begin_new_tx();
+        assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+        assert_eq!(cache.estimated_retained_bytes, initial_retained_bytes);
+    }
+
+    #[test]
+    fn tx_budget_fails_before_query_and_resets_at_next_tx() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage_len).unwrap();
+        let initial_tx_bytes = MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX - estimated_entry_bytes + 1;
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.estimated_bytes_added_in_current_tx = initial_tx_bytes;
+        let mut resources = resources_with_native(decommitment_native_cost(preimage_len));
+
+        assert!(cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut resources,
+                &mut oracle,
+            )
+            .is_err());
+        assert_eq!(oracle.queries, 0);
+        assert!(cache.storage.is_empty());
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, initial_tx_bytes);
+        assert_eq!(cache.estimated_retained_bytes, 0);
+        assert!(cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+
+        cache.begin_new_tx();
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, 0);
+        assert_eq!(cache.estimated_retained_bytes, 0);
+        assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+    }
+
+    #[test]
+    fn duplicate_record_and_frame_rollback_preserve_retained_byte_accounting() {
+        let preimage = [1u8, 2, 3, 4, 5];
+        let request = PreimageRequest {
+            hash: Bytes32::from_array(Blake2s256::digest(preimage)),
+            expected_preimage_len_in_bytes: preimage.len() as u32,
+            preimage_type: PreimageType::Bytecode,
+        };
+        let native_cost = record_native_cost();
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.begin_new_tx();
+        let rollback_handle = cache.start_frame();
+
+        let mut first_resources = resources_with_native(native_cost);
+        cache
+            .record_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut first_resources,
+                &[&preimage],
+            )
+            .unwrap();
+        let retained_bytes_after_first = cache.estimated_retained_bytes;
+        let tx_bytes_after_first = cache.estimated_bytes_added_in_current_tx;
+
+        let mut duplicate_resources = resources_with_native(native_cost);
+        cache
+            .record_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut duplicate_resources,
+                &[&preimage],
+            )
+            .unwrap();
+        assert_eq!(cache.storage.len(), 1);
+        assert_eq!(cache.estimated_retained_bytes, retained_bytes_after_first);
+        assert_eq!(
+            cache.estimated_bytes_added_in_current_tx,
+            tx_bytes_after_first
+        );
+
+        cache.finish_frame(Some(&rollback_handle)).unwrap();
+        assert_eq!(cache.storage.len(), 1);
+        assert_eq!(cache.estimated_retained_bytes, retained_bytes_after_first);
+        assert_eq!(
+            cache.estimated_bytes_added_in_current_tx,
+            tx_bytes_after_first
+        );
+    }
+
+    #[test]
+    fn record_checks_tx_budget_before_inserting() {
+        let preimage = [9u8; 16];
+        let request = PreimageRequest {
+            hash: Bytes32::from_array(Blake2s256::digest(preimage)),
+            expected_preimage_len_in_bytes: preimage.len() as u32,
+            preimage_type: PreimageType::Bytecode,
+        };
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage.len()).unwrap();
+        let initial_tx_bytes = MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX - estimated_entry_bytes + 1;
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.estimated_bytes_added_in_current_tx = initial_tx_bytes;
+        let mut resources = resources_with_native(record_native_cost());
+
+        assert!(cache
+            .record_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut resources,
+                &[&preimage],
+            )
+            .is_err());
+        assert!(cache.storage.is_empty());
+        assert_eq!(cache.estimated_retained_bytes, 0);
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, initial_tx_bytes);
+        assert!(cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+    }
+
+    #[test]
+    fn block_finalization_skips_tx_budget_but_still_checks_block_cap() {
+        let preimage = [7u8; 16];
+        let request = PreimageRequest {
+            hash: Bytes32::from_array(Blake2s256::digest(preimage)),
+            expected_preimage_len_in_bytes: preimage.len() as u32,
+            preimage_type: PreimageType::AccountData,
+        };
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage.len()).unwrap();
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.estimated_bytes_added_in_current_tx = MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX;
+        let mut resources = resources_with_native(record_native_cost());
+
+        cache
+            .record_preimage_for_block_finalization(&request, &mut resources, &[&preimage])
+            .unwrap();
+        assert_eq!(cache.estimated_retained_bytes, estimated_entry_bytes);
+        assert_eq!(
+            cache.estimated_bytes_added_in_current_tx,
+            MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX
+        );
+        assert!(!cache.tx_limit_hit_for_current_tx());
+
+        let second_preimage = [8u8; 16];
+        let second_request = PreimageRequest {
+            hash: Bytes32::from_array(Blake2s256::digest(second_preimage)),
+            expected_preimage_len_in_bytes: second_preimage.len() as u32,
+            preimage_type: PreimageType::AccountData,
+        };
+        cache.estimated_retained_bytes =
+            MAX_PREIMAGE_CACHE_RETAINED_BYTES - estimated_entry_bytes + 1;
+        let mut second_resources = resources_with_native(record_native_cost());
+        assert!(cache
+            .record_preimage_for_block_finalization(
+                &second_request,
+                &mut second_resources,
+                &[&second_preimage],
+            )
+            .is_err());
+        assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(cache.block_limit_hit_for_current_tx());
+    }
+
+    #[test]
+    fn tx_budget_is_half_the_block_cap() {
+        assert_eq!(
+            MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX * 2,
+            MAX_PREIMAGE_CACHE_RETAINED_BYTES
+        );
     }
 }

--- a/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
@@ -1,5 +1,6 @@
 use alloc::{alloc::Global, collections::BTreeMap};
 use core::{alloc::Allocator, marker::PhantomData};
+use evm_interpreter::BitMapOwned;
 use storage_models::common_structs::{snapshottable_io::SnapshottableIo, PreimageCacheModel};
 use zk_ee::{
     common_structs::{history_map::CacheSnapshotId, NewPreimagesPublicationStorage, PreimageType},
@@ -23,13 +24,15 @@ use crate::cost_constants::blake2s_native_cost;
 pub const FLAT_STORAGE_GENERIC_PREIMAGE_QUERY_ID: u32 =
     PREIMAGE_SUBSPACE_MASK | FLAT_STORAGE_SUBSPACE_MASK;
 
-/// `UsizeAlignedByteBox` rounds allocations to pairs of native words. Sixteen
-/// bytes covers that rounding on both 32- and 64-bit targets without making
-/// resource charging architecture-dependent.
-const PREIMAGE_CACHE_ALLOCATION_ALIGNMENT: usize = 16;
+/// On the 32-bit proving target, `UsizeAlignedByteBox` rounds allocations to
+/// pairs of four-byte native words.
+const PREIMAGE_CACHE_ALLOCATION_ALIGNMENT: usize = 8;
 /// Conservative allowance for the key, value, B-tree node, and allocator
 /// metadata retained by each raw cache entry.
 const PREIMAGE_CACHE_ENTRY_MEMORY_OVERHEAD: usize = 256;
+/// Transaction indices in logs are `u16`. Cache candidate IDs deliberately
+/// use the same fixed domain; `begin_new_tx` rejects any attempt to exceed it.
+const MAX_PREIMAGE_CACHE_TX_IDS: usize = u16::MAX as usize + 1;
 /// The raw preimage cache may retain at most 256 MiB, including conservative
 /// per-entry map and allocator overhead.
 pub const MAX_PREIMAGE_CACHE_RETAINED_BYTES: usize = 256 * 1024 * 1024;
@@ -47,12 +50,34 @@ pub struct PreimageRequest {
     pub preimage_type: PreimageType,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PreimageAdmission {
+    /// The entry was introduced by a transaction known to be included in the
+    /// block, or by block finalization.
+    Accepted,
+    /// The entry was first retained while this candidate transaction was
+    /// executing. Its acceptance is resolved lazily through the bitmap.
+    Pending(u16),
+}
+
+struct CachedPreimage<A: Allocator> {
+    bytes: UsizeAlignedByteBox<A>,
+    admission: PreimageAdmission,
+}
+
+impl<A: Allocator> CachedPreimage<A> {
+    fn as_slice(&self) -> &[u8] {
+        self.bytes.as_slice()
+    }
+}
+
 /// Block-scoped cache whose raw entries survive transaction and frame rollback.
 ///
 /// The block budget includes physical entries and conservative precharges for
-/// final account snapshots. Cache hits do not consume either memory budget.
-/// Before allocating a miss, the cache checks both the bytes added by the
-/// current transaction and the total bytes retained or reserved by the block.
+/// final account snapshots. Physical cache hits do not consume it. They bypass
+/// the transaction budget only when the entry was introduced by an accepted
+/// transaction or was already counted for the current candidate. Before a
+/// physical miss is allocated, the cache checks both budgets.
 ///
 /// Exceeding the transaction budget returns ordinary OON. Exceeding the block
 /// cap sets `block_limit_hit_for_current_tx`; the bootloader then rolls the
@@ -60,9 +85,16 @@ pub struct PreimageRequest {
 /// fees. `begin_new_tx` resets transaction-local accounting and flags, but the
 /// raw entries and block-retained-or-reserved byte counter deliberately remain.
 pub struct BytecodeAndAccountDataPreimagesStorage<R: Resources, A: Allocator + Clone = Global> {
-    pub(crate) storage: BTreeMap<Bytes32, UsizeAlignedByteBox<A>, A>,
+    storage: BTreeMap<Bytes32, CachedPreimage<A>, A>,
     pub(crate) publication_storage: NewPreimagesPublicationStorage<A>,
     pub(crate) allocator: A,
+    accepted_transactions: BitMapOwned<A>,
+    /// ID of the candidate currently executing, or `None` outside candidate
+    /// execution and after the fixed `u16` ID space is exhausted.
+    current_tx_id: Option<u16>,
+    /// ID to assign to the next candidate. `None` means all `u16` IDs have
+    /// already been used.
+    next_tx_id: Option<u16>,
     estimated_retained_bytes: usize,
     estimated_bytes_added_in_current_tx: usize,
     tx_limit_hit_for_current_tx: bool,
@@ -73,10 +105,15 @@ pub struct BytecodeAndAccountDataPreimagesStorage<R: Resources, A: Allocator + C
 impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<R, A> {
     pub fn new_from_parts(allocator: A) -> Self {
         let publication_storage = NewPreimagesPublicationStorage::new_from_parts(allocator.clone());
+        let accepted_transactions =
+            BitMapOwned::allocate_for_bit_capacity(MAX_PREIMAGE_CACHE_TX_IDS, allocator.clone());
         Self {
             storage: BTreeMap::new_in(allocator.clone()),
             publication_storage,
             allocator,
+            accepted_transactions,
+            current_tx_id: None,
+            next_tx_id: Some(0),
             estimated_retained_bytes: 0,
             estimated_bytes_added_in_current_tx: 0,
             tx_limit_hit_for_current_tx: false,
@@ -111,26 +148,39 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         self.estimated_retained_bytes
     }
 
-    /// Checks a cache miss against the transaction budget and then the block
-    /// cap. The caller commits the returned totals only after insertion.
+    /// Computes the transaction-local total after charging one logically new
+    /// cache entry. On overflow or limit exhaustion it sets the transaction
+    /// flag and returns OON; otherwise the caller commits the returned total
+    /// only after admission or insertion succeeds.
+    fn next_estimated_tx_bytes(
+        &mut self,
+        estimated_entry_bytes: usize,
+    ) -> Result<usize, SystemError> {
+        let Some(next_tx_bytes) = self
+            .estimated_bytes_added_in_current_tx
+            .checked_add(estimated_entry_bytes)
+        else {
+            self.tx_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        };
+        if next_tx_bytes > MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX {
+            self.tx_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        }
+
+        Ok(next_tx_bytes)
+    }
+
+    /// Checks a physical cache miss against the transaction budget and then
+    /// the block cap. The caller commits the returned totals only after a
+    /// successful insertion.
     fn next_estimated_byte_totals(
         &mut self,
         estimated_entry_bytes: usize,
         apply_transaction_budget: bool,
     ) -> Result<(usize, usize), SystemError> {
         let next_tx_bytes = if apply_transaction_budget {
-            let Some(next_tx_bytes) = self
-                .estimated_bytes_added_in_current_tx
-                .checked_add(estimated_entry_bytes)
-            else {
-                self.tx_limit_hit_for_current_tx = true;
-                return Err(out_of_native_resources!().into());
-            };
-            if next_tx_bytes > MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX {
-                self.tx_limit_hit_for_current_tx = true;
-                return Err(out_of_native_resources!().into());
-            }
-            next_tx_bytes
+            self.next_estimated_tx_bytes(estimated_entry_bytes)?
         } else {
             self.estimated_bytes_added_in_current_tx
         };
@@ -149,6 +199,84 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         }
 
         Ok((next_tx_bytes, next_retained_bytes))
+    }
+
+    /// Returns the ID of the candidate that may own a `Pending` entry.
+    fn active_candidate_id(&self) -> Result<u16, SystemError> {
+        match self.current_tx_id {
+            Some(tx_id) => Ok(tx_id),
+            None if self.block_limit_hit_for_current_tx => Err(out_of_native_resources!().into()),
+            None => Err(
+                internal_error!("pending preimage admission requires an active candidate").into(),
+            ),
+        }
+    }
+
+    /// Chooses admission for a physical miss. Work outside candidate execution
+    /// is common to sequencing and proving and is accepted immediately.
+    fn admission_for_new_preimage(&self) -> Result<PreimageAdmission, SystemError> {
+        match self.current_tx_id {
+            Some(tx_id) => Ok(PreimageAdmission::Pending(tx_id)),
+            None if self.block_limit_hit_for_current_tx => Err(out_of_native_resources!().into()),
+            None => Ok(PreimageAdmission::Accepted),
+        }
+    }
+
+    /// Makes a physical cache hit logically visible to the current candidate.
+    /// Entries introduced by invalidated candidates are charged again, while
+    /// entries introduced by accepted candidates are lazily canonicalized.
+    fn admit_cached_preimage_for_current_tx(
+        &mut self,
+        hash: &Bytes32,
+        admission: PreimageAdmission,
+        preimage_len: usize,
+    ) -> Result<(), SystemError> {
+        match admission {
+            // Block-level work or a previous lookup already established that
+            // this entry belongs to the accepted block state.
+            PreimageAdmission::Accepted => Ok(()),
+            // The entry is still tagged with its creator, but that candidate
+            // was accepted. Canonicalize it lazily; the current candidate does
+            // not pay the transaction-local cache charge again.
+            PreimageAdmission::Pending(tx_id)
+                if self
+                    .accepted_transactions
+                    .get_bit(tx_id as usize)
+                    .unwrap_or(false) =>
+            {
+                self.storage
+                    .get_mut(hash)
+                    .expect("cached preimage must remain present")
+                    .admission = PreimageAdmission::Accepted;
+                Ok(())
+            }
+            PreimageAdmission::Pending(tx_id) => {
+                let current_tx_id = self.active_candidate_id()?;
+                // The current candidate created or already re-admitted this
+                // entry, so it has already paid the transaction-local charge.
+                if tx_id == current_tx_id {
+                    return Ok(());
+                }
+                // The creator was not accepted and is not the current
+                // candidate. Its bytes remain physically cached, but the entry
+                // is logically new here: charge it and transfer Pending
+                // ownership to the current candidate.
+                let estimated_entry_bytes = match Self::estimated_entry_bytes(preimage_len) {
+                    Some(estimated_bytes) => estimated_bytes,
+                    None => {
+                        self.tx_limit_hit_for_current_tx = true;
+                        return Err(out_of_native_resources!().into());
+                    }
+                };
+                let next_tx_bytes = self.next_estimated_tx_bytes(estimated_entry_bytes)?;
+                self.storage
+                    .get_mut(hash)
+                    .expect("cached preimage must remain present")
+                    .admission = PreimageAdmission::Pending(current_tx_id);
+                self.estimated_bytes_added_in_current_tx = next_tx_bytes;
+                Ok(())
+            }
+        }
     }
 
     /// Conservatively precharges one cache entry that may be materialized
@@ -234,12 +362,18 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         Self::charge_decommitment_native_cost(resources, expected_preimage_len_in_bytes)?;
 
         if let Some(cached) = self.storage.get(hash) {
-            unsafe {
-                let cached: &'static [u8] = core::mem::transmute(cached.as_slice());
-
-                Ok(cached)
-            }
+            let admission = cached.admission;
+            // Safety: the backing allocation is owned by the block-scoped
+            // cache and entries are never removed.
+            let cached = unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) };
+            self.admit_cached_preimage_for_current_tx(
+                hash,
+                admission,
+                expected_preimage_len_in_bytes,
+            )?;
+            Ok(cached)
         } else {
+            let admission = self.admission_for_new_preimage()?;
             let estimated_entry_bytes =
                 match Self::estimated_entry_bytes(expected_preimage_len_in_bytes) {
                     Some(estimated_bytes) => estimated_bytes,
@@ -315,7 +449,10 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
                 });
             }
 
-            let inserted = self.storage.entry(*hash).or_insert(buffered);
+            let inserted = self.storage.entry(*hash).or_insert(CachedPreimage {
+                bytes: buffered,
+                admission,
+            });
             self.estimated_bytes_added_in_current_tx = next_tx_bytes;
             self.estimated_retained_bytes = next_retained_bytes;
             // Safety: IO implementer that will use it is expected to live beyond any frame (as it's part of the OS),
@@ -379,14 +516,29 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             PREIMAGE_CACHE_SET_NATIVE_COST,
         )))?;
 
-        if self.storage.contains_key(hash) {
+        if let Some(cached) = self.storage.get(hash) {
+            let admission = cached.admission;
+            // Safety: the backing allocation is owned by the block-scoped
+            // cache and entries are never removed.
+            let cached = unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) };
+            if apply_transaction_budget {
+                self.admit_cached_preimage_for_current_tx(hash, admission, preimage_len)?;
+            } else if admission != PreimageAdmission::Accepted {
+                self.storage
+                    .get_mut(hash)
+                    .expect("cached preimage must remain present")
+                    .admission = PreimageAdmission::Accepted;
+            }
             self.publication_storage
                 .add_preimage(hash, preimage_len, *preimage_type)?;
-            let cached = self.storage.get(hash).expect("preimage was found above");
-            // Safety: the cache is part of the OS and lives beyond every frame.
-            return Ok(unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) });
+            return Ok(cached);
         }
 
+        let admission = if apply_transaction_budget {
+            PreimageAdmission::Pending(self.active_candidate_id()?)
+        } else {
+            PreimageAdmission::Accepted
+        };
         let (next_tx_bytes, next_retained_bytes) = if apply_transaction_budget {
             self.next_estimated_byte_totals(estimated_entry_bytes, true)?
         } else {
@@ -398,7 +550,10 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         let boxed_data = UsizeAlignedByteBox::from_slices_in(preimage, self.allocator.clone());
         self.publication_storage
             .add_preimage(hash, preimage_len, *preimage_type)?;
-        let inserted = self.storage.entry(*hash).or_insert(boxed_data);
+        let inserted = self.storage.entry(*hash).or_insert(CachedPreimage {
+            bytes: boxed_data,
+            admission,
+        });
         self.estimated_bytes_added_in_current_tx = next_tx_bytes;
         self.estimated_retained_bytes = next_retained_bytes;
 
@@ -459,11 +614,27 @@ impl<R: Resources, A: Allocator + Clone> SnapshottableIo
     fn begin_new_tx(&mut self) {
         self.estimated_bytes_added_in_current_tx = 0;
         self.tx_limit_hit_for_current_tx = false;
-        self.block_limit_hit_for_current_tx = false;
+        self.current_tx_id = self.next_tx_id;
+        if let Some(tx_id) = self.current_tx_id {
+            self.next_tx_id = tx_id.checked_add(1);
+            self.block_limit_hit_for_current_tx = false;
+        } else {
+            // All `u16` candidate IDs were used. Do not wrap and alias an
+            // earlier candidate's acceptance bit.
+            self.block_limit_hit_for_current_tx = true;
+        }
         self.publication_storage.begin_new_tx();
     }
 
     fn finish_tx(&mut self) -> Result<(), InternalError> {
+        let tx_id = self.current_tx_id.take().ok_or_else(|| {
+            internal_error!("cannot accept a transaction without a valid u16 candidate ID")
+        })?;
+        if !self.accepted_transactions.set_bit_on(tx_id as usize) {
+            return Err(internal_error!(
+                "transaction ID is outside the acceptance bitmap"
+            ));
+        }
         self.publication_storage.finish_tx();
         Ok(())
     }
@@ -579,8 +750,167 @@ mod tests {
         assert_eq!(cache.estimated_retained_bytes, retained_bytes_after_miss);
         assert_eq!(
             cache.estimated_bytes_added_in_current_tx,
-            retained_bytes_after_miss
+            TestCache::estimated_entry_bytes(request.expected_preimage_len_in_bytes as usize)
+                .unwrap()
         );
+    }
+
+    #[test]
+    fn cache_entry_from_invalidated_tx_is_charged_again() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let native_cost = decommitment_native_cost(preimage_len);
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage_len).unwrap();
+        let mut cache = TestCache::new_from_parts(Global);
+
+        cache.begin_new_tx();
+        let rollback_handle = cache.start_frame();
+        let mut first_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut first_resources,
+                &mut oracle,
+            )
+            .unwrap();
+        cache.finish_frame(Some(&rollback_handle)).unwrap();
+        let retained_bytes = cache.estimated_retained_bytes;
+
+        // Starting the next candidate without finishing the previous one
+        // leaves transaction 0 invalidated.
+        cache.begin_new_tx();
+        let mut second_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut second_resources,
+                &mut oracle,
+            )
+            .unwrap();
+
+        assert_eq!(oracle.queries, 1);
+        assert_eq!(cache.estimated_retained_bytes, retained_bytes);
+        assert_eq!(
+            cache.estimated_bytes_added_in_current_tx,
+            estimated_entry_bytes
+        );
+        assert_eq!(
+            cache.storage.get(&request.hash).unwrap().admission,
+            PreimageAdmission::Pending(1)
+        );
+    }
+
+    #[test]
+    fn block_level_entry_is_accepted_before_first_candidate() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let native_cost = decommitment_native_cost(preimage_len);
+        let mut cache = TestCache::new_from_parts(Global);
+
+        let mut block_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::NoEE,
+                &request,
+                &mut block_resources,
+                &mut oracle,
+            )
+            .unwrap();
+        assert_eq!(
+            cache.storage.get(&request.hash).unwrap().admission,
+            PreimageAdmission::Accepted
+        );
+
+        // Candidate 0 is invalidated without touching the entry. Candidate 1
+        // must still see the common block-level entry as accepted.
+        cache.begin_new_tx();
+        cache.begin_new_tx();
+        let mut tx_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut tx_resources,
+                &mut oracle,
+            )
+            .unwrap();
+
+        assert_eq!(oracle.queries, 1);
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, 0);
+    }
+
+    #[test]
+    fn cache_entry_from_accepted_tx_is_lazily_promoted() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let native_cost = decommitment_native_cost(preimage_len);
+        let mut cache = TestCache::new_from_parts(Global);
+
+        cache.begin_new_tx();
+        let rollback_handle = cache.start_frame();
+        let mut first_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut first_resources,
+                &mut oracle,
+            )
+            .unwrap();
+        // Raw preimages and their pending admission survive internal frame
+        // rollback. Accepting the transaction resolves the pending tx ID.
+        cache.finish_frame(Some(&rollback_handle)).unwrap();
+        cache.finish_tx().unwrap();
+
+        cache.begin_new_tx();
+        let mut second_resources = resources_with_native(native_cost);
+        cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut second_resources,
+                &mut oracle,
+            )
+            .unwrap();
+
+        assert_eq!(oracle.queries, 1);
+        assert_eq!(cache.estimated_bytes_added_in_current_tx, 0);
+        assert_eq!(
+            cache.storage.get(&request.hash).unwrap().admission,
+            PreimageAdmission::Accepted
+        );
+    }
+
+    #[test]
+    fn transaction_id_limit_does_not_wrap() {
+        let (request, mut oracle) = request_and_oracle();
+        let preimage_len = request.expected_preimage_len_in_bytes as usize;
+        let native_cost = decommitment_native_cost(preimage_len);
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.next_tx_id = Some(u16::MAX);
+
+        cache.begin_new_tx();
+        assert_eq!(cache.current_tx_id, Some(u16::MAX));
+        assert_eq!(cache.next_tx_id, None);
+        assert!(!cache.block_limit_hit_for_current_tx());
+        cache.finish_tx().unwrap();
+
+        cache.begin_new_tx();
+        assert_eq!(cache.current_tx_id, None);
+        assert!(cache.block_limit_hit_for_current_tx());
+        let mut resources = resources_with_native(native_cost);
+        assert!(cache
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &request,
+                &mut resources,
+                &mut oracle,
+            )
+            .is_err());
+        assert_eq!(oracle.queries, 0);
+        assert!(cache.finish_tx().is_err());
     }
 
     #[test]
@@ -730,6 +1060,7 @@ mod tests {
         let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage.len()).unwrap();
         let initial_tx_bytes = MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX - estimated_entry_bytes + 1;
         let mut cache = TestCache::new_from_parts(Global);
+        cache.begin_new_tx();
         cache.estimated_bytes_added_in_current_tx = initial_tx_bytes;
         let mut resources = resources_with_native(record_native_cost());
 
@@ -837,10 +1168,7 @@ mod tests {
             .unwrap();
         cache.finish_frame(Some(&rollback_handle)).unwrap();
 
-        assert_eq!(
-            cache.estimated_retained_bytes,
-            ACCEPTED_TX_BITMAP_BYTES + estimated_entry_bytes
-        );
+        assert_eq!(cache.estimated_retained_bytes, estimated_entry_bytes);
     }
 
     #[test]

--- a/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
@@ -148,6 +148,16 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         self.estimated_retained_bytes
     }
 
+    #[cfg(test)]
+    pub(super) fn estimated_bytes_added_in_current_tx(&self) -> usize {
+        self.estimated_bytes_added_in_current_tx
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_estimated_bytes_added_in_current_tx(&mut self, bytes: usize) {
+        self.estimated_bytes_added_in_current_tx = bytes;
+    }
+
     /// Computes the transaction-local total after charging one logically new
     /// cache entry. On overflow or limit exhaustion it sets the transaction
     /// flag and returns OON; otherwise the caller commits the returned total
@@ -225,7 +235,7 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
     /// Makes a physical cache hit logically visible to the current candidate.
     /// Entries introduced by invalidated candidates are charged again, while
     /// entries introduced by accepted candidates are lazily canonicalized.
-    fn admit_cached_preimage_for_current_tx(
+    fn admit_cached_preimage_with_admission_for_current_tx(
         &mut self,
         hash: &Bytes32,
         admission: PreimageAdmission,
@@ -277,6 +287,34 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
                 Ok(())
             }
         }
+    }
+
+    /// Re-admits a preimage whose decoded value was served by a higher-level
+    /// cache instead of through `get_preimage`.
+    ///
+    /// Account-cache entries survive a dropped candidate. On a later cold
+    /// account access, the decoded properties can therefore be reused without
+    /// another preimage-cache lookup. Admission must still be resolved here so
+    /// a preimage introduced only by the dropped candidate consumes the later
+    /// candidate's transaction-local budget, just as it does in proving.
+    pub(super) fn admit_cached_preimage_for_current_tx(
+        &mut self,
+        hash: &Bytes32,
+        expected_preimage_len: usize,
+    ) -> Result<(), SystemError> {
+        let admission = match self.storage.get(hash) {
+            Some(cached) if cached.as_slice().len() == expected_preimage_len => cached.admission,
+            Some(_) => return Err(internal_error!("Cached preimage length mismatch").into()),
+            None => {
+                return Err(internal_error!("Materialized preimage is missing from cache").into());
+            }
+        };
+
+        self.admit_cached_preimage_with_admission_for_current_tx(
+            hash,
+            admission,
+            expected_preimage_len,
+        )
     }
 
     /// Conservatively precharges one cache entry that may be materialized
@@ -366,7 +404,7 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             // Safety: the backing allocation is owned by the block-scoped
             // cache and entries are never removed.
             let cached = unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) };
-            self.admit_cached_preimage_for_current_tx(
+            self.admit_cached_preimage_with_admission_for_current_tx(
                 hash,
                 admission,
                 expected_preimage_len_in_bytes,
@@ -522,7 +560,11 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             // cache and entries are never removed.
             let cached = unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) };
             if apply_transaction_budget {
-                self.admit_cached_preimage_for_current_tx(hash, admission, preimage_len)?;
+                self.admit_cached_preimage_with_admission_for_current_tx(
+                    hash,
+                    admission,
+                    preimage_len,
+                )?;
             } else if admission != PreimageAdmission::Accepted {
                 self.storage
                     .get_mut(hash)

--- a/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
@@ -49,16 +49,16 @@ pub struct PreimageRequest {
 
 /// Block-scoped cache whose raw entries survive transaction and frame rollback.
 ///
-/// Cache hits do not consume either memory budget. Before allocating a miss,
-/// the cache checks both the bytes added by the current transaction and the
-/// total bytes retained by the block. Counters are updated only after a
-/// successful insertion.
+/// The block budget includes physical entries and conservative precharges for
+/// final account snapshots. Cache hits do not consume either memory budget.
+/// Before allocating a miss, the cache checks both the bytes added by the
+/// current transaction and the total bytes retained or reserved by the block.
 ///
 /// Exceeding the transaction budget returns ordinary OON. Exceeding the block
 /// cap sets `block_limit_hit_for_current_tx`; the bootloader then rolls the
 /// transaction back as `BlockNativeLimitReached` without committing effects or
 /// fees. `begin_new_tx` resets transaction-local accounting and flags, but the
-/// raw entries and block-retained byte counter deliberately remain.
+/// raw entries and block-retained-or-reserved byte counter deliberately remain.
 pub struct BytecodeAndAccountDataPreimagesStorage<R: Resources, A: Allocator + Clone = Global> {
     pub(crate) storage: BTreeMap<Bytes32, UsizeAlignedByteBox<A>, A>,
     pub(crate) publication_storage: NewPreimagesPublicationStorage<A>,
@@ -106,6 +106,11 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         aligned_allocation.checked_add(PREIMAGE_CACHE_ENTRY_MEMORY_OVERHEAD)
     }
 
+    #[cfg(test)]
+    pub(super) fn estimated_retained_bytes(&self) -> usize {
+        self.estimated_retained_bytes
+    }
+
     /// Checks a cache miss against the transaction budget and then the block
     /// cap. The caller commits the returned totals only after insertion.
     fn next_estimated_byte_totals(
@@ -146,13 +151,34 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         Ok((next_tx_bytes, next_retained_bytes))
     }
 
-    /// Returns whether `additional_bytes` fit under the block-wide retained
-    /// cache cap. This is used to reserve room for deferred account snapshots
-    /// before a transaction is accepted.
-    pub(super) fn can_retain_additional_bytes(&self, additional_bytes: usize) -> bool {
-        self.estimated_retained_bytes
-            .checked_add(additional_bytes)
-            .is_some_and(|total| total <= MAX_PREIMAGE_CACHE_RETAINED_BYTES)
+    /// Conservatively precharges one cache entry that may be materialized
+    /// during block finalization. Reservations deliberately survive rollback,
+    /// just like raw cache entries and account-cache materialization.
+    pub(super) fn reserve_preimage_for_block_finalization(
+        &mut self,
+        preimage_len: usize,
+    ) -> Result<(), SystemError> {
+        let estimated_entry_bytes = match Self::estimated_entry_bytes(preimage_len) {
+            Some(estimated_bytes) => estimated_bytes,
+            None => {
+                self.block_limit_hit_for_current_tx = true;
+                return Err(out_of_native_resources!().into());
+            }
+        };
+        let Some(next_retained_bytes) = self
+            .estimated_retained_bytes
+            .checked_add(estimated_entry_bytes)
+        else {
+            self.block_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        };
+        if next_retained_bytes > MAX_PREIMAGE_CACHE_RETAINED_BYTES {
+            self.block_limit_hit_for_current_tx = true;
+            return Err(out_of_native_resources!().into());
+        }
+
+        self.estimated_retained_bytes = next_retained_bytes;
+        Ok(())
     }
 
     pub fn report_new_preimages(
@@ -302,12 +328,9 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         }
     }
 
-    /// Records an account snapshot during block finalization.
-    ///
-    /// Transactions have already been accepted at this point, so this skips
-    /// the transaction-local budget. The block-wide retained-memory cap still
-    /// applies, and room for these snapshots is checked before each candidate
-    /// transaction is accepted.
+    /// Records an account snapshot during block finalization. Its retained
+    /// memory was conservatively precharged when the account first entered the
+    /// account cache, so insertion must not charge either budget again.
     pub(super) fn record_preimage_for_block_finalization(
         &mut self,
         preimage_type: &PreimageRequest,
@@ -364,8 +387,14 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
             return Ok(unsafe { core::mem::transmute::<&[u8], &'static [u8]>(cached.as_slice()) });
         }
 
-        let (next_tx_bytes, next_retained_bytes) =
-            self.next_estimated_byte_totals(estimated_entry_bytes, apply_transaction_budget)?;
+        let (next_tx_bytes, next_retained_bytes) = if apply_transaction_budget {
+            self.next_estimated_byte_totals(estimated_entry_bytes, true)?
+        } else {
+            (
+                self.estimated_bytes_added_in_current_tx,
+                self.estimated_retained_bytes,
+            )
+        };
         let boxed_data = UsizeAlignedByteBox::from_slices_in(preimage, self.allocator.clone());
         self.publication_storage
             .add_preimage(hash, preimage_len, *preimage_type)?;
@@ -720,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn block_finalization_skips_tx_budget_but_still_checks_block_cap() {
+    fn block_finalization_uses_precharged_budget() {
         let preimage = [7u8; 16];
         let request = PreimageRequest {
             hash: Bytes32::from_array(Blake2s256::digest(preimage)),
@@ -730,36 +759,88 @@ mod tests {
         let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage.len()).unwrap();
         let mut cache = TestCache::new_from_parts(Global);
         cache.estimated_bytes_added_in_current_tx = MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX;
+        cache.estimated_retained_bytes = MAX_PREIMAGE_CACHE_RETAINED_BYTES - estimated_entry_bytes;
+        cache
+            .reserve_preimage_for_block_finalization(preimage.len())
+            .unwrap();
         let mut resources = resources_with_native(record_native_cost());
 
         cache
             .record_preimage_for_block_finalization(&request, &mut resources, &[&preimage])
             .unwrap();
-        assert_eq!(cache.estimated_retained_bytes, estimated_entry_bytes);
+        assert_eq!(
+            cache.estimated_retained_bytes,
+            MAX_PREIMAGE_CACHE_RETAINED_BYTES
+        );
         assert_eq!(
             cache.estimated_bytes_added_in_current_tx,
             MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX
         );
         assert!(!cache.tx_limit_hit_for_current_tx());
+        assert!(!cache.block_limit_hit_for_current_tx());
+    }
 
-        let second_preimage = [8u8; 16];
-        let second_request = PreimageRequest {
-            hash: Bytes32::from_array(Blake2s256::digest(second_preimage)),
-            expected_preimage_len_in_bytes: second_preimage.len() as u32,
+    #[test]
+    fn precharge_prevents_candidate_from_consuming_finalization_space() {
+        let final_preimage = [7u8; 16];
+        let final_request = PreimageRequest {
+            hash: Bytes32::from_array(Blake2s256::digest(final_preimage)),
+            expected_preimage_len_in_bytes: final_preimage.len() as u32,
             preimage_type: PreimageType::AccountData,
         };
-        cache.estimated_retained_bytes =
-            MAX_PREIMAGE_CACHE_RETAINED_BYTES - estimated_entry_bytes + 1;
-        let mut second_resources = resources_with_native(record_native_cost());
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(final_preimage.len()).unwrap();
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.estimated_retained_bytes = MAX_PREIMAGE_CACHE_RETAINED_BYTES - estimated_entry_bytes;
+        cache
+            .reserve_preimage_for_block_finalization(final_preimage.len())
+            .unwrap();
+
+        cache.begin_new_tx();
+        let (candidate_request, mut oracle) = request_and_oracle();
+        let candidate_len = candidate_request.expected_preimage_len_in_bytes as usize;
+        let mut candidate_resources =
+            resources_with_native(decommitment_native_cost(candidate_len));
         assert!(cache
-            .record_preimage_for_block_finalization(
-                &second_request,
-                &mut second_resources,
-                &[&second_preimage],
+            .get_preimage::<false>(
+                ExecutionEnvironmentType::EVM,
+                &candidate_request,
+                &mut candidate_resources,
+                &mut oracle,
             )
             .is_err());
-        assert!(!cache.tx_limit_hit_for_current_tx());
         assert!(cache.block_limit_hit_for_current_tx());
+
+        let mut finalization_resources = resources_with_native(record_native_cost());
+        cache
+            .record_preimage_for_block_finalization(
+                &final_request,
+                &mut finalization_resources,
+                &[&final_preimage],
+            )
+            .unwrap();
+        assert_eq!(
+            cache.estimated_retained_bytes,
+            MAX_PREIMAGE_CACHE_RETAINED_BYTES
+        );
+    }
+
+    #[test]
+    fn finalization_precharge_survives_frame_rollback() {
+        let preimage_len = 16;
+        let estimated_entry_bytes = TestCache::estimated_entry_bytes(preimage_len).unwrap();
+        let mut cache = TestCache::new_from_parts(Global);
+        cache.begin_new_tx();
+        let rollback_handle = cache.start_frame();
+
+        cache
+            .reserve_preimage_for_block_finalization(preimage_len)
+            .unwrap();
+        cache.finish_frame(Some(&rollback_handle)).unwrap();
+
+        assert_eq!(
+            cache.estimated_retained_bytes,
+            ACCEPTED_TX_BITMAP_BYTES + estimated_entry_bytes
+        );
     }
 
     #[test]

--- a/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/preimage_cache.rs
@@ -39,9 +39,6 @@ pub const MAX_PREIMAGE_CACHE_RETAINED_BYTES: usize = 256 * 1024 * 1024;
 /// A single transaction may add at most half of the block cache limit.
 pub const MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX: usize = MAX_PREIMAGE_CACHE_RETAINED_BYTES / 2;
 
-const _: () =
-    assert!(MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX * 2 == MAX_PREIMAGE_CACHE_RETAINED_BYTES);
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
 pub struct PreimageRequest {
@@ -300,21 +297,15 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
     pub(super) fn admit_cached_preimage_for_current_tx(
         &mut self,
         hash: &Bytes32,
-        expected_preimage_len: usize,
     ) -> Result<(), SystemError> {
-        let admission = match self.storage.get(hash) {
-            Some(cached) if cached.as_slice().len() == expected_preimage_len => cached.admission,
-            Some(_) => return Err(internal_error!("Cached preimage length mismatch").into()),
-            None => {
-                return Err(internal_error!("Materialized preimage is missing from cache").into());
-            }
+        let Some(cached) = self.storage.get(hash) else {
+            return Err(internal_error!("Materialized preimage is missing from cache").into());
         };
+        let admission = cached.admission;
+        // Charge the size of the entry that is physically retained.
+        let preimage_len = cached.as_slice().len();
 
-        self.admit_cached_preimage_with_admission_for_current_tx(
-            hash,
-            admission,
-            expected_preimage_len,
-        )
+        self.admit_cached_preimage_with_admission_for_current_tx(hash, admission, preimage_len)
     }
 
     /// Conservatively precharges one cache entry that may be materialized
@@ -584,6 +575,10 @@ impl<R: Resources, A: Allocator + Clone> BytecodeAndAccountDataPreimagesStorage<
         let (next_tx_bytes, next_retained_bytes) = if apply_transaction_budget {
             self.next_estimated_byte_totals(estimated_entry_bytes, true)?
         } else {
+            // Block finalization inserts a new entry, but
+            // `reserve_preimage_for_block_finalization` already counted its
+            // bytes when the account entered the account cache. Counting them
+            // here would charge every updated account twice.
             (
                 self.estimated_bytes_added_in_current_tx,
                 self.estimated_retained_bytes,
@@ -1211,13 +1206,5 @@ mod tests {
         cache.finish_frame(Some(&rollback_handle)).unwrap();
 
         assert_eq!(cache.estimated_retained_bytes, estimated_entry_bytes);
-    }
-
-    #[test]
-    fn tx_budget_is_half_the_block_cap() {
-        assert_eq!(
-            MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX * 2,
-            MAX_PREIMAGE_CACHE_RETAINED_BYTES
-        );
     }
 }

--- a/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
+++ b/basic_system/src/system_implementation/flat_storage_model/storage_cache.rs
@@ -216,6 +216,21 @@ impl<
         P: StorageAccessPolicy<R, Bytes32>,
     > NewStorageWithAccountPropertiesUnderHash<A, SF, M, R, P>
 {
+    /// Returns the block-start account-properties hash already materialized for
+    /// `address`, without charging resources or changing cache metadata.
+    ///
+    /// Account and storage initial records both survive frame rollback. This
+    /// lets the account cache reconnect a retained decoded account to its raw
+    /// preimage even when the access that populated it happened outside the
+    /// transaction rollback frame.
+    pub(super) fn initial_account_properties_hash(&self, address: &B160) -> Option<Bytes32> {
+        let key = WarmStorageKey {
+            address: ACCOUNT_PROPERTIES_STORAGE_ADDRESS,
+            key: address_into_special_storage_key(address),
+        };
+        self.0.cache.get(&key).map(|item| *item.initial().value())
+    }
+
     pub fn iter_as_storage_types(
         &self,
     ) -> impl Iterator<Item = (WarmStorageKey, WarmStorageValue)> + Clone + use<'_, A, SF, M, R, P>

--- a/basic_system/src/system_implementation/system/io_subsystem.rs
+++ b/basic_system/src/system_implementation/system/io_subsystem.rs
@@ -554,10 +554,6 @@ impl<
         self.storage.block_scoped_cache_limit_hit_for_current_tx()
     }
 
-    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
-        self.storage.deferred_cache_writes_exceed_block_limit()
-    }
-
     fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {
         self.storage
             .transaction_cache_memory_limit_hit_for_current_tx()

--- a/basic_system/src/system_implementation/system/io_subsystem.rs
+++ b/basic_system/src/system_implementation/system/io_subsystem.rs
@@ -550,6 +550,19 @@ impl<
         self.events_storage.begin_new_tx();
     }
 
+    fn block_scoped_cache_limit_hit_for_current_tx(&self) -> bool {
+        self.storage.block_scoped_cache_limit_hit_for_current_tx()
+    }
+
+    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
+        self.storage.deferred_cache_writes_exceed_block_limit()
+    }
+
+    fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {
+        self.storage
+            .transaction_cache_memory_limit_hit_for_current_tx()
+    }
+
     fn finish_tx(&mut self) -> Result<(), InternalError> {
         self.storage.finish_tx()?;
         self.tx_number += 1;

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -76,12 +76,13 @@ estimated bytes to the current transaction before reuse.
 
 Account properties need one additional bridge between cache layers. The account
 cache retains its decoded initial record too, so a later transaction may reuse
-it without calling `get_preimage()` again. Its rollback-aware
-`initial_preimage_admitted` marker records whether the transaction that admitted
-the backing preimage survived. On a cold account-cache hit with no surviving
-marker, the account cache explicitly re-admits the backing preimage. Thus a
-dropped sequencing candidate cannot reduce the next included transaction's
-preimage-cache byte count relative to proving.
+it without calling `get_preimage()` again. On every cold hit for an existing
+account, the account cache retrieves the block-start preimage hash from the
+storage cache's surviving initial record and asks the preimage cache to resolve
+its admission. Entries introduced by accepted transactions are free; entries
+owned by earlier unaccepted candidates are charged to the current candidate.
+This remains correct even when an account (such as the coinbase) was warmed
+before the transaction rollback frame was created.
 
 ## Account cache
 
@@ -145,8 +146,7 @@ Every charging decision must therefore be derived only from:
   (`CacheElementProperties::is_new_element`), which are identical in both runs;
 - **rollback-aware metadata** updated through `HistoryMap` records
   (`last_touched_in_tx`, `write_extra_charged_in_tx`, `new_read_extra_charged`,
-  `persist_charged_in_tx`, `initial_preimage_admitted`), so a dropped payer's
-  marker disappears with it;
+  `persist_charged_in_tx`), so a dropped payer's marker disappears with it;
 - **cache values** (`initial` / `committed` / `current`), which also roll back.
 
 In particular, "this slot/account is already in the cache" carries no information

--- a/docs/system/io/caches.md
+++ b/docs/system/io/caches.md
@@ -68,6 +68,21 @@ The preimage cache is used for account properties preimages and bytecodes. It's 
 
 This latter keeps a map of hashes to be published (whose preimage is saved in `storage`) to some publication metadata (number of uses and size). The `publication_storage` also keeps a stack of hashes with a pointer to the start of the current frame (and a stack of pointers for previous frames). For rolling back the current frame, the cache goes through all the hashes pushed to the stack in this frame and decreases the use counter. Only preimages with non-zero use counter are published.
 
+Raw preimages are retained for the block even when the candidate transaction
+that introduced them is dropped. Each entry therefore records whether it was
+introduced by an accepted transaction or is still pending under a candidate
+transaction ID. A hit on an entry owned by a dropped candidate re-admits its
+estimated bytes to the current transaction before reuse.
+
+Account properties need one additional bridge between cache layers. The account
+cache retains its decoded initial record too, so a later transaction may reuse
+it without calling `get_preimage()` again. Its rollback-aware
+`initial_preimage_admitted` marker records whether the transaction that admitted
+the backing preimage survived. On a cold account-cache hit with no surviving
+marker, the account cache explicitly re-admits the backing preimage. Thus a
+dropped sequencing candidate cannot reduce the next included transaction's
+preimage-cache byte count relative to proving.
+
 ## Account cache
 
 The [account cache](../../../basic_system/src/system_implementation/flat_storage_model/account_cache.rs) is used to temporarily store the account properties that will later be hashed and stored into the corresponding account properties hash slot.
@@ -130,7 +145,8 @@ Every charging decision must therefore be derived only from:
   (`CacheElementProperties::is_new_element`), which are identical in both runs;
 - **rollback-aware metadata** updated through `HistoryMap` records
   (`last_touched_in_tx`, `write_extra_charged_in_tx`, `new_read_extra_charged`,
-  `persist_charged_in_tx`), so a dropped payer's marker disappears with it;
+  `persist_charged_in_tx`, `initial_preimage_admitted`), so a dropped payer's
+  marker disappears with it;
 - **cache values** (`initial` / `committed` / `current`), which also roll back.
 
 In particular, "this slot/account is already in the cache" carries no information

--- a/evm_interpreter/src/lib.rs
+++ b/evm_interpreter/src/lib.rs
@@ -317,8 +317,8 @@ pub struct BitMapOwned<A: Allocator> {
 }
 
 impl<A: Allocator> BitMapOwned<A> {
-    /// Allocates a bitmap for a bytecode of length [capacity].
-    pub(crate) fn allocate_for_bit_capacity(capacity: usize, allocator: A) -> Self {
+    /// Allocates a zeroed bitmap with space for at least `capacity` bits.
+    pub fn allocate_for_bit_capacity(capacity: usize, allocator: A) -> Self {
         let u64_capacity = capacity.div_ceil(u64::BITS as usize);
         let word_capacity = u64_capacity * (u64::BITS as usize / usize::BITS as usize);
         let mut storage = Vec::with_capacity_in(word_capacity, allocator);
@@ -330,6 +330,26 @@ impl<A: Allocator> BitMapOwned<A> {
     #[inline(always)]
     pub fn as_words(&self) -> &[usize] {
         &self.inner
+    }
+
+    /// Returns the bit at `pos`, or `None` if it is outside the bitmap.
+    #[inline(always)]
+    pub fn get_bit(&self, pos: usize) -> Option<bool> {
+        let (word_idx, bit_idx) = (pos / usize::BITS as usize, pos % usize::BITS as usize);
+        self.inner
+            .get(word_idx)
+            .map(|word| word & (1usize << bit_idx) != 0)
+    }
+
+    /// Sets the bit at `pos`. Returns `false` if it is outside the bitmap.
+    #[inline(always)]
+    pub fn set_bit_on(&mut self, pos: usize) -> bool {
+        let (word_idx, bit_idx) = (pos / usize::BITS as usize, pos % usize::BITS as usize);
+        let Some(word) = self.inner.get_mut(word_idx) else {
+            return false;
+        };
+        *word |= 1usize << bit_idx;
+        true
     }
 
     /// # Safety

--- a/storage_models/src/common_structs/traits/storage_model.rs
+++ b/storage_models/src/common_structs/traits/storage_model.rs
@@ -234,12 +234,6 @@ pub trait StorageModel: Sized + SnapshottableIo {
         false
     }
 
-    /// Returns whether deferred cache writes from the candidate block state
-    /// would exceed a block-scoped retained-memory limit.
-    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
-        false
-    }
-
     /// Returns whether the current transaction exhausted a transaction-local
     /// cache memory budget.
     fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {

--- a/storage_models/src/common_structs/traits/storage_model.rs
+++ b/storage_models/src/common_structs/traits/storage_model.rs
@@ -228,6 +228,24 @@ pub trait StorageModel: Sized + SnapshottableIo {
     /// Get amount of pubdata needed to encode current tx diff in bytes.
     fn pubdata_used_by_tx(&self) -> u32;
 
+    /// Returns whether the current transaction attempted to grow a
+    /// block-scoped cache past its safe retained-memory limit.
+    fn block_scoped_cache_limit_hit_for_current_tx(&self) -> bool {
+        false
+    }
+
+    /// Returns whether deferred cache writes from the candidate block state
+    /// would exceed a block-scoped retained-memory limit.
+    fn deferred_cache_writes_exceed_block_limit(&self) -> bool {
+        false
+    }
+
+    /// Returns whether the current transaction exhausted a transaction-local
+    /// cache memory budget.
+    fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool {
+        false
+    }
+
     /// Get current counter of refunds
     fn get_refund_counter(&'_ self) -> &'_ Self::Resources;
 

--- a/system_hooks/src/addresses_constants.rs
+++ b/system_hooks/src/addresses_constants.rs
@@ -40,6 +40,16 @@ pub const FRI_PRECOMPILE_ADDRESS: B160 =
 // L2 message root storage contract
 pub const MESSAGE_ROOT_ADDRESS: B160 = B160::from_limbs([0x10005, 0, 0]);
 
+// L2 native token vault contract
+pub const L2_NATIVE_TOKEN_VAULT_ADDRESS_LOW: u32 = 0x10004;
+pub const L2_NATIVE_TOKEN_VAULT_ADDRESS: B160 =
+    B160::from_limbs([L2_NATIVE_TOKEN_VAULT_ADDRESS_LOW as u64, 0, 0]);
+
+// L2 chain asset handler contract
+pub const L2_CHAIN_ASSET_HANDLER_ADDRESS_LOW: u32 = 0x1000a;
+pub const L2_CHAIN_ASSET_HANDLER_ADDRESS: B160 =
+    B160::from_limbs([L2_CHAIN_ASSET_HANDLER_ADDRESS_LOW as u64, 0, 0]);
+
 // L2 interop root storage system contract
 pub const L2_INTEROP_ROOT_STORAGE_ADDRESS_LOW: u32 = 0x10008;
 pub const L2_INTEROP_ROOT_STORAGE_ADDRESS: B160 =

--- a/tests/instances/transactions/src/asset_tracker.rs
+++ b/tests/instances/transactions/src/asset_tracker.rs
@@ -17,19 +17,37 @@ use alloy_sol_types::sol;
 use alloy_sol_types::SolCall;
 use rig::alloy::consensus::TxLegacy;
 use rig::alloy::primitives::{address, TxKind};
+use rig::basic_system::system_implementation::flat_storage_model::{
+    FlatStorageCommitment, TREE_HEIGHT,
+};
+use rig::chain::TestingOracleFactory;
 use rig::crypto::MiniDigest;
 use rig::evm_bytecode::BytecodeBuilder;
 use rig::forward_system::run::convert_alloy::IntoAlloy;
+use rig::forward_system::run::test_impl::{InMemoryPreimageSource, InMemoryTree};
+use rig::forward_system::run::{
+    make_oracle_for_proofs_and_dumps_with_chain_config, FriVerifierArtifacts, PreimageSource,
+};
+use rig::fri::InMemoryFriProofSidecarSource;
+use rig::oracle_provider::ZkEENonDeterminismSource;
 use rig::predeployed_contracts::{
     DEFAULT_BASE_TOKEN_ASSET_ID, L2_ASSET_TRACKER_L1_CHAIN_ID_SLOT,
     SYSTEM_CONTEXT_SETTLEMENT_LAYER_CHAIN_ID_SLOT,
 };
 use rig::ruint::aliases::{B256, U256};
-use rig::system_hooks::addresses_constants::{L2_ASSET_TRACKER_ADDRESS, SYSTEM_CONTEXT_ADDRESS};
+use rig::system_hooks::addresses_constants::{
+    L2_ASSET_TRACKER_ADDRESS, L2_CHAIN_ASSET_HANDLER_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
+};
 use rig::testing_signer;
 use rig::utils::L1TxBuilder;
+use rig::zk_ee::common_structs::{da_commitment_scheme::DACommitmentScheme, ProofData};
+use rig::zk_ee::system::metadata::chain_config::ChainConfig;
+use rig::zk_ee::system::metadata::zk_metadata::BlockMetadataFromOracle;
+use rig::zk_ee::utils::Bytes32;
+use rig::zksync_os_interface::traits::TxListSource;
 use rig::zksync_os_interface::types::{ExecutionOutput, ExecutionResult};
 use rig::TestingFramework;
+use std::sync::{Arc, Mutex};
 use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 
 sol! {
@@ -38,6 +56,118 @@ sol! {
 
 const L2_ASSET_TRACKER_INTEROP_INFO_SLOT: u64 = 156;
 const INTEROP_INFO_TOTAL_SUCCESSFUL_DEPOSITS_OFFSET: u64 = 1;
+
+#[derive(Clone)]
+struct RecordingPreimageSource {
+    inner: InMemoryPreimageSource,
+    requested: Arc<Mutex<Vec<Bytes32>>>,
+}
+
+impl PreimageSource for RecordingPreimageSource {
+    fn get_preimage(&mut self, hash: Bytes32) -> Option<Vec<u8>> {
+        self.requested.lock().expect("lock poisoned").push(hash);
+        self.inner.get_preimage(hash)
+    }
+}
+
+struct RecordingPreimageFactory {
+    requested: Arc<Mutex<Vec<Bytes32>>>,
+}
+
+impl RecordingPreimageFactory {
+    #[allow(clippy::too_many_arguments)]
+    fn create_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        chain_config: ChainConfig,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        fri_sidecar: InMemoryFriProofSidecarSource,
+        fri_artifacts: Option<Arc<FriVerifierArtifacts>>,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_uart: bool,
+        use_native_callable_oracles: bool,
+    ) -> ZkEENonDeterminismSource {
+        make_oracle_for_proofs_and_dumps_with_chain_config(
+            chain_config,
+            block_metadata,
+            state_tree,
+            RecordingPreimageSource {
+                inner: preimage_source,
+                requested: self.requested.clone(),
+            },
+            tx_source,
+            fri_sidecar,
+            fri_artifacts,
+            proof_data,
+            da_commitment_scheme,
+            add_uart,
+            use_native_callable_oracles,
+        )
+    }
+}
+
+impl TestingOracleFactory<false> for RecordingPreimageFactory {
+    fn create_forward_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        chain_config: ChainConfig,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        fri_sidecar: InMemoryFriProofSidecarSource,
+        fri_artifacts: Option<Arc<FriVerifierArtifacts>>,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_uart: bool,
+        use_native_callable_oracles: bool,
+    ) -> ZkEENonDeterminismSource {
+        self.create_oracle(
+            block_metadata,
+            chain_config,
+            state_tree,
+            preimage_source,
+            tx_source,
+            fri_sidecar,
+            fri_artifacts,
+            proof_data,
+            da_commitment_scheme,
+            add_uart,
+            use_native_callable_oracles,
+        )
+    }
+
+    fn create_proof_oracle(
+        &self,
+        block_metadata: BlockMetadataFromOracle,
+        chain_config: ChainConfig,
+        state_tree: InMemoryTree<false>,
+        preimage_source: InMemoryPreimageSource,
+        tx_source: TxListSource,
+        fri_sidecar: InMemoryFriProofSidecarSource,
+        fri_artifacts: Option<Arc<FriVerifierArtifacts>>,
+        proof_data: Option<ProofData<FlatStorageCommitment<{ TREE_HEIGHT }>>>,
+        da_commitment_scheme: Option<DACommitmentScheme>,
+        add_uart: bool,
+        use_native_callable_oracles: bool,
+    ) -> ZkEENonDeterminismSource {
+        self.create_oracle(
+            block_metadata,
+            chain_config,
+            state_tree,
+            preimage_source,
+            tx_source,
+            fri_sidecar,
+            fri_artifacts,
+            proof_data,
+            da_commitment_scheme,
+            add_uart,
+            use_native_callable_oracles,
+        )
+    }
+}
 
 fn b160_to_address(b: rig::ruint::aliases::B160) -> rig::alloy::primitives::Address {
     b.into_alloy()
@@ -75,6 +205,56 @@ fn read_l1_chain_id_tx(nonce: u64) -> ZKsyncTxEnvelope {
         input: L1_CHAIN_IDCall {}.abi_encode().into(),
     };
     ZKsyncTxEnvelope::from_eth_tx(tx, wallet)
+}
+
+#[test]
+fn test_preloop_unconditionally_loads_chain_asset_handler_implementation() {
+    let implementation = address!("0000000000000000000000000000000000020000");
+    // migrationNumber(uint256) returns 0.
+    let implementation_bytecode = [0x5f, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3];
+
+    // Minimal EIP-1967 delegatecall proxy: copy calldata, load the
+    // implementation address from storage, delegatecall, copy returndata,
+    // and return it.
+    let implementation_slot = [
+        0x36, 0x08, 0x94, 0xa1, 0x3b, 0xa1, 0xa3, 0x21, 0x06, 0x67, 0xc8, 0x28, 0x49, 0x2d, 0xb9,
+        0x8d, 0xca, 0x3e, 0x20, 0x76, 0xcc, 0x37, 0x35, 0xa9, 0x20, 0xa3, 0xca, 0x50, 0x5d, 0x38,
+        0x2b, 0xbc,
+    ];
+    let mut proxy_bytecode = vec![0x36, 0x5f, 0x5f, 0x37, 0x5f, 0x5f, 0x36, 0x5f, 0x7f];
+    proxy_bytecode.extend_from_slice(&implementation_slot);
+    proxy_bytecode.extend_from_slice(&[0x54, 0x5a, 0xf4, 0x3d, 0x5f, 0x5f, 0x3e, 0x3d, 0x5f, 0xf3]);
+
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let factory = RecordingPreimageFactory {
+        requested: requested.clone(),
+    };
+    let mut tester = TestingFramework::new()
+        .with_evm_contract(
+            b160_to_address(L2_CHAIN_ASSET_HANDLER_ADDRESS),
+            &proxy_bytecode,
+        )
+        .with_storage_slot(
+            b160_to_address(L2_CHAIN_ASSET_HANDLER_ADDRESS),
+            U256::from_be_bytes(implementation_slot),
+            B256::from(U256::from_be_slice(implementation.as_slice())),
+        )
+        .with_evm_contract(implementation, &implementation_bytecode)
+        .with_custom_oracle_factory(factory);
+    let implementation_hash = tester.get_account_properties(&implementation).bytecode_hash;
+
+    // The default fixture has assetMigrationNumber = 1, so AssetTracker's
+    // state-dependent path skips L2ChainAssetHandler. The implementation can
+    // only be loaded by the unconditional block-level prewarm.
+    let output = tester.execute_block(vec![]);
+    assert!(output.tx_results.is_empty());
+    assert!(
+        requested
+            .lock()
+            .expect("lock poisoned")
+            .contains(&implementation_hash),
+        "chain asset handler implementation preimage must be loaded before the tx loop"
+    );
 }
 
 fn assert_reverted_deposit_asset_tracker(
@@ -196,7 +376,8 @@ fn test_asset_tracker_predeploy_is_usable_in_l1_flow() {
     }
 }
 
-/// Verify that an unconditional zero-amount notification records no deposit.
+/// Verify that neither the rolled-back pre-loop warm-up nor an unconditional
+/// zero-amount transaction notification records a deposit.
 #[test]
 fn test_asset_tracker_does_not_record_zero_deposit() {
     let from = address!("1234000000000000000000000000000000000000");
@@ -225,7 +406,7 @@ fn test_asset_tracker_does_not_record_zero_deposit() {
     assert_eq!(
         read_total_successful_deposits_from_l1(&mut tester),
         U256::ZERO,
-        "asset tracker should not record deposits when total_deposited == 0"
+        "asset tracker should not retain the synthetic warm-up or a zero deposit"
     );
 }
 

--- a/tests/instances/transactions/src/asset_tracker.rs
+++ b/tests/instances/transactions/src/asset_tracker.rs
@@ -2,11 +2,12 @@
 //! Tests for the L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 calls
 //! that the bootloader makes during L1 transaction processing.
 //!
-//! When an L1 transaction deposits base tokens (total_deposited > 0), the
-//! bootloader calls handleFinalizeBaseTokenBridgingOnL2(uint256, uint256)
-//! on the real L2AssetTracker contract up to three times — once for the
-//! value mint, once for the operator fee, and once for the refund. If any
-//! of these amounts is zero the corresponding call is skipped.
+//! When an L1 transaction is processed, the bootloader calls
+//! handleFinalizeBaseTokenBridgingOnL2(uint256, uint256)
+//! on the real L2AssetTracker contract for the value mint and operator fee,
+//! even when either amount is zero, and once more for a non-zero refund. The
+//! unconditional pre-execution call admits the preimages needed by mandatory
+//! post-execution accounting before user execution begins.
 //!
 //! When the source chain matches `L1_CHAIN_ID` and the current settlement
 //! layer also matches `L1_CHAIN_ID`, the contract records the aggregate
@@ -195,9 +196,9 @@ fn test_asset_tracker_predeploy_is_usable_in_l1_flow() {
     }
 }
 
-/// Verify that no deposit is recorded when total_deposited == 0.
+/// Verify that an unconditional zero-amount notification records no deposit.
 #[test]
-fn test_asset_tracker_not_called_without_deposit() {
+fn test_asset_tracker_does_not_record_zero_deposit() {
     let from = address!("1234000000000000000000000000000000000000");
     let to = address!("abcd000000000000000000000000000000000000");
     let gas_price: u128 = 0;

--- a/tests/instances/transactions/src/lib.rs
+++ b/tests/instances/transactions/src/lib.rs
@@ -40,6 +40,8 @@ use zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
 mod asset_tracker;
 mod l1_tx_resilience;
 mod native_charging;
+// Per-transaction memory budget of the block-scoped raw preimage cache.
+mod preimage_cache_budget;
 mod storage_charging;
 // Pre-execution transaction validation and bootloader rejection paths.
 mod validation_failures;

--- a/tests/instances/transactions/src/preimage_cache_budget.rs
+++ b/tests/instances/transactions/src/preimage_cache_budget.rs
@@ -1,0 +1,240 @@
+//! Per-transaction memory budget of the block-scoped raw preimage cache.
+//!
+//! Raw preimages stay in the cache for the whole block and survive the rollback
+//! of an invalidated transaction. A later transaction must still pay for them
+//! against its own memory budget: the proving run executes only the included
+//! transactions, so in that run the later transaction is the first one to
+//! materialize those preimages. See the charging invariant in
+//! `docs/system/io/caches.md`. Only the preimages of an accepted transaction
+//! are free for the transactions that follow.
+//!
+//! Both tests execute the same three transactions and differ only in the block
+//! pubdata limit. The limit decides whether the bootloader accepts or drops the
+//! second transaction after it warms a large set of bytecodes. The third
+//! transaction warms the same set plus two more bytecodes. That total crosses
+//! the per-transaction budget only when the bootloader drops the second
+//! transaction.
+
+use rig::alloy::consensus::TxEip1559;
+use rig::alloy::primitives::{address, Address, TxKind, U256 as AlloyU256};
+use rig::alloy::signers::local::PrivateKeySigner;
+use rig::basic_system::system_implementation::flat_storage_model::MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX;
+use rig::constants::*;
+use rig::evm_bytecode::BytecodeBuilder;
+use rig::forward_system::run::output::BlockOutput;
+use rig::ruint::aliases::U256;
+use rig::zk_ee::system::metadata::chain_config::DEFAULT_MAX_TX_GAS_LIMIT;
+use rig::zksync_os_interface::error::InvalidTransaction;
+use rig::zksync_os_tests_common::zksync_tx::ZKsyncTxEnvelope;
+use rig::{
+    assert_gas_used_gt, assert_tx_reverted, assert_tx_success, BlockContext, TestingFramework,
+};
+
+/// Runtime code length of one filler contract. The value is a multiple of 64, so
+/// ZKsync OS stores the code without padding and the jump-destination bitmap
+/// covers it exactly.
+const FILLER_CODE_LEN: usize = 8 * 1024 * 1024;
+
+/// Jump-destination bitmap that ZKsync OS appends to stored bytecode: one bit
+/// per code byte.
+const FILLER_ARTIFACTS_LEN: usize = FILLER_CODE_LEN / 8;
+
+/// Preimage that one filler contract retains in the cache: code plus artifacts.
+const FILLER_PREIMAGE_LEN: usize = FILLER_CODE_LEN + FILLER_ARTIFACTS_LEN;
+
+/// Filler contracts that both the second and the third transaction warm.
+const SHARED_FILLER_COUNT: u16 = 13;
+
+/// Filler contracts that only the third transaction warms.
+const EXTRA_FILLER_COUNT: u16 = 2;
+
+/// The shared preimages alone must fit in one transaction budget. The margin of
+/// one whole entry absorbs the per-entry bookkeeping that the cache adds on top
+/// of every preimage, plus the account and toucher preimages of the transaction.
+const _: () = assert!(
+    (SHARED_FILLER_COUNT as usize + 1) * FILLER_PREIMAGE_LEN
+        < MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX
+);
+
+/// A second charge for the shared preimages must exceed one transaction budget
+/// on preimage bytes alone.
+const _: () = assert!(
+    (SHARED_FILLER_COUNT + EXTRA_FILLER_COUNT) as usize * FILLER_PREIMAGE_LEN
+        > MAX_PREIMAGE_CACHE_BYTES_ADDED_PER_TX
+);
+
+/// First address of the contiguous filler contract range.
+const FILLER_ADDRESS_BASE: Address = address!("00000000000000000000000000000000f1110000");
+
+/// Contract that the second transaction calls.
+const SHARED_TOUCHER_ADDRESS: Address = address!("00000000000000000000000000000000f0110001");
+
+/// Contract that the third transaction calls.
+const FULL_TOUCHER_ADDRESS: Address = address!("00000000000000000000000000000000f0110002");
+
+/// Recipient of the first transaction.
+const TRANSFER_RECIPIENT_ADDRESS: Address = address!("00000000000000000000000000000000f0110003");
+
+/// Gas limit of the two decommitting transactions. Each one charges about 750
+/// million native for its decommits, which needs about 7.5 million gas at the
+/// default native price.
+const TOUCHER_GAS_LIMIT: u64 = DEFAULT_MAX_TX_GAS_LIMIT;
+
+/// Fresh storage slots that the second transaction writes. They are the only
+/// large pubdata producer in the block, which lets the block pubdata limit
+/// decide whether the bootloader accepts that transaction.
+const SHARED_TOUCHER_STORAGE_WRITES: u16 = 100;
+
+/// Block pubdata limit that drops the second transaction.
+///
+/// The bootloader compares the limit against the block total, which starts at
+/// `BLOCK_INTRINSIC_PUBDATA_BYTES` (118 bytes). Measured block totals, in
+/// bytes: 292 after the first transaction, 3_867 after the second, and 467
+/// after the third one once the bootloader drops the second one. The limit sits
+/// above what the first and third transaction need and below what the second
+/// one reaches.
+const PUBDATA_LIMIT_THAT_DROPS_SHARED_TOUCHER: u64 = 2_000;
+
+/// Address of the filler contract at `index`.
+fn filler_address(index: u16) -> Address {
+    let mut bytes = FILLER_ADDRESS_BASE.into_array();
+    bytes[18..].copy_from_slice(&index.to_be_bytes());
+    Address::from(bytes)
+}
+
+/// Runtime code of the filler contract at `index`.
+///
+/// The code never executes. The trailing index keeps the bytecodes distinct, so
+/// every contract retains its own cache entry.
+fn filler_bytecode(index: u16) -> Vec<u8> {
+    let mut bytecode = vec![0u8; FILLER_CODE_LEN];
+    bytecode[FILLER_CODE_LEN - 2..].copy_from_slice(&index.to_be_bytes());
+    bytecode
+}
+
+/// Builds runtime code that decommits the bytecode of every filler contract
+/// below `filler_count`, then writes `storage_writes` fresh storage slots.
+///
+/// A zero-length `EXTCODECOPY` still decommits the whole target bytecode, so one
+/// call retains one cache entry per filler contract and copies nothing.
+fn toucher_bytecode(filler_count: u16, storage_writes: u16) -> Vec<u8> {
+    let mut builder = BytecodeBuilder::new();
+    for index in 0..filler_count {
+        // EXTCODECOPY pops address, destination offset, source offset, length.
+        builder = builder
+            .push0()
+            .push0()
+            .push0()
+            .push_address(filler_address(index))
+            .extcodecopy();
+    }
+    for slot in 1..=storage_writes {
+        // SSTORE pops key, then value. Both are the slot index, which is never
+        // zero, so every write produces a state diff.
+        builder = builder.push_u16(slot).push_u16(slot).sstore();
+    }
+    builder.return_empty().finish()
+}
+
+fn call_tx(signer: PrivateKeySigner, to: Address, gas_limit: u64) -> ZKsyncTxEnvelope {
+    let tx = TxEip1559 {
+        chain_id: TEST_CHAIN_ID,
+        nonce: 0,
+        max_fee_per_gas: DEFAULT_MAX_FEE,
+        max_priority_fee_per_gas: DEFAULT_PRIORITY_FEE,
+        gas_limit,
+        to: TxKind::Call(to),
+        value: AlloyU256::ZERO,
+        access_list: Default::default(),
+        input: Default::default(),
+    };
+    ZKsyncTxEnvelope::from_eth_tx(tx, signer)
+}
+
+/// Executes one block of three transactions under `pubdata_limit`.
+///
+/// Transaction 0 is a plain transfer. Transaction 1 warms the shared filler
+/// bytecodes and writes storage. Transaction 2 warms the shared filler
+/// bytecodes plus the extra ones. Each transaction has its own sender, so the
+/// nonces stay independent.
+fn execute_block_with_pubdata_limit(pubdata_limit: u64) -> BlockOutput {
+    let transfer_signer = PrivateKeySigner::random();
+    let shared_toucher_signer = PrivateKeySigner::random();
+    let full_toucher_signer = PrivateKeySigner::random();
+
+    let mut tester = TestingFramework::new()
+        // The block retains more than 128 MiB of raw preimages. Replaying that
+        // in the RISC-V simulator is not viable, so this test stays on the
+        // forward path.
+        .with_run_config(rig::run_config::forward_only())
+        // REVM has no preimage-cache memory budget and prices decommits
+        // differently, so it diverges from ZKsync OS on both blocks by design.
+        .without_revm_consistency_check()
+        .with_evm_contract(
+            SHARED_TOUCHER_ADDRESS,
+            &toucher_bytecode(SHARED_FILLER_COUNT, SHARED_TOUCHER_STORAGE_WRITES),
+        )
+        .with_evm_contract(
+            FULL_TOUCHER_ADDRESS,
+            &toucher_bytecode(SHARED_FILLER_COUNT + EXTRA_FILLER_COUNT, 0),
+        )
+        .with_balance(transfer_signer.address(), U256::from(DEFAULT_BALANCE))
+        .with_balance(shared_toucher_signer.address(), U256::from(DEFAULT_BALANCE))
+        .with_balance(full_toucher_signer.address(), U256::from(DEFAULT_BALANCE))
+        .with_block_context(BlockContext {
+            pubdata_limit,
+            ..Default::default()
+        });
+
+    for index in 0..SHARED_FILLER_COUNT + EXTRA_FILLER_COUNT {
+        tester.set_evm_contract(filler_address(index), &filler_bytecode(index));
+    }
+
+    tester.execute_block(vec![
+        call_tx(
+            transfer_signer,
+            TRANSFER_RECIPIENT_ADDRESS,
+            TRANSFER_GAS_LIMIT,
+        ),
+        call_tx(
+            shared_toucher_signer,
+            SHARED_TOUCHER_ADDRESS,
+            TOUCHER_GAS_LIMIT,
+        ),
+        call_tx(full_toucher_signer, FULL_TOUCHER_ADDRESS, TOUCHER_GAS_LIMIT),
+    ])
+}
+
+#[test]
+fn preimage_budget_recounts_entries_from_invalidated_tx() {
+    let output = execute_block_with_pubdata_limit(PUBDATA_LIMIT_THAT_DROPS_SHARED_TOUCHER);
+
+    assert_tx_success!(output, 0);
+    assert!(
+        matches!(
+            &output.tx_results[1],
+            Err(InvalidTransaction::BlockPubdataLimitReached)
+        ),
+        "expected BlockPubdataLimitReached, got {:?}",
+        output.tx_results[1]
+    );
+    // The shared bytecodes stay in the cache but belong to a dropped
+    // transaction, so this transaction pays for them again and runs out of
+    // native resources on the extra bytecodes.
+    assert_tx_reverted!(output, 2);
+    // A lack of native resources exhausts the gas limit, which separates this
+    // halt from an ordinary revert. The control test proves that the same work
+    // fits well inside the same gas limit.
+    assert_gas_used_gt!(output, 2, TOUCHER_GAS_LIMIT - 1);
+}
+
+#[test]
+fn preimage_budget_promotes_entries_from_accepted_tx() {
+    let output = execute_block_with_pubdata_limit(u64::MAX);
+
+    assert_tx_success!(output, 0);
+    assert_tx_success!(output, 1);
+    // In this block the shared bytecodes belong to an accepted transaction, so
+    // this transaction pays only for the extra bytecodes and stays in budget.
+    assert_tx_success!(output, 2);
+}

--- a/tests/rig/src/evm_bytecode.rs
+++ b/tests/rig/src/evm_bytecode.rs
@@ -61,6 +61,11 @@ impl BytecodeBuilder {
         self
     }
 
+    pub fn extcodecopy(mut self) -> Self {
+        self.bytes.push(0x3c);
+        self
+    }
+
     pub fn sload(mut self) -> Self {
         self.bytes.push(0x54);
         self

--- a/zk_ee/src/system/io.rs
+++ b/zk_ee/src/system/io.rs
@@ -386,10 +386,6 @@ pub trait IOSubsystemExt: IOSubsystem {
     /// block-scoped IO cache past its safe retained-memory limit.
     fn block_scoped_cache_limit_hit_for_current_tx(&self) -> bool;
 
-    /// Returns whether deferred cache writes from the candidate block state
-    /// would exceed a block-scoped retained-memory limit.
-    fn deferred_cache_writes_exceed_block_limit(&self) -> bool;
-
     /// Returns whether the current transaction exhausted a transaction-local
     /// IO cache memory budget.
     fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool;

--- a/zk_ee/src/system/io.rs
+++ b/zk_ee/src/system/io.rs
@@ -382,6 +382,18 @@ pub trait IOSubsystemExt: IOSubsystem {
     /// Indicate the a new transaction is being processed.
     fn begin_next_tx(&mut self);
 
+    /// Returns whether the current transaction attempted to grow a
+    /// block-scoped IO cache past its safe retained-memory limit.
+    fn block_scoped_cache_limit_hit_for_current_tx(&self) -> bool;
+
+    /// Returns whether deferred cache writes from the candidate block state
+    /// would exceed a block-scoped retained-memory limit.
+    fn deferred_cache_writes_exceed_block_limit(&self) -> bool;
+
+    /// Returns whether the current transaction exhausted a transaction-local
+    /// IO cache memory budget.
+    fn transaction_cache_memory_limit_hit_for_current_tx(&self) -> bool;
+
     /// Finish current transaction, destructing accounts marked during
     /// selfdestruct.
     fn finish_tx(&mut self) -> Result<(), InternalError>;


### PR DESCRIPTION
## Summary

- bound retained flat preimage-cache data to keep proving memory usage predictable
- apply a per-transaction retention budget and return out-of-native when it is exhausted
- reserve capacity for deferred account preimages before accepting a transaction
- preserve existing cache-hit and native-cost behavior

## Testing

- `cargo test -p basic_system preimage_cache`
- `cargo test -p basic_bootloader block_flow::zk`
