### PR TITLE
fix(divergence-validator): make EIP-7702, deep call stacks and block overrides testable

### DIFF
--- a/tests/evm_divergence_validator/examples/block_context.yaml
+++ b/tests/evm_divergence_validator/examples/block_context.yaml
@@ -1,0 +1,26 @@
+# Example declaring an explicit `block:` section.
+#
+# The bootloader requires the blob base fee to be exactly 1 when EIP-4844 is
+# disabled, which is the production configuration. Any scenario that reaches
+# `make_block_context` therefore depends on that field being set correctly, so
+# this example exercises the block override path end to end.
+contracts:
+  Store:
+    bytecode: "0x60003560005500"
+    address: "0x0000000000000000000000000000000000000101"
+
+accounts:
+  alice:
+    balance: "1000000000000000000"
+
+block:
+  basefee: 1000
+  gas_limit: 30000000
+  timestamp: 1700000000
+
+steps:
+  - type: send_raw
+    to: Store
+    from: alice
+    data: "0x000000000000000000000000000000000000000000000000000000000000002a"
+    gas: 1000000

--- a/tests/evm_divergence_validator/examples/deep_call_stack.yaml
+++ b/tests/evm_divergence_validator/examples/deep_call_stack.yaml
@@ -1,0 +1,34 @@
+# Example driving the EVM call stack to its 1024 frame limit.
+#
+# The contract calls itself, carrying the current depth in 32 bytes of calldata
+# and stopping once that depth reaches the bound compiled into the bytecode. The
+# deepest frame that succeeds writes last, so slot 0 ends up holding the maximum
+# depth reached. A failing nested call does not revert its parent, so the write
+# survives and the depth limit itself becomes observable.
+#
+# Bytecode, with the bound 0x000400 = 1024 pushed at offset 6:
+#   PUSH0 CALLDATALOAD            d
+#   PUSH0 SSTORE                  slot 0 <- d
+#   PUSH0 CALLDATALOAD            d
+#   PUSH3 0x000400 GT             bound > d ?
+#   PUSH1 0x0f JUMPI              continue if so
+#   STOP
+#   JUMPDEST
+#   PUSH0 CALLDATALOAD PUSH1 1 ADD PUSH0 MSTORE
+#   CALL(gas=GAS, self, value=0, args=0..32, no return)
+#   POP STOP
+contracts:
+  Recur:
+    bytecode: "0x5f355f555f356200040011600f57005b5f356001015f525f5f60205f5f305af15000"
+    address: "0x0000000000000000000000000000000000000101"
+
+accounts:
+  alice:
+    balance: "1000000000000000000000"
+
+steps:
+  - type: send_raw
+    to: Recur
+    from: alice
+    data: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    gas: 100000000000000

--- a/tests/evm_divergence_validator/examples/eip7702_delegation.yaml
+++ b/tests/evm_divergence_validator/examples/eip7702_delegation.yaml
@@ -1,0 +1,35 @@
+# Example covering an account that carries an EIP-7702 delegation designator.
+#
+# EIP-7702 is enabled by the production feature set, so a delegated account is
+# part of the surface this tool is meant to compare. Such an account holds the
+# 23 byte designator 0xef0100 || address as its bytecode.
+#
+# Delegate bytecode: 602a5f5500
+#   PUSH1 0x2a, PUSH0, SSTORE, STOP   (stores 42 in the caller's slot 0)
+#
+# Probe bytecode: 5f5f5f5f5f610202620186a0f15f556102023b6001556102023f60025500
+#   CALL(gas=100000, 0x0202, value=0, no args, no return)
+#   slot 0 <- call success
+#   slot 1 <- EXTCODESIZE(0x0202)     expected 23, the designator length
+#   slot 2 <- EXTCODEHASH(0x0202)     expected keccak of the designator
+contracts:
+  Delegate:
+    bytecode: "0x602a5f5500"
+    address: "0x0000000000000000000000000000000000000303"
+  Delegator:
+    bytecode: "0xef01000000000000000000000000000000000000000303"
+    address: "0x0000000000000000000000000000000000000202"
+  Probe:
+    bytecode: "0x5f5f5f5f5f610202620186a0f15f556102023b6001556102023f60025500"
+    address: "0x0000000000000000000000000000000000000101"
+
+accounts:
+  alice:
+    balance: "1000000000000000000000"
+
+steps:
+  - type: send_raw
+    to: Probe
+    from: alice
+    data: "0x"
+    gas: 8000000

