### PR TITLE
ci(update-appbin): remove RELEASE_TOKEN

### DIFF
--- a/.github/workflows/update-appbin.yml
+++ b/.github/workflows/update-appbin.yml
@@ -23,8 +23,19 @@ jobs:
     env:
       COMMIT_MESSAGE: "chore: update RISC-V binaries"
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zksync-os
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Build fresh app bin
         run: zksync_os/reproduce/reproduce.sh

--- a/.github/workflows/update-appbin.yml
+++ b/.github/workflows/update-appbin.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          app-id: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
           private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: zksync-os

--- a/.github/workflows/update-appbin.yml
+++ b/.github/workflows/update-appbin.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Build fresh app bin
         run: zksync_os/reproduce/reproduce.sh


### PR DESCRIPTION
## What ❔

The manual binary-update workflow now checks out and pushes using a GitHub App installation token scoped to this repo, replacing `RELEASE_TOKEN`.

## Why ❔

- Removes a long-lived personal access token from this repo's CI. The replacement expires after an hour and can only reach this repository.
- Keeps the push able to trigger downstream workflows, which `GITHUB_TOKEN` cannot do.
- Anyone running this workflow no longer needs a personal token configured.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. <!-- n/a: CI config only -->
- [ ] Documentation comments have been added / updated. <!-- n/a -->
- [x] Code has been formatted.