### PR TITLE
fix(deps): update h2 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## What ❔

Updates the transitive `h2` dependency in `Cargo.lock` from 0.4.14 to 0.4.16.

## Why ❔

`h2` 0.4.14 is affected by RUSTSEC-2026-0258, which allows an unbounded number of empty DATA frames to be queued and can cause unbounded memory use or a panic. Version 0.4.16 contains the upstream fix and restores the Cargo Deny PR check.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated. (No new test needed for a transitive lockfile-only security update.)
- [x] Documentation comments have been added / updated. (Not applicable.)
- [x] Code has been formatted. (No source-code changes.)

## Validation

- `cargo deny check --allow unmaintained --hide-inclusion-graph`
- `cargo deny --manifest-path zksync_os/Cargo.toml check --allow unmaintained --hide-inclusion-graph`
