### PR TITLE
fix: let prewarm fail for l1 txs

### DIFF
--- a/basic_bootloader/src/bootloader/transaction/rlp_encoded/transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction/rlp_encoded/transaction.rs
@@ -98,7 +98,7 @@ impl<A: Allocator> RlpEncodedTransaction<A> {
     pub fn statement_versioned_hashes(
         &self,
     ) -> Option<crate::bootloader::transaction::rlp_encoded::transaction_types::fri_proof_tx::StatementVersionedHashesList<'_>>
-    {
+{
         match &self.inner {
             RlpEncodedTxInner::FriProof(tx, _) => Some(tx.statement_versioned_hashes),
             _ => None,

--- a/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
+++ b/basic_bootloader/src/bootloader/transaction_flow/zk/process_l1_transaction.rs
@@ -661,6 +661,7 @@ where
             &mut resources,
             &mut tracer,
             &mut validator,
+            true, // can_fail
         )
     })();
 
@@ -946,6 +947,7 @@ where
         resources,
         tracer,
         validator,
+        false, // can_fail
     )?;
 
     transfer_from_treasury::<S>(system, amount, to, resources, Config::SIMULATION)
@@ -1044,6 +1046,7 @@ fn notify_l2_asset_tracker<'a, S: EthereumLikeTypes + 'a>(
     resources: &mut S::Resources,
     tracer: &mut impl Tracer<S>,
     validator: &mut impl TxValidator<S>,
+    can_fail: bool,
 ) -> Result<(), BootloaderSubsystemError>
 where
     S::IO: IOSubsystemExt,
@@ -1096,10 +1099,14 @@ where
             "L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 failed for amount {amount:?}\n"
         );
         // A revert here means the chain's token accounting would be inconsistent.
-        // Treated as a fatal system error — block processing cannot continue.
-        return Err(
-            internal_error!("L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 reverted").into(),
-        );
+        // Treated as a fatal system error — block processing cannot continue, unless
+        // the call is the prewarming call, which is allowed to fail.
+        if !can_fail {
+            return Err(internal_error!(
+                "L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2 reverted"
+            )
+            .into());
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## What ❔
Let the `prewarm_l1_postprocessing` calls revert, as it otherwise blocks genesis.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.