--- a/tests/evm_divergence_validator/src/main.rs
+++ b/tests/evm_divergence_validator/src/main.rs
@@ -13,6 +13,21 @@ use std::process;
 use anyhow::Context;
 
 fn main() {
+    // Both engines recurse natively once per EVM call frame. On the main thread's default
+    // stack, a scenario nesting more than a few hundred frames aborts the process before a
+    // report is produced, which makes the 1024 call-depth limit impossible to exercise.
+    // Run the work on a thread with a large stack instead.
+    let child = std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(real_main)
+        .expect("failed to spawn worker thread");
+    match child.join() {
+        Ok(()) => {}
+        Err(_) => process::exit(2),
+    }
+}
+
+fn real_main() {
     // rig::init_logger() is called by TestingFramework::new(), so we don't
     // initialize env_logger here to avoid double-init panics.
     // Users can still set RUST_LOG to control verbosity.

--- a/tests/evm_divergence_validator/src/runner.rs
+++ b/tests/evm_divergence_validator/src/runner.rs
@@ -494,6 +494,10 @@ fn make_block_context(block: &BlockDef) -> rig::BlockContext {
         pubdata_limit: u64::MAX,
         coinbase: Default::default(),
         mix_hash: Default::default(),
-        blob_fee: Default::default(),
+        // The bootloader requires the blob base fee to be exactly 1 when EIP-4844 is
+        // disabled, which is the production configuration. Leaving this at zero makes
+        // every scenario that declares a `block:` section fail with an internal error
+        // before execution starts. `block_reexecutor` already uses `U256::ONE` here.
+        blob_fee: ruint::aliases::U256::ONE,
     }
 }

--- a/tests/evm_divergence_validator/tests/examples.rs
+++ b/tests/evm_divergence_validator/tests/examples.rs
@@ -1,0 +1,52 @@
+//! Runs the bytecode based example scenarios through the built binary.
+//!
+//! Each scenario must be reported as a match, which means exit code 0. The
+//! examples that compile Solidity are left out so the suite does not depend on
+//! a Foundry installation.
+
+use std::process::Command;
+
+fn assert_match(scenario: &str) {
+    let binary = env!("CARGO_BIN_EXE_evm-divergence-validator");
+    let path = format!("{}/examples/{}", env!("CARGO_MANIFEST_DIR"), scenario);
+
+    let output = Command::new(binary)
+        .arg(&path)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run the validator on {scenario}: {err}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{scenario} was not reported as a match\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn predeployed_bytecode() {
+    assert_match("predeployed_bytecode.yaml");
+}
+
+/// Covers the `block:` override path, which the bootloader rejects unless the
+/// blob base fee is set to 1 while EIP-4844 is disabled.
+#[test]
+fn block_context() {
+    assert_match("block_context.yaml");
+}
+
+/// Covers an account holding an EIP-7702 delegation designator. The designator
+/// has to survive preimage trimming, reach REVM as a delegation rather than as
+/// legacy code, and be hashable by the consistency checker.
+#[test]
+fn eip7702_delegation() {
+    assert_match("eip7702_delegation.yaml");
+}
+
+/// Covers a scenario nesting frames up to the 1024 call depth limit, which
+/// exceeds the default stack of the main thread.
+#[test]
+fn deep_call_stack() {
+    assert_match("deep_call_stack.yaml");
+}

--- a/tests/revm_runner/src/revm_runner.rs
+++ b/tests/revm_runner/src/revm_runner.rs
@@ -124,10 +124,17 @@ where
             if !report.is_empty() {
                 log::warn!("State mismatch found after REVM replay");
                 report.log_tracing(100);
+                // Report the mismatching entries themselves: the counts alone do not say
+                // which account or which storage slot diverged, which leaves a reported
+                // divergence impossible to diagnose from the CLI output.
                 bail!(
-                    "REVM consistency mismatch: storage={} account={}",
+                    "REVM consistency mismatch: storage={} account={}
+                       storage_detail={:#?}
+  account_detail={:#?}",
                     report.storage.len(),
-                    report.accounts.len()
+                    report.accounts.len(),
+                    report.storage,
+                    report.accounts
                 );
             }
         }

--- a/tests/revm_runner/src/revm_state_provider.rs
+++ b/tests/revm_runner/src/revm_state_provider.rs
@@ -178,10 +178,32 @@ where
                 let code = if props.bytecode_hash.is_zero() {
                     None
                 } else {
-                    let bytecode = self.code_by_hash_ref(props.bytecode_hash.into_alloy())?;
-                    let unpadded =
-                        zksync_os_api::helpers::get_unpadded_code(bytecode.bytes_slice(), &props);
-                    Some(Bytecode::new_legacy(Bytes::copy_from_slice(unpadded)))
+                    // Bytecode preimages are stored padded, with the true length kept in
+                    // `unpadded_code_len`, so the preimage has to be trimmed before REVM
+                    // validates it. Validating the padded bytes rejects a well-formed
+                    // 23-byte EIP-7702 delegation designator as malformed, and reports the
+                    // resulting failure as a divergence.
+                    //
+                    // Constructing the trimmed bytes with the checked constructor rather
+                    // than `Bytecode::new_legacy` also lets REVM recognise a designator as
+                    // a delegation; wrapping it as legacy code hides delegations entirely.
+                    let code_hash = props.bytecode_hash.into_alloy();
+                    let raw: Bytes = {
+                        let mut state_view = self.state_view()?;
+                        state_view
+                            .get_preimage(code_hash)
+                            .ok_or(RevmStateProviderError::MissingCodePreimage { code_hash })?
+                            .into()
+                    };
+                    let unpadded = zksync_os_api::helpers::get_unpadded_code(raw.as_ref(), &props);
+                    Some(
+                        Bytecode::new_raw_checked(Bytes::copy_from_slice(unpadded)).map_err(
+                            |err| RevmStateProviderError::MalformedCodePreimage {
+                                code_hash,
+                                reason: err.to_string(),
+                            },
+                        )?,
+                    )
                 };
 
                 Ok(AccountInfo {

--- a/tests/revm_runner/src/storage_diff_comp.rs
+++ b/tests/revm_runner/src/storage_diff_comp.rs
@@ -277,12 +277,11 @@ where
             } else {
                 match code.kind() {
                     BytecodeKind::LegacyAnalyzed => calculate_bytecode_hash(code),
-                    BytecodeKind::Eip7702 => {
-                        return Err(anyhow::anyhow!(
-                            "EIP-7702 bytecode is not supported on Consistency Checker (delegated_address={:?})",
-                            code.eip7702_address()
-                        ));
-                    }
+                    // A delegated account stores the 23-byte designator as its bytecode
+                    // and hashes it through the same path as any other EVM bytecode, so it
+                    // hashes here exactly like legacy code. Returning an error instead left
+                    // every scenario involving a delegated account uncomparable.
+                    BytecodeKind::Eip7702 => calculate_bytecode_hash(code),
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

`tests/evm_divergence_validator` is offered in its README as a bug bounty triage tool and as an automated feedback loop. Four defects currently make parts of the EVM surface impossible to compare through it, and a fifth makes any divergence it does report hard to act on. Each is fixed here, with an example scenario that fails without the fix.

Nothing in the engine is touched. All changes are under `tests/`.

## What is currently unreachable

**Any scenario declaring a `block:` section.** `make_block_context` left `blob_fee` at zero, while the bootloader requires exactly 1 when EIP-4844 is disabled, which is the production configuration. The documented block override therefore aborted with an internal error before execution started. `tests/block_reexecutor` already builds its context with `U256::ONE`.

**Any account holding an EIP-7702 delegation.** Three separate layers:

1. `revm_state_provider::basic_ref` validated the still padded preimage through `code_by_hash_ref`. Preimages are stored padded with the true length in `unpadded_code_len`, so a well formed 23 byte designator was rejected as malformed and surfaced as a divergence.
2. Even once trimmed, the result was wrapped in `Bytecode::new_legacy`, so REVM would never see a designator as a delegation.
3. `storage_diff_comp::build_revm_accounts` returned an error for `BytecodeKind::Eip7702`, so the consistency checker could not compare such an account at all.

EIP-7702 is enabled by the `production` feature set, so these accounts are part of the surface this tool is meant to cover.

**Any scenario nesting more than a few hundred call frames.** Both engines recurse natively per EVM call frame. On the main thread's default stack the process aborted before producing a report, which put the 1024 call depth limit out of reach.

**Diagnosing a reported divergence.** The mismatch error carried only the number of differing storage slots and accounts, not which ones.

## Verification

Each example fails without its fix and passes with it:

| Fix reverted | Failing test |
| --- | --- |
| `runner.rs` blob base fee | `block_context` |
| `revm_state_provider.rs` preimage trimming | `eip7702_delegation` |
| `storage_diff_comp.rs` delegated account hashing | `eip7702_delegation` |
| `main.rs` worker stack | `deep_call_stack` |

With all four applied:

```
cd tests/evm_divergence_validator
cargo test --release
```

```
running 4 tests
test block_context ... ok
test predeployed_bytecode ... ok
test eip7702_delegation ... ok
test deep_call_stack ... ok
```

The `deep_call_stack` example is also useful on its own: raising the bound compiled into its bytecode past 1024 shows the depth limit binding rather than gas, with both engines agreeing on where it binds.

## Notes

`tests/evm_divergence_validator` is excluded from the workspace, so the new integration suite does not run in CI. Happy to wire it up in a follow up if that is wanted; it would need the crate's `Cargo.lock` committed as well, since a fresh resolve currently picks an `alloy` that `revm-inspectors 0.39` cannot build against.

That same resolution drift already affects the workspace itself, independently of this change. On an unmodified `origin/main`:

```
cargo clippy --all -- -D warnings

error[E0063]: missing fields `state_gas_cost` and `state_gas_reservoir` in initializer of `StructLog`
error[E0063]: missing fields `execution_gas_used`, `gas_refund` and `state_gas_used` in initializer of `DefaultFrame`
error: could not compile `revm-inspectors` (lib) due to 3 previous errors
```

This is why the jobs that build `revm-inspectors` are red while the others are green. It looked out of scope for this PR, and the `aba-add-cargo-lock` branch already addresses it, so nothing here touches dependency resolution.
