### PR TITLE
feat(rig): export the per-tx revert flag in state dumps

### DIFF
--- a/tests/rig/src/state_dump.rs
+++ b/tests/rig/src/state_dump.rs
@@ -90,6 +90,10 @@ struct TxDump {
     /// True when the native `tx_result` for this tx is `Err`: the tx was in
     /// the block's input list but was not executed (invalid / filtered).
     failed: bool,
+    /// True when the tx executed but its top-level execution reverted
+    /// (tx_result is `Ok` with `status == false`). Distinct from `failed`:
+    /// the tx is in the sealed block with its fee and nonce effects.
+    reverted: bool,
 }
 
 /// The block environment the STF ran under (mirrors the sealed header values).
@@ -331,6 +335,10 @@ pub(crate) fn write_block_dump(
             signed,
             gas_used: result.as_ref().map(|output| output.gas_used).unwrap_or(0),
             failed: result.is_err(),
+            reverted: result
+                .as_ref()
+                .map(|output| !output.is_success())
+                .unwrap_or(false),
         })
         .collect();
 


### PR DESCRIPTION
A tx that executed and reverted (tx_result Ok with status false) is part of the sealed block with its fee and nonce effects, but the dump carried no signal for it — the only flag was failed (validation rejection). The witness conversion needs the revert flag to force-fail such txs for the guest, whose settlement leg cannot reproduce native's failure classes.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted.